### PR TITLE
Enhance SyntaxMapping with impl Trait

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -168,7 +168,7 @@ impl App {
                     return Err("Invalid syntax mapping. The format of the -m/--map-syntax option is 'from:to'.".into());
                 }
 
-                syntax_mapping.insert(parts[0].into(), parts[1].into());
+                syntax_mapping.insert(parts[0], parts[1]);
             }
         }
 

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -9,24 +9,24 @@ impl SyntaxMapping {
         SyntaxMapping(HashMap::new())
     }
 
-    pub fn insert(&mut self, from: String, to: String) -> Option<String> {
-        self.0.insert(from, to)
+    pub fn insert(&mut self, from: impl Into<String>, to: impl Into<String>) -> Option<String> {
+        self.0.insert(from.into(), to.into())
     }
 
-    pub fn replace<'a>(&self, input: &'a str) -> Cow<'a, str> {
-        let mut out = Cow::from(input);
-        if let Some(value) = self.0.get(input) {
-            out = Cow::from(value.clone())
+    pub fn replace<'a>(&self, input: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
+        let input = input.into();
+        match self.0.get(input.as_ref()) {
+            Some(s) => Cow::from(s.clone()),
+            None => input,
         }
-        out
     }
 }
 
 #[test]
 fn basic() {
     let mut map = SyntaxMapping::new();
-    map.insert("Cargo.lock".into(), "toml".into());
-    map.insert(".ignore".into(), ".gitignore".into());
+    map.insert("Cargo.lock", "toml");
+    map.insert(".ignore", ".gitignore");
 
     assert_eq!("toml", map.replace("Cargo.lock"));
     assert_eq!("other.lock", map.replace("other.lock"));


### PR DESCRIPTION
Just a tiny PR which uses impl Trait so that one does not have to specify `into` in the arguments :smile: