### PR TITLE
Add syntax highlighting support for '*.mjs' files

### DIFF
--- a/assets/syntaxes/Javascript (Babel).sublime-syntax
+++ b/assets/syntaxes/Javascript (Babel).sublime-syntax
@@ -4,6 +4,7 @@
 name: JavaScript (Babel)
 file_extensions:
   - js
+  - mjs
   - jsx
   - babel
   - es6


### PR DESCRIPTION
This change allows files with a '.mjs' extension to be syntax-highlighted as Javascript files.  
Node.js uses this extension for ECMAScript modules (which Node.js parses slightly differently from standard Javascript scripts but is still completely valid Javascript with no syntax changes).  