### PR TITLE
controller.rs: Lock `Stdout` before running.

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -22,7 +22,14 @@ impl<'b> Controller<'b> {
 
     pub fn run(&self) -> Result<bool> {
         let mut output_type = OutputType::from_mode(self.config.paging_mode);
-        let writer = output_type.handle()?;
+        let mut lock;
+        let writer: &mut Write = match output_type {
+            OutputType::Stdout(ref mut stdout) => {
+                lock = stdout.lock();
+                &mut lock
+            }
+            _ => output_type.handle()?,
+        };
         let mut no_errors: bool = true;
 
         for filename in &self.config.files {


### PR DESCRIPTION
`bat` locks `Stdout` when listing themes or languages, but not in regular operation. My understanding is that there’s no real downside to locking it if the output is all coming from one place, and it seems like a good idea when dealing with large files. This PR is an inelegant attempt to implement locking in the normal case too.