### PR TITLE
Using slice notation instead of as_ref

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -47,7 +47,7 @@ pub fn list_languages(assets: &HighlightingAssets, term_width: usize) {
             }
 
             num_chars += new_chars;
-            print!("{}", Green.paint(word.as_ref()));
+            print!("{}", Green.paint(&word[..]));
             if extension.peek().is_some() {
                 print!("{}", comma_separator);
             }


### PR DESCRIPTION
That would fix the type annotation error discussed in #148 