### PR TITLE
Add spec for using cargo-rpm

### DIFF
--- a/.rpm/bat.spec
+++ b/.rpm/bat.spec
@@ -1,0 +1,33 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: bat
+Summary: A cat(1) clone with wings.
+Version: @@VERSION@@
+Release: 1
+License: MIT or ASL 2.0
+Group: Applications/System
+Source0: %{name}-%{version}.tar.gz
+URL: https://github.com/sharkdp/bat
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/*
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,9 @@ features = []
 
 [dev-dependencies]
 tempdir = "0.3"
+
+[package.metadata.rpm.cargo]
+buildflags = ["--release"]
+
+[package.metadata.rpm.targets]
+bat = { path = "/usr/bin/bat" }


### PR DESCRIPTION
With this, fedora/rhel/centos users can use their default package
manager to install bat, without needing cargo or rust.