### PR TITLE
Report filename in error message

### DIFF
--- a/src/inputfile.rs
+++ b/src/inputfile.rs
@@ -59,7 +59,10 @@ impl<'a> InputFile<'a> {
         match self {
             InputFile::StdIn => Ok(InputFileReader::new(stdin.lock())),
             InputFile::Ordinary(filename) => {
-                let file = File::open(filename)?;
+                let file = match File::open(filename) {
+                    Ok(f) => f,
+                    Err(e) => return Err(format!("{}: {}", filename, e).into()),
+                };
 
                 if file.metadata()?.is_dir() {
                     return Err(format!("'{}' is a directory.", filename).into());


### PR DESCRIPTION
This PR fixes issue #441.
( And also adds filename to any other Errors from opening a file. )

I wonder if there is more concise way to do this, so please let me know if there is.
Thanks in advance!