### PR TITLE
Fixed #124

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,4 +1,3 @@
-use Colors;
 use app::Config;
 use console::AnsiCodeIterator;
 use decorations::{Decoration, GridBorderDecoration, LineChangesDecoration, LineNumberDecoration};
@@ -10,6 +9,7 @@ use std::vec::Vec;
 use style::OutputWrap;
 use syntect::highlighting;
 use terminal::as_terminal_escaped;
+use Colors;
 
 pub struct Printer<'a> {
     handle: &'a mut Write,
@@ -119,7 +119,8 @@ impl<'a> Printer<'a> {
 
         // Line decorations.
         if self.panel_width > 0 {
-            let decorations = self.decorations
+            let decorations = self
+                .decorations
                 .iter()
                 .map(|ref d| d.generate(self.line_number, false, self))
                 .collect::<Vec<_>>();
@@ -194,7 +195,8 @@ impl<'a> Printer<'a> {
                                             "{} ",
                                             self.decorations
                                                 .iter()
-                                                .map(|ref d| d.generate(self.line_number, true, self)
+                                                .map(|ref d| d
+                                                    .generate(self.line_number, true, self)
                                                     .text)
                                                 .collect::<Vec<String>>()
                                                 .join(" ")


### PR DESCRIPTION
Fixed #124 by using `console::AnsiCodeIterator`. 

![image](https://user-images.githubusercontent.com/32112321/40145177-bd3d7cf8-5915-11e8-8269-db5e8d34846f.png)


# Caveats
Due to the way that all the input is formatted with the default styling before being printed, I had to use the ANSI escape sequences as prefixes to the input text. Not doing so would result in the ANSI styles being overridden like so: `\x1B[32m\x1B[0m`. It's not an elegant solution, and it definitely doesn't help performance, but it works.