### PR TITLE
Line highlight

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -80,8 +80,8 @@ pub struct Config<'a> {
     /// Whether or not to use ANSI italics
     pub use_italic_text: bool,
 
-    /// A line to highlight
-    pub highlight_line: Option<usize>,
+    /// Lines to highlight
+    pub highlight_lines: Vec<usize>,
 }
 
 fn is_truecolor_terminal() -> bool {
@@ -268,10 +268,11 @@ impl App {
                 Some("always") => true,
                 _ => false,
             },
-            highlight_line: self
+            highlight_lines: self
                 .matches
-                .value_of("highlight-line")
-                .and_then(|w| w.parse().ok()),
+                .values_of("highlight-line")
+                .and_then(|ws| ws.map(|w| w.parse().ok()).collect())
+                .unwrap_or_default(),
         })
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,7 +77,11 @@ pub struct Config<'a> {
     /// Command to start the pager
     pub pager: Option<&'a str>,
 
+    /// Whether or not to use ANSI italics
     pub use_italic_text: bool,
+
+    /// A line to highlight
+    pub highlight_line: Option<usize>,
 }
 
 fn is_truecolor_terminal() -> bool {
@@ -264,6 +268,10 @@ impl App {
                 Some("always") => true,
                 _ => false,
             },
+            highlight_line: self
+                .matches
+                .value_of("highlight-line")
+                .and_then(|w| w.parse().ok()),
         })
     }
 

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -189,6 +189,17 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
+            Arg::with_name("highlight-line")
+                .long("highlight-line")
+                .overrides_with("highlight-line")
+                .takes_value(true)
+                .value_name("N")
+                .help("Highlight a line.")
+                .long_help(
+                    "Highlight the Nth line. The background color is changed to create contrast.",
+                ),
+        )
+        .arg(
             Arg::with_name("color")
                 .long("color")
                 .overrides_with("color")

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -194,6 +194,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long("highlight-line")
                 .short("H")
                 .takes_value(true)
+                .number_of_values(1)
                 .multiple(true)
                 .value_name("N")
                 .help("Highlight the given line.")

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -175,6 +175,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("line-range")
                 .long("line-range")
+                .short("r")
                 .multiple(true)
                 .takes_value(true)
                 .number_of_values(1)
@@ -191,6 +192,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("highlight-line")
                 .long("highlight-line")
+                .short("H")
                 .takes_value(true)
                 .multiple(true)
                 .value_name("N")

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -191,12 +191,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("highlight-line")
                 .long("highlight-line")
-                .overrides_with("highlight-line")
                 .takes_value(true)
+                .multiple(true)
                 .value_name("N")
-                .help("Highlight a line.")
+                .help("Highlight the given line.")
                 .long_help(
-                    "Highlight the Nth line. The background color is changed to create contrast.",
+                    "Highlight the N-th line with a different background color",
                 ),
         )
         .arg(

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -7,6 +7,7 @@ use ansi_term::Style;
 use console::AnsiCodeIterator;
 
 use syntect::easy::HighlightLines;
+use syntect::highlighting::Color;
 use syntect::highlighting::Theme;
 use syntect::parsing::SyntaxSet;
 
@@ -79,6 +80,7 @@ pub struct InteractivePrinter<'a> {
     pub line_changes: Option<LineChanges>,
     highlighter: Option<HighlightLines<'a>>,
     syntax_set: &'a SyntaxSet,
+    background_highlight: Option<Color>,
 }
 
 impl<'a> InteractivePrinter<'a> {
@@ -89,6 +91,8 @@ impl<'a> InteractivePrinter<'a> {
         reader: &mut InputFileReader,
     ) -> Self {
         let theme = assets.get_theme(&config.theme);
+
+        let background_highlight = theme.settings.line_highlight;
 
         let colors = if config.colored_output {
             Colors::colored(theme, config.true_color)
@@ -156,6 +160,7 @@ impl<'a> InteractivePrinter<'a> {
             line_changes,
             highlighter,
             syntax_set: &assets.syntax_set,
+            background_highlight,
         }
     }
 
@@ -301,6 +306,12 @@ impl<'a> Printer for InteractivePrinter<'a> {
             }
         }
 
+        // Line highlighting
+        let background = self.config.highlight_line
+            .filter(|line| *line == line_number)
+            .map(|_| self.background_highlight)
+            .unwrap();
+
         // Line contents.
         if self.config.output_wrap == OutputWrap::None {
             let true_color = self.config.true_color;
@@ -313,7 +324,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
                 write!(
                     handle,
                     "{}",
-                    as_terminal_escaped(style, text_trimmed, true_color, colored_output, italics,)
+                    as_terminal_escaped(style, text_trimmed, true_color, colored_output, italics, background)
                 )?;
                 write!(handle, "{}", &text[text_trimmed.len()..])?;
             }
@@ -370,7 +381,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
                                             ),
                                             self.config.true_color,
                                             self.config.colored_output,
-                                            self.config.use_italic_text
+                                            self.config.use_italic_text,
+                                            background
                                         )
                                     )?;
                                     break;
@@ -410,7 +422,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
                                         ),
                                         self.config.true_color,
                                         self.config.colored_output,
-                                        self.config.use_italic_text
+                                        self.config.use_italic_text,
+                                        background
                                     ),
                                     panel_wrap.clone().unwrap()
                                 )?;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -19,8 +19,9 @@ pub fn as_terminal_escaped(
     true_color: bool,
     colored: bool,
     italics: bool,
+    background_color: Option<highlighting::Color>,
 ) -> String {
-    let style = if !colored {
+    let mut style = if !colored {
         Style::default()
     } else {
         let color = to_ansi_color(style.foreground, true_color);
@@ -36,5 +37,6 @@ pub fn as_terminal_escaped(
         }
     };
 
+    style.background = background_color.map(|c| to_ansi_color(c, true_color));
     style.paint(text).to_string()
 }


### PR DESCRIPTION
Continuing the work of #346 (/CC @tskinn)

* Allow for multiple occurrences of `--highlight-line <N>`
* Highlight the full line
* Proper handling for overlong lines

![image](https://user-images.githubusercontent.com/4209276/50058813-1e74f800-017e-11e9-94f0-1c13fef87590.png)

![image](https://user-images.githubusercontent.com/4209276/50058845-9b07d680-017e-11e9-8e91-ff0e633c8f45.png)


closes #175 