### PR TITLE
Feature: Highlight non-printable characters

### DIFF
--- a/assets/syntaxes/show-nonprintable.sublime-syntax
+++ b/assets/syntaxes/show-nonprintable.sublime-syntax
@@ -11,6 +11,8 @@ contexts:
       scope: support.function.show-nonprintable.space
     - match: "├─*┤"
       scope: constant.character.escape.show-nonprintable.tab
+    - match: "↹"
+      scope: constant.character.escape.show-nonprintable.tab
     - match: "␤"
       scope: keyword.operator.show-nonprintable.newline
     - match: "␍"

--- a/assets/syntaxes/show-nonprintable.sublime-syntax
+++ b/assets/syntaxes/show-nonprintable.sublime-syntax
@@ -1,0 +1,25 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Highlight non-printables
+file_extensions:
+    - show-nonprintable
+scope: whitespace
+contexts:
+  main:
+    - match: "•"
+      scope: support.function.show-nonprintable.space
+    - match: "├─*┤"
+      scope: constant.character.escape.show-nonprintable.tab
+    - match: "␤"
+      scope: keyword.operator.show-nonprintable.newline
+    - match: "␍"
+      scope: string.show-nonprintable.carriage-return
+    - match: "␀"
+      scope: entity.other.attribute-name.show-nonprintable.null
+    - match: "␇"
+      scope: entity.other.attribute-name.show-nonprintable.bell
+    - match: "␛"
+      scope: entity.other.attribute-name.show-nonprintable.escape
+    - match: "␈"
+      scope: entity.other.attribute-name.show-nonprintable.backspace

--- a/assets/syntaxes/show-nonprintable.sublime-syntax
+++ b/assets/syntaxes/show-nonprintable.sublime-syntax
@@ -13,8 +13,8 @@ contexts:
       scope: constant.character.escape.show-nonprintable.tab
     - match: "↹"
       scope: constant.character.escape.show-nonprintable.tab
-    - match: "␤"
-      scope: keyword.operator.show-nonprintable.newline
+    - match: "␊"
+      scope: keyword.operator.show-nonprintable.line-feed
     - match: "␍"
       scope: string.show-nonprintable.carriage-return
     - match: "␀"

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,6 +37,9 @@ pub struct Config<'a> {
     /// The explicitly configured language, if any
     pub language: Option<&'a str>,
 
+    /// Whether or not to show/replace non-printable characters like space, tab and newline.
+    pub show_nonprintable: bool,
+
     /// The character width of the terminal
     pub term_width: usize,
 
