### PR TITLE
Avoid endless bat executions with PAGER="bat"

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -37,11 +37,15 @@ impl OutputType {
             .chain_err(|| "Could not parse (BAT_)PAGER environment variable.")?;
 
         match pagerflags.split_first() {
-            Some((initial_pager, args)) => {
-                let pager_name = match initial_pager.as_ref() {
-                    "bat" => "less",
-                    _ => initial_pager,
-                };
+            Some((initial_pager, mut args)) => {
+                let pager_name;
+                if initial_pager == "bat" {
+                    pager_name = "less";
+                    args = &[];
+                }
+                else {
+                    pager_name = initial_pager;
+                }
 
                 let pager_path = PathBuf::from(pager_name);
                 let is_less = pager_path.file_stem() == Some(&OsString::from("less"));

--- a/src/output.rs
+++ b/src/output.rs
@@ -27,10 +27,15 @@ impl OutputType {
     /// Try to launch the pager. Fall back to stdout in case of errors.
     fn try_pager(quit_if_one_screen: bool, pager_from_config: Option<&str>) -> Result<Self> {
         let pager_from_env = env::var("BAT_PAGER").or_else(|_| env::var("PAGER"));
-        let pager = pager_from_config
+
+        let mut pager = pager_from_config
             .map(|p| p.to_string())
             .or(pager_from_env.ok())
             .unwrap_or(String::from("less"));
+
+        if pager == "bat" {
+            pager = String::from("less");
+        }
 
         let pagerflags = shell_words::split(&pager)
             .chain_err(|| "Could not parse (BAT_)PAGER environment variable.")?;

--- a/src/output.rs
+++ b/src/output.rs
@@ -42,8 +42,7 @@ impl OutputType {
                 if initial_pager == "bat" {
                     pager_name = "less";
                     args = &[];
-                }
-                else {
+                } else {
                     pager_name = initial_pager;
                 }
 


### PR DESCRIPTION
This PR fix issue #383.

I had to make `pager` a mutable variable, please let me know if there's a better way.