### PR TITLE
Allow specifying the theme via the `BAT_THEME` environment variable

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -283,7 +283,8 @@ impl App {
             },
             term_width: Term::stdout().size().1 as usize,
             files,
-            theme: self.matches
+            theme: self
+                .matches
                 .value_of("theme")
                 .and_then(|theme_name_arg| Some(String::from(theme_name_arg)))
                 .or_else(|| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,3 @@
-use assets::HighlightingAssets;
 use atty::{self, Stream};
 use clap::{App as ClapApp, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand};
 use console::Term;
@@ -287,15 +286,8 @@ impl App {
                 .matches
                 .value_of("theme")
                 .map(String::from)
-                .or_else(|| {
-                    env::var("BAT_THEME").ok().and_then(|theme_name_env| {
-                        if HighlightingAssets::new().theme_exists(&theme_name_env) {
-                            Some(theme_name_env)
-                        } else {
-                            None
-                        }
-                    })
-                }),
+                .or_else(|| env::var("BAT_THEME").ok())
+                .unwrap_or(String::from("Default")),
             line_range: transpose(self.matches.value_of("line-range").map(LineRange::from))?,
         })
     }
@@ -349,7 +341,7 @@ pub struct Config<'a> {
     pub paging_mode: PagingMode,
     pub term_width: usize,
     pub files: Vec<Option<&'a str>>,
-    pub theme: Option<String>,
+    pub theme: String,
     pub line_range: Option<LineRange>,
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -286,7 +286,7 @@ impl App {
             theme: self
                 .matches
                 .value_of("theme")
-                .and_then(|theme_name_arg| Some(String::from(theme_name_arg)))
+                .map(String::from)
                 .or_else(|| {
                     env::var("BAT_THEME").ok().and_then(|theme_name_env| {
                         if HighlightingAssets::new().theme_exists(&theme_name_env) {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -132,6 +132,10 @@ impl HighlightingAssets {
         })?)
     }
 
+    pub fn theme_exists(&self, theme: &str) -> bool {
+        self.theme_set.themes.contains_key(theme)
+    }
+
     pub fn get_syntax(&self, language: Option<&str>, filename: Option<&str>) -> &SyntaxDefinition {
         let syntax = match (language, filename) {
             (Some(language), _) => self.syntax_set.find_syntax_by_token(language),

--- a/src/features.rs
+++ b/src/features.rs
@@ -57,7 +57,11 @@ pub fn list_languages(assets: &HighlightingAssets, term_width: usize) {
 }
 
 pub fn print_files(assets: &HighlightingAssets, config: &Config) -> Result<bool> {
-    let theme = assets.get_theme(config.theme.unwrap_or("Default"))?;
+    let theme = assets.get_theme(match config.theme {
+        Some(ref theme_name) => theme_name,
+        None => "Default",
+    })?;
+
     let mut output_type = OutputType::from_mode(config.paging_mode);
     let handle = output_type.handle()?;
     let mut printer = Printer::new(handle, &config);

--- a/src/features.rs
+++ b/src/features.rs
@@ -57,10 +57,7 @@ pub fn list_languages(assets: &HighlightingAssets, term_width: usize) {
 }
 
 pub fn print_files(assets: &HighlightingAssets, config: &Config) -> Result<bool> {
-    let theme = assets.get_theme(match config.theme {
-        Some(ref theme_name) => theme_name,
-        None => "Default",
-    })?;
+    let theme = assets.get_theme(&config.theme);
 
     let mut output_type = OutputType::from_mode(config.paging_mode);
     let handle = output_type.handle()?;


### PR DESCRIPTION
The `--theme` command line option stills takes precedence and this
change preserves how errors are handled when it's used: If a theme name
that doesn't exist is specified using the argument, this error is fatal.
However, if a theme that doesn't exist is specified using the environment
variable, the error is logged to `stderr` and the "Default" theme is
loaded as a fallback.

This a refactor/variation of sharkdp/bat#187 based on feedback from @sharkdp.

Fixes sharkdp/bat#177