### PR TITLE
Fixed issue #245

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::env;
+use std::path::Path;
 
 use atty::{self, Stream};
 
@@ -9,7 +10,6 @@ use console::Term;
 
 #[cfg(windows)]
 use ansi_term;
-
 use assets::BAT_THEME_DEFAULT;
 use errors::*;
 use line_range::LineRange;
@@ -102,6 +102,10 @@ impl App {
             AppSettings::ColorNever
         };
 
+        // Check if the current directory contains a file name cache, if it does
+        // do not make the arguements for subcommand 'cache' required.
+        let arg_group_required = !Path::new("./cache").exists();
+
         ClapApp::new(crate_name!())
             .version(crate_version!())
             .global_setting(clap_color_setting)
@@ -125,8 +129,7 @@ impl App {
                          to read from standard input.",
                     ).multiple(true)
                     .empty_values(false),
-                    )
-            .arg(
+            ).arg(
                 Arg::with_name("language")
                     .short("l")
                     .long("language")
@@ -303,7 +306,7 @@ impl App {
                     ).group(
                         ArgGroup::with_name("cache-actions")
                             .args(&["init", "clear", "config-dir"])
-                            .required(true),
+                            .required(arg_group_required),
                     ).arg(
                         Arg::with_name("source")
                             .long("source")

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,8 +181,21 @@ fn run() -> Result<bool> {
 
     match app.matches.subcommand() {
         ("cache", Some(cache_matches)) => {
-            run_cache_subcommand(cache_matches)?;
-            Ok(true)
+            // If there is a file named 'cache' in the current working directory,
+            // arguments for subcommand 'cache' are not mandatory.
+            // If there are non-zero arguments, execute the subcommand cache, else, open the file cache.
+            if !cache_matches.args.is_empty() {
+                run_cache_subcommand(cache_matches)?;
+                Ok(true)
+            } else {
+                let mut config = app.config()?;
+                let assets = HighlightingAssets::new();
+
+                config.files = vec![InputFile::Ordinary(&"cache")];
+                
+                let controller = Controller::new(&config, &assets);
+                controller.run()
+            }
         }
         _ => {
             let config = app.config()?;


### PR DESCRIPTION
Now if a cache file exists in the current directory, and the user passes
no arguments to the cache command, the cache file would be displayed.
If however the user uses cache command with arguments, the cache command
would be executed as normal regardless of wether the file cache exists
in the current directory or not.