### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ makepkg -si
 
 ### From source
 
-If you want to build to compile `bat` from source, you need Rust 1.22 or higher.
+If you want to build to compile `bat` from source, you need Rust 1.24 or higher.
 Make sure that you have the devel-version of libopenssl installed (see instructions
 [here](https://github.com/sfackler/rust-openssl)). You can then use `cargo` to build everything:
 


### PR DESCRIPTION
Bump the required Rust version. Because of some transitive dependencies needing `std::sync::atomic::spin_loop_hint`, this won't compile without [1.24](https://blog.rust-lang.org/2018/02/15/Rust-1.24.html):

```
   Compiling parking_lot_core v0.2.14
error[E0432]: unresolved import `std::sync::atomic::spin_loop_hint`
  --> .cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.2.14/src/spinwait.rs:14:5
   |
14 | use std::sync::atomic::spin_loop_hint;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `spin_loop_hint` in `sync::atomic`

error: aborting due to previous error

error: Could not compile `parking_lot_core`.
warning: build failed, waiting for other jobs to finish...
error: failed to compile `bat v0.2.0`, intermediate artifacts can be found at `/var/folders/z6/9wkk458s4y1g3_82242l_wv5ws7k_8/T/cargo-install.Nyyc2EJDojxa`
```