### PR TITLE
Added text wrapping. (Fixes #54)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use console::Term;
 use errors::*;
 use std::collections::HashSet;
 use std::env;
-use style::{OutputComponent, OutputComponents};
+use style::{OutputComponent, OutputComponents, OutputWrap};
 
 pub struct App {
     pub matches: ArgMatches<'static>,
@@ -135,6 +135,7 @@ impl App {
             true_color: is_truecolor_terminal(),
             output_components: self.output_components()?,
             language: self.matches.value_of("language"),
+            output_wrap: OutputWrap::Character,
             colored_output: match self.matches.value_of("color") {
                 Some("always") => true,
                 Some("never") => false,
@@ -191,6 +192,7 @@ impl App {
 
 pub struct Config<'a> {
     pub true_color: bool,
+    pub output_wrap: OutputWrap,
     pub output_components: OutputComponents,
     pub language: Option<&'a str>,
     pub colored_output: bool,

--- a/src/app.rs
+++ b/src/app.rs
@@ -81,6 +81,14 @@ impl App {
                     .help("When to use the pager"),
             )
             .arg(
+                Arg::with_name("wrap")
+                    .long("wrap")
+                    .takes_value(true)
+                    .possible_values(&["character", "never"])
+                    .default_value("character")
+                    .help("When to wrap text"),
+            )
+            .arg(
                 Arg::with_name("list-languages")
                     .long("list-languages")
                     .help("Displays supported languages"),
@@ -135,7 +143,16 @@ impl App {
             true_color: is_truecolor_terminal(),
             output_components: self.output_components()?,
             language: self.matches.value_of("language"),
-            output_wrap: OutputWrap::Character,
+            output_wrap: if ! self.interactive_output {
+                // We don't have the tty width when piping to another program.
+                // There's no point in wrapping when this is the case.
+                OutputWrap::None
+            } else {
+                match self.matches.value_of("wrap") {
+                    Some("character") => OutputWrap::Character,
+                    Some("never") | _ => OutputWrap::None,
+                }
+            },
             colored_output: match self.matches.value_of("color") {
                 Some("always") => true,
                 Some("never") => false,

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,7 +59,7 @@ impl App {
                     .use_delimiter(true)
                     .takes_value(true)
                     .possible_values(&[
-                        "auto", "full", "plain", "changes", "header", "grid", "numbers",
+                        "auto", "full", "plain", "changes", "header", "grid", "numbers"
                     ])
                     .default_value("auto")
                     .help("Additional info to display along with content"),

--- a/src/app.rs
+++ b/src/app.rs
@@ -143,7 +143,7 @@ impl App {
             true_color: is_truecolor_terminal(),
             output_components: self.output_components()?,
             language: self.matches.value_of("language"),
-            output_wrap: if ! self.interactive_output {
+            output_wrap: if !self.interactive_output {
                 // We don't have the tty width when piping to another program.
                 // There's no point in wrapping when this is the case.
                 OutputWrap::None

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,7 +59,7 @@ impl App {
                     .use_delimiter(true)
                     .takes_value(true)
                     .possible_values(&[
-                        "auto", "full", "plain", "changes", "header", "grid", "numbers"
+                        "auto", "full", "plain", "changes", "header", "grid", "numbers",
                     ])
                     .default_value("auto")
                     .help("Additional info to display along with content"),

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -23,7 +23,8 @@ pub fn get_git_diff(filename: &str) -> Option<LineChanges> {
     diff_options.pathspec(pathspec);
     diff_options.context_lines(0);
 
-    let diff = repo.diff_index_to_workdir(None, Some(&mut diff_options))
+    let diff = repo
+        .diff_index_to_workdir(None, Some(&mut diff_options))
         .ok()?;
 
     let mut line_changes: LineChanges = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,11 @@ extern crate syntect;
 
 mod app;
 mod assets;
+mod decorations;
 mod diff;
 mod printer;
 mod style;
 mod terminal;
-mod decorations;
 
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Write};

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod diff;
 mod printer;
 mod style;
 mod terminal;
+mod decorations;
 
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Write};

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -250,7 +250,7 @@ impl<'a> Printer<'a> {
 
     fn print_horizontal_line(&mut self, grid_char: char) -> Result<()> {
         if self.panel_width == 0 {
-            writeln!(self.handle, "{}", "─".repeat(self.config.term_width))?;
+            writeln!(self.handle, "{}", self.colors.grid.paint("─".repeat(self.config.term_width)))?;
         } else {
             let hline = "─".repeat(self.config.term_width - (self.panel_width + 1));
             let hline = format!("{}{}{}", "─".repeat(self.panel_width), grid_char, hline);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -142,8 +142,9 @@ impl<'a> Printer<'a> {
             )?;
         } else {
             for &(style, text) in regions.iter() {
-                let mut chars = text.chars().filter(|c| *c != '\n');
-                let mut remaining = text.chars().filter(|c| *c != '\n').count();
+                let text = text.trim_right_matches(|c| c == '\r' || c == '\n');
+                let mut chars = text.chars();
+                let mut remaining = text.chars().count();
 
                 while remaining > 0 {
                     let available = cursor_max - cursor;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -135,7 +135,7 @@ impl<'a> Printer<'a> {
                    regions.iter()
                        .map(|&(style, text)| as_terminal_escaped(style, text, true_color, colored_output))
                        .collect::<Vec<_>>()
-                       .join(" ")
+                       .join("")
             )?;
         } else {
             for &(style, text) in regions.iter() {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -188,15 +188,12 @@ impl<'a> Printer<'a> {
                         " ".repeat(gutter_width),
                         border.text.to_owned()
                     )?;
-
-                    continue;
                 }
             }
 
             write!(self.handle, "\n")?;
         }
 
-        // Finished.
         Ok(())
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -38,7 +38,7 @@ impl<'a> Printer<'a> {
             decorations.push(Box::new(LineChangesDecoration::new(&colors)));
         }
 
-        let panel_width: usize =
+        let mut panel_width: usize =
             decorations.len() + decorations.iter().fold(0, |a, x| a + x.width());
 
         // The grid border decoration isn't added until after the panel_width calculation, since the
@@ -46,6 +46,13 @@ impl<'a> Printer<'a> {
         // width is without the grid border.
         if config.output_components.grid() && decorations.len() > 0 {
             decorations.push(Box::new(GridBorderDecoration::new(&colors)));
+        }
+
+        // Disable the panel if the terminal is too small (i.e. can't fit 5 characters with the
+        // panel showing).
+        if config.term_width < (decorations.len() + decorations.iter().fold(0, |a, x| a + x.width())) + 5 {
+            decorations.clear();
+            panel_width = 0;
         }
 
         // Create printer.

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -231,7 +231,7 @@ impl<'a> Printer<'a> {
     fn gen_border(&self) -> PrintSegment {
         return PrintSegment {
             text: self.colors.grid.paint("│").to_string(),
-            size: 2,
+            size: 1,
         };
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -112,7 +112,7 @@ impl<'a> Printer<'a> {
         if self.panel_width > 0 {
             let decorations = self.decorations
                 .iter()
-                .map(|ref d| d.for_line(line_number, self))
+                .map(|ref d| d.generate(line_number, false, self))
                 .collect::<Vec<_>>();
 
             for deco in decorations {
@@ -174,7 +174,7 @@ impl<'a> Printer<'a> {
                                 "{} ",
                                 self.decorations
                                     .iter()
-                                    .map(|ref d| d.for_wrap(line_number, self).text)
+                                    .map(|ref d| d.generate(line_number, true, self).text)
                                     .collect::<Vec<String>>()
                                     .join(" ")
                             ))

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,13 +1,13 @@
 use app::Config;
+use decorations::{Decoration, GridBorderDecoration, LineChangesDecoration, LineNumberDecoration};
 use diff::LineChanges;
 use errors::*;
+use std::boxed::Box;
 use std::io::Write;
 use std::vec::Vec;
-use std::boxed::Box;
+use style::OutputWrap;
 use syntect::highlighting;
 use terminal::as_terminal_escaped;
-use style::OutputWrap;
-use decorations::{Decoration, GridBorderDecoration, LineChangesDecoration, LineNumberDecoration};
 use Colors;
 
 pub struct Printer<'a> {
@@ -50,7 +50,9 @@ impl<'a> Printer<'a> {
 
         // Disable the panel if the terminal is too small (i.e. can't fit 5 characters with the
         // panel showing).
-        if config.term_width < (decorations.len() + decorations.iter().fold(0, |a, x| a + x.width())) + 5 {
+        if config.term_width
+            < (decorations.len() + decorations.iter().fold(0, |a, x| a + x.width())) + 5
+        {
             decorations.clear();
             panel_width = 0;
         }
@@ -117,7 +119,8 @@ impl<'a> Printer<'a> {
 
         // Line decorations.
         if self.panel_width > 0 {
-            let decorations = self.decorations
+            let decorations = self
+                .decorations
                 .iter()
                 .map(|ref d| d.generate(line_number, false, self))
                 .collect::<Vec<_>>();

--- a/src/style.rs
+++ b/src/style.rs
@@ -16,7 +16,7 @@ pub enum OutputComponent {
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum OutputWrap {
     Character,
-    None
+    None,
 }
 
 impl OutputComponent {

--- a/src/style.rs
+++ b/src/style.rs
@@ -15,7 +15,7 @@ pub enum OutputComponent {
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum OutputWrap {
-    Character
+    Character,
 }
 
 impl OutputComponent {

--- a/src/style.rs
+++ b/src/style.rs
@@ -13,6 +13,11 @@ pub enum OutputComponent {
     Plain,
 }
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+pub enum OutputWrap {
+    Character
+}
+
 impl OutputComponent {
     pub fn components(&self, interactive_terminal: bool) -> &'static [OutputComponent] {
         match *self {

--- a/src/style.rs
+++ b/src/style.rs
@@ -16,6 +16,7 @@ pub enum OutputComponent {
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum OutputWrap {
     Character,
+    None
 }
 
 impl OutputComponent {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -26,26 +26,46 @@ fn rgb2ansi(r: u8, g: u8, b: u8) -> u8 {
     }
 }
 
+//pub fn as_terminal_escaped(
+//    v: &[(highlighting::Style, &str)],
+//    true_color: bool,
+//    colored: bool,
+//) -> String {
+//    let mut s: String = String::new();
+//    for &(ref style, text) in v.iter() {
+//        let style = if !colored {
+//            Style::default()
+//        } else if true_color {
+//            RGB(style.foreground.r, style.foreground.g, style.foreground.b).normal()
+//        } else {
+//            let ansi = rgb2ansi(style.foreground.r, style.foreground.g, style.foreground.b);
+//            Fixed(ansi).normal()
+//        };
+//
+//        write!(s, "{}", style.paint(text)).unwrap();
+//    }
+//
+//    s
+//}
+
 pub fn as_terminal_escaped(
-    v: &[(highlighting::Style, &str)],
+    color:highlighting::Style,
+    text: &str,
     true_color: bool,
     colored: bool,
 ) -> String {
+    let style = if !colored {
+        Style::default()
+    } else if true_color {
+        RGB(color.foreground.r, color.foreground.g, color.foreground.b).normal()
+    } else {
+        let ansi = rgb2ansi(color.foreground.r, color.foreground.g, color.foreground.b);
+        Fixed(ansi).normal()
+    };
+
     let mut s: String = String::new();
-    for &(ref style, text) in v.iter() {
-        let style = if !colored {
-            Style::default()
-        } else if true_color {
-            RGB(style.foreground.r, style.foreground.g, style.foreground.b).normal()
-        } else {
-            let ansi = rgb2ansi(style.foreground.r, style.foreground.g, style.foreground.b);
-            Fixed(ansi).normal()
-        };
-
-        write!(s, "{}", style.paint(text)).unwrap();
-    }
-
-    s
+    write!(s, "{}", style.paint(text)).unwrap();
+    return s;
 }
 
 #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -26,30 +26,8 @@ fn rgb2ansi(r: u8, g: u8, b: u8) -> u8 {
     }
 }
 
-//pub fn as_terminal_escaped(
-//    v: &[(highlighting::Style, &str)],
-//    true_color: bool,
-//    colored: bool,
-//) -> String {
-//    let mut s: String = String::new();
-//    for &(ref style, text) in v.iter() {
-//        let style = if !colored {
-//            Style::default()
-//        } else if true_color {
-//            RGB(style.foreground.r, style.foreground.g, style.foreground.b).normal()
-//        } else {
-//            let ansi = rgb2ansi(style.foreground.r, style.foreground.g, style.foreground.b);
-//            Fixed(ansi).normal()
-//        };
-//
-//        write!(s, "{}", style.paint(text)).unwrap();
-//    }
-//
-//    s
-//}
-
 pub fn as_terminal_escaped(
-    color:highlighting::Style,
+    color: highlighting::Style,
     text: &str,
     true_color: bool,
     colored: bool,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use ansi_term::Colour::{Fixed, RGB};
 use ansi_term::Style;
 use syntect::highlighting::{self, FontStyle};
@@ -32,7 +30,6 @@ pub fn as_terminal_escaped(
     true_color: bool,
     colored: bool,
 ) -> String {
-
     let style = if !colored {
         Style::default()
     } else {
@@ -54,9 +51,7 @@ pub fn as_terminal_escaped(
         }
     };
 
-    let mut s: String = String::new();
-    write!(s, "{}", style.paint(text)).unwrap();
-    return s;
+    style.paint(text).to_string()
 }
 
 #[test]

--- a/tests/snapshots/output/changes,grid,header.snapshot.txt
+++ b/tests/snapshots/output/changes,grid,header.snapshot.txt
@@ -1,25 +1,25 @@
-───────┬────────────────────────────────────────────────────────────────────────
-       │ File: sample.rs
-───────┼────────────────────────────────────────────────────────────────────────
-       │ struct Rectangle {
-       │     width: u32,
-       │     height: u32,
-       │ }
-       │ 
-     _ │ fn main() {
-       │     let rect1 = Rectangle { width: 30, height: 50 };
-       │ 
-       │     println!(
-     ~ │         "The perimeter of the rectangle is {} pixels.",
-     ~ │         perimeter(&rect1)
-       │     );
-       │ }
-       │ 
-       │ fn area(rectangle: &Rectangle) -> u32 {
-       │     rectangle.width * rectangle.height
-       │ }
-     + │ 
-     + │ fn perimeter(rectangle: &Rectangle) -> u32 {
-     + │     (rectangle.width + rectangle.height) * 2
-     + │ }
-───────┴────────────────────────────────────────────────────────────────────────
+──┬─────────────────────────────────────────────────────────────────────────────
+  │ File: sample.rs
+──┼─────────────────────────────────────────────────────────────────────────────
+  │ struct Rectangle {
+  │     width: u32,
+  │     height: u32,
+  │ }
+  │ 
+_ │ fn main() {
+  │     let rect1 = Rectangle { width: 30, height: 50 };
+  │ 
+  │     println!(
+~ │         "The perimeter of the rectangle is {} pixels.",
+~ │         perimeter(&rect1)
+  │     );
+  │ }
+  │ 
+  │ fn area(rectangle: &Rectangle) -> u32 {
+  │     rectangle.width * rectangle.height
+  │ }
++ │ 
++ │ fn perimeter(rectangle: &Rectangle) -> u32 {
++ │     (rectangle.width + rectangle.height) * 2
++ │ }
+──┴─────────────────────────────────────────────────────────────────────────────

--- a/tests/snapshots/output/changes,grid.snapshot.txt
+++ b/tests/snapshots/output/changes,grid.snapshot.txt
@@ -1,22 +1,22 @@
-       │ struct Rectangle {
-       │     width: u32,
-       │     height: u32,
-       │ }
-       │ 
-     _ │ fn main() {
-       │     let rect1 = Rectangle { width: 30, height: 50 };
-       │ 
-       │     println!(
-     ~ │         "The perimeter of the rectangle is {} pixels.",
-     ~ │         perimeter(&rect1)
-       │     );
-       │ }
-       │ 
-       │ fn area(rectangle: &Rectangle) -> u32 {
-       │     rectangle.width * rectangle.height
-       │ }
-     + │ 
-     + │ fn perimeter(rectangle: &Rectangle) -> u32 {
-     + │     (rectangle.width + rectangle.height) * 2
-     + │ }
-───────┴────────────────────────────────────────────────────────────────────────
+  │ struct Rectangle {
+  │     width: u32,
+  │     height: u32,
+  │ }
+  │ 
+_ │ fn main() {
+  │     let rect1 = Rectangle { width: 30, height: 50 };
+  │ 
+  │     println!(
+~ │         "The perimeter of the rectangle is {} pixels.",
+~ │         perimeter(&rect1)
+  │     );
+  │ }
+  │ 
+  │ fn area(rectangle: &Rectangle) -> u32 {
+  │     rectangle.width * rectangle.height
+  │ }
++ │ 
++ │ fn perimeter(rectangle: &Rectangle) -> u32 {
++ │     (rectangle.width + rectangle.height) * 2
++ │ }
+──┴─────────────────────────────────────────────────────────────────────────────

--- a/tests/snapshots/output/grid,header,numbers.snapshot.txt
+++ b/tests/snapshots/output/grid,header,numbers.snapshot.txt
@@ -1,25 +1,25 @@
-───────┬────────────────────────────────────────────────────────────────────────
-       │ File: sample.rs
-───────┼────────────────────────────────────────────────────────────────────────
-   1   │ struct Rectangle {
-   2   │     width: u32,
-   3   │     height: u32,
-   4   │ }
-   5   │ 
-   6   │ fn main() {
-   7   │     let rect1 = Rectangle { width: 30, height: 50 };
-   8   │ 
-   9   │     println!(
-  10   │         "The perimeter of the rectangle is {} pixels.",
-  11   │         perimeter(&rect1)
-  12   │     );
-  13   │ }
-  14   │ 
-  15   │ fn area(rectangle: &Rectangle) -> u32 {
-  16   │     rectangle.width * rectangle.height
-  17   │ }
-  18   │ 
-  19   │ fn perimeter(rectangle: &Rectangle) -> u32 {
-  20   │     (rectangle.width + rectangle.height) * 2
-  21   │ }
-───────┴────────────────────────────────────────────────────────────────────────
+─────┬──────────────────────────────────────────────────────────────────────────
+     │ File: sample.rs
+─────┼──────────────────────────────────────────────────────────────────────────
+   1 │ struct Rectangle {
+   2 │     width: u32,
+   3 │     height: u32,
+   4 │ }
+   5 │ 
+   6 │ fn main() {
+   7 │     let rect1 = Rectangle { width: 30, height: 50 };
+   8 │ 
+   9 │     println!(
+  10 │         "The perimeter of the rectangle is {} pixels.",
+  11 │         perimeter(&rect1)
+  12 │     );
+  13 │ }
+  14 │ 
+  15 │ fn area(rectangle: &Rectangle) -> u32 {
+  16 │     rectangle.width * rectangle.height
+  17 │ }
+  18 │ 
+  19 │ fn perimeter(rectangle: &Rectangle) -> u32 {
+  20 │     (rectangle.width + rectangle.height) * 2
+  21 │ }
+─────┴──────────────────────────────────────────────────────────────────────────

--- a/tests/snapshots/output/grid,header.snapshot.txt
+++ b/tests/snapshots/output/grid,header.snapshot.txt
@@ -1,25 +1,25 @@
-───────┬────────────────────────────────────────────────────────────────────────
-       │ File: sample.rs
-───────┼────────────────────────────────────────────────────────────────────────
-       │ struct Rectangle {
-       │     width: u32,
-       │     height: u32,
-       │ }
-       │ 
-       │ fn main() {
-       │     let rect1 = Rectangle { width: 30, height: 50 };
-       │ 
-       │     println!(
-       │         "The perimeter of the rectangle is {} pixels.",
-       │         perimeter(&rect1)
-       │     );
-       │ }
-       │ 
-       │ fn area(rectangle: &Rectangle) -> u32 {
-       │     rectangle.width * rectangle.height
-       │ }
-       │ 
-       │ fn perimeter(rectangle: &Rectangle) -> u32 {
-       │     (rectangle.width + rectangle.height) * 2
-       │ }
-───────┴────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────────────
+ File: sample.rs
+────────────────────────────────────────────────────────────────────────────────
+struct Rectangle {
+    width: u32,
+    height: u32,
+}
+
+fn main() {
+    let rect1 = Rectangle { width: 30, height: 50 };
+
+    println!(
+        "The perimeter of the rectangle is {} pixels.",
+        perimeter(&rect1)
+    );
+}
+
+fn area(rectangle: &Rectangle) -> u32 {
+    rectangle.width * rectangle.height
+}
+
+fn perimeter(rectangle: &Rectangle) -> u32 {
+    (rectangle.width + rectangle.height) * 2
+}
+────────────────────────────────────────────────────────────────────────────────

--- a/tests/snapshots/output/grid,numbers.snapshot.txt
+++ b/tests/snapshots/output/grid,numbers.snapshot.txt
@@ -1,22 +1,22 @@
-   1   │ struct Rectangle {
-   2   │     width: u32,
-   3   │     height: u32,
-   4   │ }
-   5   │ 
-   6   │ fn main() {
-   7   │     let rect1 = Rectangle { width: 30, height: 50 };
-   8   │ 
-   9   │     println!(
-  10   │         "The perimeter of the rectangle is {} pixels.",
-  11   │         perimeter(&rect1)
-  12   │     );
-  13   │ }
-  14   │ 
-  15   │ fn area(rectangle: &Rectangle) -> u32 {
-  16   │     rectangle.width * rectangle.height
-  17   │ }
-  18   │ 
-  19   │ fn perimeter(rectangle: &Rectangle) -> u32 {
-  20   │     (rectangle.width + rectangle.height) * 2
-  21   │ }
-───────┴────────────────────────────────────────────────────────────────────────
+   1 │ struct Rectangle {
+   2 │     width: u32,
+   3 │     height: u32,
+   4 │ }
+   5 │ 
+   6 │ fn main() {
+   7 │     let rect1 = Rectangle { width: 30, height: 50 };
+   8 │ 
+   9 │     println!(
+  10 │         "The perimeter of the rectangle is {} pixels.",
+  11 │         perimeter(&rect1)
+  12 │     );
+  13 │ }
+  14 │ 
+  15 │ fn area(rectangle: &Rectangle) -> u32 {
+  16 │     rectangle.width * rectangle.height
+  17 │ }
+  18 │ 
+  19 │ fn perimeter(rectangle: &Rectangle) -> u32 {
+  20 │     (rectangle.width + rectangle.height) * 2
+  21 │ }
+─────┴──────────────────────────────────────────────────────────────────────────

--- a/tests/snapshots/output/grid.snapshot.txt
+++ b/tests/snapshots/output/grid.snapshot.txt
@@ -1,22 +1,22 @@
-       │ struct Rectangle {
-       │     width: u32,
-       │     height: u32,
-       │ }
-       │ 
-       │ fn main() {
-       │     let rect1 = Rectangle { width: 30, height: 50 };
-       │ 
-       │     println!(
-       │         "The perimeter of the rectangle is {} pixels.",
-       │         perimeter(&rect1)
-       │     );
-       │ }
-       │ 
-       │ fn area(rectangle: &Rectangle) -> u32 {
-       │     rectangle.width * rectangle.height
-       │ }
-       │ 
-       │ fn perimeter(rectangle: &Rectangle) -> u32 {
-       │     (rectangle.width + rectangle.height) * 2
-       │ }
-───────┴────────────────────────────────────────────────────────────────────────
+struct Rectangle {
+    width: u32,
+    height: u32,
+}
+
+fn main() {
+    let rect1 = Rectangle { width: 30, height: 50 };
+
+    println!(
+        "The perimeter of the rectangle is {} pixels.",
+        perimeter(&rect1)
+    );
+}
+
+fn area(rectangle: &Rectangle) -> u32 {
+    rectangle.width * rectangle.height
+}
+
+fn perimeter(rectangle: &Rectangle) -> u32 {
+    (rectangle.width + rectangle.height) * 2
+}
+────────────────────────────────────────────────────────────────────────────────

--- a/tests/tester.rs
+++ b/tests/tester.rs
@@ -29,10 +29,7 @@ impl BatTester {
 
     pub fn test_snapshot(&self, style: &str) {
         let output = Command::new(&self.exe)
-            .args(&[
-                "tests/snapshots/sample.rs",
-                &format!("--style={}", style),
-            ])
+            .args(&["tests/snapshots/sample.rs", &format!("--style={}", style)])
             .output()
             .expect("bat failed");
         // have to do the replace because the filename in the header changes based on the current working directory


### PR DESCRIPTION
I use bat pretty frequently, so I wanted to give back and make it even better by adding text wrapping (issue #54).

I've never touched Rust before this, and I apologize if the code style is weird or if any of my changes have less-than-ideal performance.

## Changes:
- **Text wrapping.**
   Lines will now automatically wrap at a character boundary.
   Syntax coloring will also wrap.
![image](https://user-images.githubusercontent.com/32112321/39954037-7374f742-556c-11e8-9c43-2856b07d3ce6.png)


- **Resizing gutter (panel).**
   The gutter (area that shows line numbers and changes) will now automatically resize.
   This cuts back on the amount of wasted space when not showing everything.
![image](https://user-images.githubusercontent.com/32112321/39954054-0db9db56-556d-11e8-8557-f6be8d81510f.png)
   It will also disappear if not needed.
   ![image](https://user-images.githubusercontent.com/32112321/39954079-bf96ae44-556d-11e8-88b4-01a18d5db20d.png)

