### PR TITLE
Disable wrapping when --plain is used. (Fixes #289)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -415,10 +415,8 @@ impl App {
                         } else {
                             InputFile::Ordinary(filename)
                         }
-                    })
-                    .collect()
-            })
-            .unwrap_or_else(|| vec![InputFile::StdIn])
+                    }).collect()
+            }).unwrap_or_else(|| vec![InputFile::StdIn])
     }
 
     fn output_components(&self) -> Result<OutputComponents> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -190,7 +190,7 @@ impl App {
                     .long("plain")
                     .conflicts_with("style")
                     .conflicts_with("number")
-                    .help("Show plain style (alias for '--style=plain'.")
+                    .help("Show plain style (alias for '--style=plain').")
                     .long_help(
                         "Only show plain style, no decorations. This is an alias for \
                          '--style=plain'",

--- a/src/app.rs
+++ b/src/app.rs
@@ -384,7 +384,8 @@ impl App {
                     }
                 },
             },
-            term_width: self.matches
+            term_width: self
+                .matches
                 .value_of("terminal-width")
                 .and_then(|w| w.parse().ok())
                 .unwrap_or(Term::stdout().size().1 as usize),
@@ -392,7 +393,8 @@ impl App {
                 || self.matches.value_of("color") == Some("always")
                 || self.matches.value_of("decorations") == Some("always")),
             files,
-            theme: self.matches
+            theme: self
+                .matches
                 .value_of("theme")
                 .map(String::from)
                 .or_else(|| env::var("BAT_THEME").ok())

--- a/src/style.rs
+++ b/src/style.rs
@@ -78,4 +78,8 @@ impl OutputComponents {
     pub fn numbers(&self) -> bool {
         self.0.contains(&OutputComponent::Numbers)
     }
+
+    pub fn plain(&self) -> bool {
+        self.0.is_empty()
+    }
 }


### PR DESCRIPTION
This is a fix for #289. As I explained in my reply [here](https://github.com/sharkdp/bat/issues/289#issuecomment-419501495), it didn't make sense to leave wrapping on with `--plain`, since the terminal is more than capable of wrapping the lines itself when the sidebar isn't used.