@@ -169,7 +172,14 @@ impl App {
 
         Ok(Config {
             true_color: is_truecolor_terminal(),
-            language: self.matches.value_of("language"),
+            language: self.matches.value_of("language").or_else(|| {
+                if self.matches.is_present("show-all") {
+                    Some("show-nonprintable")
+                } else {
+                    None
+                }
+            }),
+            show_nonprintable: self.matches.is_present("show-all"),
             output_wrap: if !self.interactive_output {
                 // We don't have the tty width when piping to another program.
                 // There's no point in wrapping when this is the case.

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -159,6 +159,18 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("show-all")
+                .long("show-all")
+                .alias("show-nonprintable")
+                .short("A")
+                .conflicts_with("language")
+                .help("Show non-printable characters (space, tab, newline, ..).")
+                .long_help(
+                    "Show non-printable characters like space, tab or newline. \
+                     Use '--tabs' to control the width of the tab-placeholders.",
+                ),
+        )
+        .arg(
             Arg::with_name("line-range")
                 .long("line-range")
                 .multiple(true)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,5 +1,4 @@
 use std::io::{self, Write};
-use std::mem::swap;
 
 use app::Config;
 use assets::HighlightingAssets;
@@ -7,7 +6,6 @@ use errors::*;
 use inputfile::{InputFile, InputFileReader};
 use line_range::{LineRanges, RangeCheckResult};
 use output::OutputType;
-use preprocessor::replace_nonprintable;
 use printer::{InteractivePrinter, Printer, SimplePrinter};
 
 pub struct Controller<'a> {
@@ -66,14 +64,7 @@ impl<'b> Controller<'b> {
         input_file: InputFile<'a>,
     ) -> Result<()> {
         printer.print_header(writer, input_file)?;
-        self.print_file_ranges(
-            printer,
-            writer,
-            reader,
-            &self.config.line_ranges,
-            self.config.show_nonprintable,
-            self.config.tab_width,
-        )?;
+        self.print_file_ranges(printer, writer, reader, &self.config.line_ranges)?;
         printer.print_footer(writer)?;
 
         Ok(())
@@ -85,20 +76,11 @@ impl<'b> Controller<'b> {
         writer: &mut Write,
         mut reader: InputFileReader,
         line_ranges: &LineRanges,
-        show_nonprintable: bool,
-        tab_width: usize,
     ) -> Result<()> {
         let mut line_buffer = Vec::new();
-        let mut line_buffer_processed = Vec::new();
-
         let mut line_number: usize = 1;
 
         while reader.read_line(&mut line_buffer)? {
-            if show_nonprintable {
-                replace_nonprintable(&mut line_buffer, &mut line_buffer_processed, tab_width);
-                swap(&mut line_buffer, &mut line_buffer_processed);
-            }
-
             match line_ranges.check(line_number) {
                 RangeCheckResult::OutsideRange => {
                     // Call the printer in case we need to call the syntax highlighter

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -52,10 +52,10 @@ pub fn replace_nonprintable(input: &mut Vec<u8>, output: &mut Vec<u8>, tab_width
                     output.extend_from_slice("┤".as_bytes());
                 }
             }
-            // new line
-            b'\n' => output.extend_from_slice("␤".as_bytes()),
+            // line feed
+            0x0A => output.extend_from_slice("␊".as_bytes()),
             // carriage return
-            b'\r' => output.extend_from_slice("␍".as_bytes()),
+            0x0D => output.extend_from_slice("␍".as_bytes()),
             // null
             0x00 => output.extend_from_slice("␀".as_bytes()),
             // bell

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -36,13 +36,7 @@ pub fn expand_tabs(line: &str, width: usize, cursor: &mut usize) -> String {
 pub fn replace_nonprintable(input: &mut Vec<u8>, output: &mut Vec<u8>, tab_width: usize) {
     output.clear();
 
-    let tab_width = if tab_width == 0 {
-        4
-    } else if tab_width == 1 {
-        2
-    } else {
-        tab_width
-    };
+    let tab_width = if tab_width == 0 { 4 } else { tab_width };
 
     for chr in input {
         match *chr {
@@ -50,9 +44,13 @@ pub fn replace_nonprintable(input: &mut Vec<u8>, output: &mut Vec<u8>, tab_width
             b' ' => output.extend_from_slice("•".as_bytes()),
             // tab
             b'\t' => {
-                output.extend_from_slice("├".as_bytes());
-                output.extend_from_slice("─".repeat(tab_width - 2).as_bytes());
-                output.extend_from_slice("┤".as_bytes());
+                if tab_width == 1 {
+                    output.extend_from_slice("↹".as_bytes());
+                } else {
+                    output.extend_from_slice("├".as_bytes());
+                    output.extend_from_slice("─".repeat(tab_width - 2).as_bytes());
+                    output.extend_from_slice("┤".as_bytes());
+                }
             }
             // new line
             b'\n' => output.extend_from_slice("␤".as_bytes()),

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -33,39 +33,41 @@ pub fn expand_tabs(line: &str, width: usize, cursor: &mut usize) -> String {
     buffer
 }
 
-pub fn replace_nonprintable(input: &mut Vec<u8>, output: &mut Vec<u8>, tab_width: usize) {
-    output.clear();
+pub fn replace_nonprintable(input: &str, tab_width: usize) -> String {
+    let mut output = String::new();
 
     let tab_width = if tab_width == 0 { 4 } else { tab_width };
 
-    for chr in input {
-        match *chr {
+    for chr in input.chars() {
+        match chr {
             // space
-            b' ' => output.extend_from_slice("•".as_bytes()),
+            ' ' => output.push('•'),
             // tab
-            b'\t' => {
+            '\t' => {
                 if tab_width == 1 {
-                    output.extend_from_slice("↹".as_bytes());
+                    output.push('↹');
                 } else {
-                    output.extend_from_slice("├".as_bytes());
-                    output.extend_from_slice("─".repeat(tab_width - 2).as_bytes());
-                    output.extend_from_slice("┤".as_bytes());
+                    output.push('├');
+                    output.push_str(&"─".repeat(tab_width - 2));
+                    output.push('┤');
                 }
             }
             // line feed
-            0x0A => output.extend_from_slice("␊".as_bytes()),
+            '\x0A' => output.push('␊'),
             // carriage return
-            0x0D => output.extend_from_slice("␍".as_bytes()),
+            '\x0D' => output.push('␍'),
             // null
-            0x00 => output.extend_from_slice("␀".as_bytes()),
+            '\x00' => output.push('␀'),
             // bell
-            0x07 => output.extend_from_slice("␇".as_bytes()),
+            '\x07' => output.push('␇'),
             // backspace
-            0x08 => output.extend_from_slice("␈".as_bytes()),
+            '\x08' => output.push('␈'),
             // escape
-            0x1B => output.extend_from_slice("␛".as_bytes()),
+            '\x1B' => output.push('␛'),
             // anything else
-            _ => output.push(*chr),
+            _ => output.push(chr),
         }
     }
+
+    output
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -22,7 +22,7 @@ use diff::get_git_diff;
 use diff::LineChanges;
 use errors::*;
 use inputfile::{InputFile, InputFileReader};
-use preprocessor::expand;
+use preprocessor::expand_tabs;
 use style::OutputWrap;
 use terminal::{as_terminal_escaped, to_ansi_color};
 
@@ -177,7 +177,7 @@ impl<'a> InteractivePrinter<'a> {
 
     fn preprocess(&self, text: &str, cursor: &mut usize) -> String {
         if self.config.tab_width > 0 {
-            expand(text, self.config.tab_width, cursor)
+            expand_tabs(text, self.config.tab_width, cursor)
         } else {
             text.to_string()
         }


### PR DESCRIPTION
Adds a new `-A`/`--show-all` option (in analogy to GNU Linux `cat`s option) that
highlights non-printable characters like space, tab or newline.

This works in two steps:
- **Preprocessing**: replace space by `•`, replace tab by `├──┤`, replace
newline by `␤`, etc.
- **Highlighting**: Use a newly written Sublime syntax to highlight
these special symbols.

#### without `--show-all`
![image](https://user-images.githubusercontent.com/4209276/47851023-a58d2d00-ddd7-11e8-90c9-cf68aa72b41d.png)

#### with `--show-all`
![image](https://user-images.githubusercontent.com/4209276/47851032-ad4cd180-ddd7-11e8-9bee-d4eab8e95a8a.png)


Remarks:
- This feature is not technically a drop-in replacement for GNU `cat`s `--show-all` but it has the same purpose.
- This replaces normal syntax highlighting. You can not use syntax highlighting with `--show-all`.
- Tab-width can be controlled via `--tabs N`
- This closes #381 (see also: #228)