### PR TITLE
add line-range

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -150,8 +150,8 @@ impl App {
                     .long_help(
                         "Print a specified range or ranges of lines from the files. \
                          For example: '--line-range 30:40' will print lines 30 to 40 \n\
-                                      '--line-range :40' will print lines 1 to 40 \n\
-                                      '--line-range 40:' will print lines 40 to the end of the file",
+                         '--line-range :40' will print lines 1 to 40 \n\
+                         '--line-range 40:' will print lines 40 to the end of the file",
                     ),
             )
             .arg(

--- a/src/app.rs
+++ b/src/app.rs
@@ -146,7 +146,8 @@ impl App {
                     .long("line-range")
                     .overrides_with("line-range")
                     .takes_value(true)
-                    .help("Print range of lines")
+                    .value_name("n:m")
+                    .help("Only print the lines from n to m")
                     .long_help(
                         "Print a specified range or ranges of lines from the files. \
                          For example: '--line-range 30:40' will print lines 30 to 40 \n\

--- a/src/app.rs
+++ b/src/app.rs
@@ -282,7 +282,7 @@ impl App {
             term_width: Term::stdout().size().1 as usize,
             files,
             theme: self.matches.value_of("theme"),
-            line_range: LineRange::from(self.matches.value_of("line-range")),
+            line_range: self.matches.value_of("line-range").map(LineRange::from),
         })
     }
 
@@ -351,20 +351,19 @@ pub struct LineRange {
 }
 
 impl LineRange {
-    pub fn from(value: Option<&str>) -> Option<LineRange> {
-        match value {
-            None => None,
-            Some(range_raw) => {
-                return LineRange::parse_range(range_raw).ok();
-            }
+    pub fn from(range_raw: &str) -> LineRange {
+        LineRange::parse_range(range_raw).unwrap_or(LineRange::new())
+    }
+
+    pub fn new() -> LineRange {
+        LineRange{
+            lower: usize::min_value(),
+            upper: usize::max_value(),
         }
     }
 
     pub fn parse_range(range_raw: &str) -> Result<LineRange> {
-        let mut new_range = LineRange{
-            lower: usize::min_value(),
-            upper: usize::max_value(),
-        };
+        let mut new_range = LineRange::new();
 
         if range_raw.bytes().nth(0).ok_or("No first byte")? == b':' {
             new_range.upper = range_raw[1..].parse()?;

--- a/src/features.rs
+++ b/src/features.rs
@@ -96,12 +96,25 @@ fn print_file(
     printer.print_header(filename)?;
 
     let mut buffer = Vec::new();
+
     while reader.read_until(b'\n', &mut buffer)? > 0 {
         {
             let line = String::from_utf8_lossy(&buffer);
             let regions = highlighter.highlight(line.as_ref());
 
-            printer.print_line(&regions)?;
+            if printer.config.line_range.is_some() {
+                if printer.line_number + 1 < printer.config.line_range.unwrap().0 {
+                    // skip line
+                    printer.line_number += 1;
+                } else if printer.line_number >= printer.config.line_range.unwrap().1 {
+                    // no more lines in range
+                    break;
+                } else {
+                    printer.print_line(&regions)?;
+                }
+            } else {
+                printer.print_line(&regions)?;
+            }
         }
         buffer.clear();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ mod errors {
             Clap(::clap::Error);
             Io(::std::io::Error);
             SyntectError(::syntect::LoadingError);
+            ParseIntError(::std::num::ParseIntError);
         }
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -15,10 +15,10 @@ use terminal::as_terminal_escaped;
 pub struct Printer<'a> {
     handle: &'a mut Write,
     colors: Colors,
-    config: &'a Config<'a>,
+    pub config: &'a Config<'a>,
     decorations: Vec<Box<Decoration>>,
     panel_width: usize,
-    line_number: usize,
+    pub line_number: usize,
     pub line_changes: Option<LineChanges>,
 }
 


### PR DESCRIPTION
This is my first attempt at actually writing some rust code so bear with me.

I wasn't sure of the best place to put the logic for checking line range. I started with putting it in the print_line function but moved it out to be able to short circuit and stop processing once out of the range.

I didn't add the ability to do multiple ranges yet but it should be fairly simple.

How robust of error checking do we need on validating the line ranges? Like do we want to sort or make sure they are not conflicting or that they are in least to greatest order or anything like that?