### PR TITLE
Add -X to less wrapper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ script as a wrapper, for example:
 ```bash
 #!/bin/bash
 
-less --tabs 4 -RF "$@"
+less --tabs 4 -RXF "$@"
 ```
 
 ## Using `bat` on Windows


### PR DESCRIPTION
Without `-X` the less wrapper script can fail (seen on Ubuntu 18.04).

Fixes #312.