### PR TITLE
Implement syntax mapping

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -12,6 +12,7 @@ use dirs::PROJECT_DIRS;
 
 use errors::*;
 use inputfile::{InputFile, InputFileReader};
+use syntax_mapping::SyntaxMapping;
 
 pub const BAT_THEME_DEFAULT: &str = "Monokai Extended";
 
@@ -167,6 +168,7 @@ impl HighlightingAssets {
         language: Option<&str>,
         filename: InputFile,
         reader: &mut InputFileReader,
+        mapping: &SyntaxMapping,
     ) -> &SyntaxReference {
         let syntax = match (language, filename) {
             (Some(language), _) => self.syntax_set.find_syntax_by_token(language),
@@ -174,10 +176,14 @@ impl HighlightingAssets {
                 let path = Path::new(filename);
                 let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
                 let extension = path.extension().and_then(|x| x.to_str()).unwrap_or("");
+
+                let file_name = mapping.replace(file_name);
+                let extension = mapping.replace(extension);
+
                 let ext_syntax = self
                     .syntax_set
-                    .find_syntax_by_extension(file_name)
-                    .or_else(|| self.syntax_set.find_syntax_by_extension(extension));
+                    .find_syntax_by_extension(&file_name)
+                    .or_else(|| self.syntax_set.find_syntax_by_extension(&extension));
                 let line_syntax = if ext_syntax.is_none() {
                     String::from_utf8(reader.first_line.clone())
                         .ok()

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -60,6 +60,22 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long_help("Display a list of supported languages for syntax highlighting."),
         )
         .arg(
+            Arg::with_name("map-syntax")
+                .short("m")
+                .long("map-syntax")
+                .multiple(true)
+                .takes_value(true)
+                .value_name("from:to")
+                .help("Map a file extension or name to an existing syntax")
+                .long_help(
+                    "Map a file extension or file name to an existing syntax. For example, \
+                     to highlight *.conf files with the INI syntax, use '-m conf:ini'. \
+                     To highlight files named '.myignore' with the Git Ignore syntax, use \
+                     '-m .myignore:gitignore'.",
+                )
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("theme")
                 .long("theme")
                 .overrides_with("theme")

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod output;
 mod preprocessor;
 mod printer;
 mod style;
+mod syntax_mapping;
 mod terminal;
 mod util;
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -142,7 +142,7 @@ impl<'a> InteractivePrinter<'a> {
             };
 
             // Determine the type of syntax for highlighting
-            let syntax = assets.get_syntax(config.language, file, reader);
+            let syntax = assets.get_syntax(config.language, file, reader, &config.syntax_mapping);
             Some(HighlightLines::new(syntax, theme))
         };
 

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -1,0 +1,35 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct SyntaxMapping(HashMap<String, String>);
+
+impl SyntaxMapping {
+    pub fn new() -> SyntaxMapping {
+        SyntaxMapping(HashMap::new())
+    }
+
+    pub fn insert(&mut self, from: String, to: String) -> Option<String> {
+        self.0.insert(from, to)
+    }
+
+    pub fn replace<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let mut out = Cow::from(input);
+        if let Some(value) = self.0.get(input) {
+            out = Cow::from(value.clone())
+        }
+        out
+    }
+}
+
+#[test]
+fn basic() {
+    let mut map = SyntaxMapping::new();
+    map.insert("Cargo.lock".into(), "toml".into());
+    map.insert(".ignore".into(), ".gitignore".into());
+
+    assert_eq!("toml", map.replace("Cargo.lock"));
+    assert_eq!("other.lock", map.replace("other.lock"));
+
+    assert_eq!(".gitignore", map.replace(".ignore"));
+}


### PR DESCRIPTION
This adds a `-m`/`--map-syntax` option that allows users to (re)map
certain file extensions or file names to an existing syntax.

For example:
```
bat --map-syntax .config:json ...
```

The option can be use multiple times. Note that you can easily make
these mappings permanent by using `bat`s new configuration file.

closes #169