### PR TITLE
Fixes #328 - adds info for light backgrounds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,7 @@ bat --list-themes | fzf --preview="bat --theme={} --color=always /path/to/file"
 
 `bat` looks good on a dark background by default. However, if your terminal uses a
 light background, some themes will work better for you. For example, the `GitHub`
-theme is made for light backgrounds. To set your theme permanently, put
-`export BAT_THEME="GitHub"` in your shell's startup file (like `.bashrc`). If you'd
-like to see the other available themes, run `bat --list-themes`. You can also make
-your own theme by following the
+theme is made for light backgrounds. You can also make your own theme by following the
 ['Adding new themes' section below](https://github.com/sharkdp/bat#adding-new-themes).
 
 ### Output style

--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ the following command (you need [`fzf`](https://github.com/junegunn/fzf) for thi
 bat --list-themes | fzf --preview="bat --theme={} --color=always /path/to/file"
 ```
 
+`bat` looks good on a dark background by default. However, if your terminal uses a
+light background, some themes will work better for you. For example, the `GitHub`
+theme is made for light backgrounds. To set your theme permanently, put
+`export BAT_THEME="GitHub"` in your shell's startup file (like `.bashrc`). If you'd
+like to see the other available themes, run `bat --list-themes`. You can also make
+your own theme by following the
+['Adding new themes' section below](https://github.com/sharkdp/bat#adding-new-themes).
+
 ### Output style
 
 You can use the `--style` option to control the appearance of `bat`s output.


### PR DESCRIPTION
Should fix #328 - describes steps for using a theme compatible with light terminal backgrounds. 