### PR TITLE
Add "--list-languages" command line argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -568,18 +568,23 @@ fn run() -> Result<()> {
             if let Some(_) = app_matches.values_of("list languages") {
                 let languages = assets.syntax_set.syntaxes();
 
-                for lang in languages {
-                    print!("{}\t", lang.name);
+                let longest = match languages.iter()
+                    .map(|s| s.name.len())
+                    .max() {
+                    Some(longlang) => longlang,
+                    None => 32,
+                };
 
+                for lang in languages {
+                    print!("{:width$} | ", lang.name, width = longest);
                     for i in 0..lang.file_extensions.len() {
                         print!("{}", lang.file_extensions[i]);
 
                         if i < lang.file_extensions.len() - 1 {
                             print!(", ");
-                        } else {
-                            println!();
                         }
                     }
+                    println!();
                 }
 
                 return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -582,14 +582,15 @@ fn run() -> Result<()> {
                     print!("{:width$}{}", lang.name, separator, width = longest);
 
                     // Line-wrapping for the possible file extension overflow.
-                    let desired_width = options.term_width - longest;
+                    let desired_width = options.term_width - longest - separator.len();
                     // Number of characters on this line so far, wrap before `desired_width`
                     let mut num_chars = 0;
 
+                    let comma_separator = ", ";
                     let mut extension = lang.file_extensions.iter().peekable();
                     while let Some(word) = extension.next() {
                         // If we can't fit this word in, then create a line break and align it in.
-                        if word.len() + num_chars >= desired_width {
+                        if word.len() + num_chars + comma_separator.len() >= desired_width {
                             num_chars = 0;
                             print!("\n{:width$}{}", "", separator, width = longest);
                         }
@@ -597,7 +598,7 @@ fn run() -> Result<()> {
                         num_chars += word.len();
                         print!("{}", word);
                         if extension.peek().is_some() {
-                            print!(", ");
+                            print!("{}", comma_separator);
                         }
                     }
                     println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -569,7 +569,9 @@ fn run() -> Result<()> {
             if app_matches.is_present("list-languages") {
                 let languages = assets.syntax_set.syntaxes();
 
-                let longest = languages.iter()
+                let longest = languages
+                    .iter()
+                    .filter(|s| !s.hidden)
                     .map(|s| s.name.len())
                     .max()
                     .unwrap_or(32); // Fallback width if they have no language definitions.
@@ -590,12 +592,13 @@ fn run() -> Result<()> {
                     let mut extension = lang.file_extensions.iter().peekable();
                     while let Some(word) = extension.next() {
                         // If we can't fit this word in, then create a line break and align it in.
-                        if num_chars + word.len() + comma_separator.len() >= desired_width {
+                        let new_chars = word.len() + comma_separator.len();
+                        if num_chars + new_chars >= desired_width {
                             num_chars = 0;
                             print!("\n{:width$}{}", "", separator, width = longest);
                         }
 
-                        num_chars += word.len() + comma_separator.len();
+                        num_chars += new_chars;
                         print!("{}", word);
                         if extension.peek().is_some() {
                             print!("{}", comma_separator);

--- a/src/main.rs
+++ b/src/main.rs
@@ -565,6 +565,26 @@ fn run() -> Result<()> {
                 )
             })?;
 
+            if let Some(_) = app_matches.values_of("list languages") {
+                let languages = assets.syntax_set.syntaxes();
+
+                for lang in languages {
+                    print!("{}\t", lang.name);
+
+                    for i in 0..lang.file_extensions.len() {
+                        print!("{}", lang.file_extensions[i]);
+
+                        if i < lang.file_extensions.len() - 1 {
+                            print!(", ");
+                        } else {
+                            println!();
+                        }
+                    }
+                }
+
+                return Ok(());
+            }
+
             let mut output_type = get_output_type(options.paging);
             let handle = output_type.handle()?;
             let mut printer = Printer::new(handle, &options);

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,7 +457,7 @@ fn run() -> Result<()> {
         .arg(
             Arg::with_name("list-languages")
                 .long("list-languages")
-                .help("Displays supported languages")
+                .help("Displays supported languages"),
         )
         .subcommand(
             SubCommand::with_name("cache")
@@ -576,7 +576,7 @@ fn run() -> Result<()> {
                     .max()
                     .unwrap_or(32); // Fallback width if they have no language definitions.
 
-                let separator = " | ";
+                let separator = " ";
                 for lang in languages {
                     if lang.hidden {
                         continue;
@@ -599,7 +599,7 @@ fn run() -> Result<()> {
                         }
 
                         num_chars += new_chars;
-                        print!("{}", word);
+                        print!("{}", Green.paint(word as &str));
                         if extension.peek().is_some() {
                             print!("{}", comma_separator);
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,8 +571,8 @@ fn run() -> Result<()> {
                 let longest = match languages.iter()
                     .map(|s| s.name.len())
                     .max() {
-                    Some(longlang) => longlang,
-                    None => 32,
+                    Some(length) => length,
+                    None => 32, // Fallback width if they have no language definitions.
                 };
 
                 for lang in languages {

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,9 +454,8 @@ fn run() -> Result<()> {
                 .help("When to use the pager"),
         )
         .arg(
-            Arg::with_name("list languages")
+            Arg::with_name("list-languages")
                 .long("list-languages")
-                .takes_value(false)
                 .help("Displays supported languages")
         )
         .subcommand(
@@ -565,26 +564,17 @@ fn run() -> Result<()> {
                 )
             })?;
 
-            if let Some(_) = app_matches.values_of("list languages") {
+            if app_matches.is_present("list-languages") {
                 let languages = assets.syntax_set.syntaxes();
 
-                let longest = match languages.iter()
+                let longest = languages.iter()
                     .map(|s| s.name.len())
-                    .max() {
-                    Some(length) => length,
-                    None => 32, // Fallback width if they have no language definitions.
-                };
+                    .max()
+                    .unwrap_or(32); // Fallback width if they have no language definitions.
 
                 for lang in languages {
                     print!("{:width$} | ", lang.name, width = longest);
-                    for i in 0..lang.file_extensions.len() {
-                        print!("{}", lang.file_extensions[i]);
-
-                        if i < lang.file_extensions.len() - 1 {
-                            print!(", ");
-                        }
-                    }
-                    println!();
+                    println!("{}", lang.file_extensions.join(", "));
                 }
 
                 return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,6 +453,12 @@ fn run() -> Result<()> {
                 .default_value("auto")
                 .help("When to use the pager"),
         )
+        .arg(
+            Arg::with_name("list languages")
+                .long("list-languages")
+                .takes_value(false)
+                .help("Displays supported languages")
+        )
         .subcommand(
             SubCommand::with_name("cache")
                 .about("Modify the syntax-definition and theme cache")

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,14 +571,14 @@ fn run() -> Result<()> {
 
                 let longest = languages
                     .iter()
-                    .filter(|s| !s.hidden)
+                    .filter(|s| !s.hidden && s.file_extensions.len() > 0)
                     .map(|s| s.name.len())
                     .max()
                     .unwrap_or(32); // Fallback width if they have no language definitions.
 
                 let separator = " ";
                 for lang in languages {
-                    if lang.hidden {
+                    if lang.hidden || lang.file_extensions.len() == 0 {
                         continue;
                     }
                     print!("{:width$}{}", lang.name, separator, width = longest);

--- a/src/main.rs
+++ b/src/main.rs
@@ -572,9 +572,30 @@ fn run() -> Result<()> {
                     .max()
                     .unwrap_or(32); // Fallback width if they have no language definitions.
 
+                let separator = " | ";
                 for lang in languages {
-                    print!("{:width$} | ", lang.name, width = longest);
-                    println!("{}", lang.file_extensions.join(", "));
+                    print!("{:width$}{}", lang.name, separator, width = longest);
+
+                    // Line-wrapping for the possible file extension overflow.
+                    let desired_width = 48;
+                    // Number of characters on this line so far, wrap before `desired_width`
+                    let mut num_chars = 0;
+
+                    let mut extension = lang.file_extensions.iter().peekable();
+                    while let Some(word) = extension.next() {
+                        // If we can't fit this word in, then create a line break and align it in.
+                        if word.len() + num_chars >= desired_width {
+                            num_chars = 0;
+                            print!("\n{:width$}{}", "", separator, width = longest);
+                        }
+
+                        num_chars += word.len();
+                        print!("{}", word);
+                        if extension.peek().is_some() {
+                            print!(", ");
+                        }
+                    }
+                    println!();
                 }
 
                 return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ pub struct Options<'a> {
     pub language: Option<&'a str>,
     pub colored_output: bool,
     pub paging: bool,
+    pub term_width: usize,
 }
 
 enum OutputType {
@@ -552,6 +553,7 @@ fn run() -> Result<()> {
                         interactive_terminal
                     },
                 },
+                term_width: console::Term::stdout().size().1 as usize,
             };
 
             let assets =
@@ -580,7 +582,7 @@ fn run() -> Result<()> {
                     print!("{:width$}{}", lang.name, separator, width = longest);
 
                     // Line-wrapping for the possible file extension overflow.
-                    let desired_width = 90 - longest; 
+                    let desired_width = options.term_width - longest;
                     // Number of characters on this line so far, wrap before `desired_width`
                     let mut num_chars = 0;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -577,7 +577,7 @@ fn run() -> Result<()> {
                     print!("{:width$}{}", lang.name, separator, width = longest);
 
                     // Line-wrapping for the possible file extension overflow.
-                    let desired_width = 48;
+                    let desired_width = 90 - longest; 
                     // Number of characters on this line so far, wrap before `desired_width`
                     let mut num_chars = 0;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -574,6 +574,9 @@ fn run() -> Result<()> {
 
                 let separator = " | ";
                 for lang in languages {
+                    if lang.hidden {
+                        continue;
+                    }
                     print!("{:width$}{}", lang.name, separator, width = longest);
 
                     // Line-wrapping for the possible file extension overflow.

--- a/src/main.rs
+++ b/src/main.rs
@@ -590,12 +590,12 @@ fn run() -> Result<()> {
                     let mut extension = lang.file_extensions.iter().peekable();
                     while let Some(word) = extension.next() {
                         // If we can't fit this word in, then create a line break and align it in.
-                        if word.len() + num_chars + comma_separator.len() >= desired_width {
+                        if num_chars + word.len() + comma_separator.len() >= desired_width {
                             num_chars = 0;
                             print!("\n{:width$}{}", "", separator, width = longest);
                         }
 
-                        num_chars += word.len();
+                        num_chars += word.len() + comma_separator.len();
                         print!("{}", word);
                         if extension.peek().is_some() {
                             print!("{}", comma_separator);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -17,8 +17,6 @@ pub struct Printer<'a> {
 
 impl<'a> Printer<'a> {
     pub fn new(handle: &'a mut Write, options: &'a Options) -> Self {
-        let term_width = options.term_width;
-
         let colors = if options.colored_output {
             Colors::colored()
         } else {
@@ -28,7 +26,7 @@ impl<'a> Printer<'a> {
         Printer {
             handle,
             colors,
-            term_width,
+            term_width: options.term_width,
             options,
             line_changes: None,
         }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -10,7 +10,6 @@ const PANEL_WIDTH: usize = 7;
 pub struct Printer<'a> {
     handle: &'a mut Write,
     colors: Colors,
-    term_width: usize,
     options: &'a Options<'a>,
     pub line_changes: Option<LineChanges>,
 }
@@ -26,7 +25,6 @@ impl<'a> Printer<'a> {
         Printer {
             handle,
             colors,
-            term_width: options.term_width,
             options,
             line_changes: None,
         }
@@ -137,7 +135,7 @@ impl<'a> Printer<'a> {
     }
 
     fn print_horizontal_line(&mut self, grid_char: char) -> Result<()> {
-        let hline = "─".repeat(self.term_width - (PANEL_WIDTH + 1));
+        let hline = "─".repeat(self.options.term_width - (PANEL_WIDTH + 1));
         let hline = format!("{}{}{}", "─".repeat(PANEL_WIDTH), grid_char, hline);
 
         writeln!(self.handle, "{}", self.colors.grid.paint(hline))?;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,5 +1,4 @@
 use ansi_term::Style;
-use console::Term;
 use errors::*;
 use std::io::Write;
 use syntect::highlighting;
@@ -18,8 +17,7 @@ pub struct Printer<'a> {
 
 impl<'a> Printer<'a> {
     pub fn new(handle: &'a mut Write, options: &'a Options) -> Self {
-        let (_, term_width) = Term::stdout().size();
-        let term_width = term_width as usize;
+        let term_width = options.term_width;
 
         let colors = if options.colored_output {
             Colors::colored()


### PR DESCRIPTION
Closes #69 

```
$ ./target/debug/bat.exe Cargo.toml --list-languages
ASP                              | asa
HTML (ASP)                       | asp
ActionScript                     | as
AppleScript                      | applescript, script editor
Batch File                       | bat, cmd
NAnt Build File                  | build
C#                               | cs, csx
C++                              | cpp, cc, cp, cxx, c++, C, h, hh, hpp, hxx, h++, inl, ipp
C                                | c, h
--snipped--
```