### PR TITLE
Fix launching of pager so all control characters are interpreted.

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -26,6 +26,7 @@ impl OutputType {
         }
         Command::new("less")
             .args(&args)
+            .env("LESSCHARSET", "UTF-8")
             .stdin(Stdio::piped())
             .spawn()
             .map(OutputType::Pager)


### PR DESCRIPTION
Fix launching of pager so all control characters are interpreted
instead of only ANSI "color" escape sequences.

This fixes issue https://github.com/sharkdp/bat/issues/98