### PR TITLE
Highlight XDG desktop entry as .ini file

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -29,4 +29,4 @@ themes (`bat cache --clear`).
 The following files have been manually modified after converting from a `.tmLanguage` file:
 
 * `Dart.sublime-syntax` => removed `#regex.dart` include.
-* `INI.sublime-syntax` => added `.hgrc` and `hgrc` file types.
+* `INI.sublime-syntax` => added `.hgrc`, `hgrc`, and `desktop` file types.

--- a/assets/syntaxes/INI.sublime-syntax
+++ b/assets/syntaxes/INI.sublime-syntax
@@ -12,6 +12,7 @@ file_extensions:
   - lng
   - cfg
   - CFG
+  - desktop
   - url
   - URL
   - .editorconfig


### PR DESCRIPTION
Reference: https://standards.freedesktop.org/desktop-entry-spec/latest/