### PR TITLE
Allow offset values in `--terminal-width`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -196,7 +196,23 @@ impl App {
             term_width: self
                 .matches
                 .value_of("terminal-width")
-                .and_then(|w| w.parse().ok())
+                .and_then(|w| {
+                    if w.starts_with("+") || w.starts_with("-") {
+                        // Treat argument as a delta to the current terminal width
+                        w.parse().ok().map(|delta: i16| {
+                            let old_width: u16 = Term::stdout().size().1;
+                            let new_width: i32 = old_width as i32 + delta as i32;
+
+                            if new_width <= 0 {
+                                old_width as usize
+                            } else {
+                                new_width as usize
+                            }
+                        })
+                    } else {
+                        w.parse().ok()
+                    }
+                })
                 .unwrap_or(Term::stdout().size().1 as usize),
             loop_through: !(self.interactive_output
                 || self.matches.value_of("color") == Some("always")

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -287,8 +287,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long("terminal-width")
                 .takes_value(true)
                 .value_name("width")
-                .hidden(true)
-                .help("Set the width of the terminal"),
+                .hidden_short_help(true)
+                .help(
+                    "Explicitly set the width of the terminal instead of determining it \
+                     automatically. If prefixed with '+' or '-', the value will be treated \
+                     as an offset to the actual terminal width.",
+                ),
         )
         .arg(
             Arg::with_name("no-config")


### PR DESCRIPTION
Allows the `width` argument to `--terminal-width` to be an offset
instead of an absolute number. Examples:

    --terminal-width=80   # Set output width to 80 characters
    --terminal-width=-2   # Set output width to actual_width - 2

closes #376