### PR TITLE
Handle `less` in a portable way

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,7 @@
 use std::env;
+use std::ffi::OsString;
 use std::io::{self, Write};
+use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 
 use app::PagingMode;
@@ -26,13 +28,16 @@ impl OutputType {
             .or_else(|_| env::var("PAGER"))
             .unwrap_or(String::from("less"));
 
-        let mut process = if pager == "less" || pager.ends_with("/less") {
+        let less_path = PathBuf::from(&pager);
+        let is_less = less_path.file_stem() == Some(&OsString::from("less"));
+
+        let mut process = if is_less {
             let mut args = vec!["--RAW-CONTROL-CHARS", "--no-init"];
             if quit_if_one_screen {
                 args.push("--quit-if-one-screen");
             }
 
-            let mut p = Command::new("less");
+            let mut p = Command::new(&less_path);
             p.args(&args).env("LESSCHARSET", "UTF-8");
             p
         } else {


### PR DESCRIPTION
The current logic for special-casing `less` relies on the pager being specified as the literal string or using Unix-style paths. It also ignores the actual pager specified when calling it, so even if you set `PAGER`/`BAT_PAGER` to `/my/path/to/less`, `bat` will simply call `less`.

This PR treats any specified pager as a path and checks only the file stem so that `C:\foo\bar\less.exe`, `/foo/bar/less`, and `less` are all recognized.  It also uses the specified `less`.

I managed to write a test for this by creating a stub `bin/less.rs` that verifies its arguments and the environment. However, this binary was installed along with `bat` when running `cargo install`. [I haven’t yet found a way to test the behaviour without this issue](https://stackoverflow.com/q/52205295/8492116), so for the moment I can only offer the fix without the test (but with the assurance that I’ve tested its behaviour both manually and automatically).