### PR TITLE
Fix #182

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -64,6 +64,7 @@ pub fn print_files(assets: &HighlightingAssets, config: &Config) -> Result<bool>
     let mut no_errors: bool = true;
 
     for file in &config.files {
+        printer.ansi_prefix_sgr.clear();
         printer.line_changes = file.and_then(|filename| get_git_diff(filename));
         let syntax = assets.get_syntax(config.language, *file);
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -126,7 +126,8 @@ impl<'a> Printer<'a> {
 
         // Line decorations.
         if self.panel_width > 0 {
-            let decorations = self.decorations
+            let decorations = self
+                .decorations
                 .iter()
                 .map(|ref d| d.generate(self.line_number, false, self))
                 .collect::<Vec<_>>();
@@ -213,11 +214,9 @@ impl<'a> Printer<'a> {
                                             "{} ",
                                             self.decorations
                                                 .iter()
-                                                .map(|ref d| d.generate(
-                                                    self.line_number,
-                                                    true,
-                                                    self
-                                                ).text)
+                                                .map(|ref d| d
+                                                    .generate(self.line_number, true, self)
+                                                    .text)
                                                 .collect::<Vec<String>>()
                                                 .join(" ")
                                         ))

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -164,9 +164,13 @@ impl<'a> Printer<'a> {
                     match chunk {
                         // ANSI escape passthrough.
                         (text, true) => {
-                            if text.chars().last().unwrap() == 'm' {
-                                self.ansi_prefix_sgr.push_str(text);
+                            if text.chars().last().map_or(false, |c| c == 'm') {
                                 ansi_prefix.push_str(text);
+                                if text == "\x1B[0m" {
+                                    self.ansi_prefix_sgr = "\x1B[0m".to_owned();
+                                } else {
+                                    self.ansi_prefix_sgr.push_str(text);
+                                }
                             } else {
                                 ansi_prefix.push_str(text);
                             }


### PR DESCRIPTION
Tested with:

```shell
printf '\033[33mfoo\033[1m bar\033[22m baz' | cargo run
```

Results (italic = yellow):

cat *foo* **_bar_** *baz*
bat 0.4.1: *foo* **bar** baz
fix-182: *foo* **_bar_** *baz*
