### PR TITLE
Refactor cache subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ and theme. To add new syntax definitions, do the following.
 Create a folder with syntax definition files:
 
 ```bash
-mkdir -p "$(bat cache --config-dir)/syntaxes"
-cd "$(bat cache --config-dir)/syntaxes"
+mkdir -p "$(bat --config-dir)/syntaxes"
+cd "$(bat --config-dir)/syntaxes"
 
 # Put new '.sublime-syntax' language definition files
 # in this folder (or its subdirectories), for example:
@@ -298,8 +298,8 @@ This works very similar to how we add new syntax definitions.
 
 First, create a folder with the new syntax highlighting themes:
 ```bash
-mkdir -p "$(bat cache --config-dir)/themes"
-cd "$(bat cache --config-dir)/themes"
+mkdir -p "$(bat --config-dir)/themes"
+cd "$(bat --config-dir)/themes"
 
 # Download a theme in '.tmTheme' format, for example:
 git clone https://github.com/greggb/sublime-snazzy

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ git clone https://github.com/tellnobody1/sublime-purescript-syntax
 Now use the following command to parse these files into a binary cache:
 
 ```bash
-bat cache --init
+bat cache --build
 ```
 
 Finally, use `bat --list-languages` to check if the new languages are available.
@@ -305,7 +305,7 @@ cd "$(bat cache --config-dir)/themes"
 git clone https://github.com/greggb/sublime-snazzy
 
 # Update the binary cache
-bat cache --init
+bat cache --build
 ```
 
 Finally, use `bat --list-themes` to check if the new themes are available.

--- a/assets/README.md
+++ b/assets/README.md
@@ -13,7 +13,7 @@ In order to add new syntaxes to `bat`, follow these steps:
    Sublime Text and convert it to a `.sublime-syntax` file via *Tools* -> *Developer* ->
    *New Syntax from XXX.tmLanguage...*. Save the new file in the `assets/syntaxes` folder.
 
-3. Run the `create.sh` script. It calls `bat cache --init` to parse all available
+3. Run the `create.sh` script. It calls `bat cache --build` to parse all available
    `.sublime-syntax` files and serialize them to a `syntaxes.bin` file (in this folder).
 
 4. Re-compile `bat`. At compilation time, the `syntaxes.bin` file will be stored inside the

--- a/assets/create.sh
+++ b/assets/create.sh
@@ -11,6 +11,6 @@ JAVADOC_FILE="${ASSET_DIR}/syntaxes/Packages/Java/JavaDoc.sublime-syntax"
 JAVADOC_PATCH="${ASSET_DIR}/JavaDoc.sublime-syntax.patch"
 patch "$JAVADOC_FILE" "$JAVADOC_PATCH"
 
-bat cache --init --blank --source="$ASSET_DIR" --target="$ASSET_DIR"
+bat cache --build --blank --source="$ASSET_DIR" --target="$ASSET_DIR"
 
 patch -R "$JAVADOC_FILE" "$JAVADOC_PATCH"

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -263,8 +263,8 @@ bat --list-themes | fzf --preview="bat --theme={} --color=always /path/to/file"
 構文定義ファイルを入れておくためのフォルダを作る:
 
 ```bash
-mkdir -p "$(bat cache --config-dir)/syntaxes"
-cd "$(bat cache --config-dir)/syntaxes"
+mkdir -p "$(bat --config-dir)/syntaxes"
+cd "$(bat --config-dir)/syntaxes"
 
 # Put new '.sublime-syntax' language definition files
 # in this folder (or its subdirectories), for example:
@@ -290,8 +290,8 @@ bat cache --clear
 
 まず、新しいシンタックスハイライトのテーマのフォルダを作ります:
 ```bash
-mkdir -p "$(bat cache --config-dir)/themes"
-cd "$(bat cache --config-dir)/themes"
+mkdir -p "$(bat --config-dir)/themes"
+cd "$(bat --config-dir)/themes"
 
 # Download a theme in '.tmTheme' format, for example:
 git clone https://github.com/greggb/sublime-snazzy

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -274,7 +274,7 @@ git clone https://github.com/tellnobody1/sublime-purescript-syntax
 次のコマンドを使用して、これらのファイルをバイナリキャッシュに解析します:
 
 ```bash
-bat cache --init
+bat cache --build
 ```
 
 最後に `bat --list-languages` と入力すると新しい言語が利用可能かどうかチェックします。
@@ -297,7 +297,7 @@ cd "$(bat cache --config-dir)/themes"
 git clone https://github.com/greggb/sublime-snazzy
 
 # Update the binary cache
-bat cache --init
+bat cache --build
 ```
 
 最後に、 `bat --list-themes` で新しいテーマが利用可能がチェックします

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -349,6 +349,18 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .hidden(true)
                 .help("Show path to the configuration file."),
         )
+        .arg(
+            Arg::with_name("config-dir")
+                .long("config-dir")
+                .hidden(true)
+                .help("Show bat's configuration directory."),
+        )
+        .arg(
+            Arg::with_name("cache-dir")
+                .long("cache-dir")
+                .hidden(true)
+                .help("Show bat's cache directory."),
+        )
         .subcommand(
             SubCommand::with_name("cache")
                 .about("Modify the syntax-definition and theme cache")
@@ -368,20 +380,9 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                         .short("c")
                         .help("Remove the cached syntax definitions and themes."),
                 )
-                .arg(
-                    Arg::with_name("config-dir")
-                        .long("config-dir")
-                        .short("d")
-                        .help("Show bat's configuration directory."),
-                )
-                .arg(
-                    Arg::with_name("cache-dir")
-                        .long("cache-dir")
-                        .help("Show bat's cache directory."),
-                )
                 .group(
                     ArgGroup::with_name("cache-actions")
-                        .args(&["build", "clear", "config-dir", "cache-dir"])
+                        .args(&["build", "clear"])
                         .required(arg_group_required),
                 )
                 .arg(

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -353,13 +353,13 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             SubCommand::with_name("cache")
                 .about("Modify the syntax-definition and theme cache")
                 .arg(
-                    Arg::with_name("init")
-                        .long("init")
-                        .short("i")
-                        .help("Initialize the syntax/theme cache.")
+                    Arg::with_name("build")
+                        .long("build")
+                        .short("b")
+                        .help("Initialize (or update) the syntax/theme cache.")
                         .long_help(
-                            "Initialize the syntax/theme cache by loading from the \
-                             source directory (default: the configuration directory).",
+                            "Initialize (or update) the syntax/theme cache by loading from \
+                             the source directory (default: the configuration directory).",
                         ),
                 )
                 .arg(
@@ -381,13 +381,13 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 )
                 .group(
                     ArgGroup::with_name("cache-actions")
-                        .args(&["init", "clear", "config-dir", "cache-dir"])
+                        .args(&["build", "clear", "config-dir", "cache-dir"])
                         .required(arg_group_required),
                 )
                 .arg(
                     Arg::with_name("source")
                         .long("source")
-                        .requires("init")
+                        .requires("build")
                         .takes_value(true)
                         .value_name("dir")
                         .help("Use a different directory to load syntaxes and themes from."),
@@ -395,14 +395,14 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .arg(
                     Arg::with_name("target")
                         .long("target")
-                        .requires("init")
+                        .requires("build")
                         .takes_value(true)
                         .value_name("dir")
                         .help(
                             "Use a different directory to store the cached syntax and theme set.",
                         ),
                 )
-                .arg(Arg::with_name("blank").long("blank").requires("init").help(
+                .arg(Arg::with_name("blank").long("blank").requires("build").help(
                     "Create completely new syntax and theme sets \
                      (instead of appending to the default sets).",
                 )),

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,10 +96,6 @@ fn run_cache_subcommand(matches: &clap::ArgMatches) -> Result<()> {
         assets.save(target_dir)?;
     } else if matches.is_present("clear") {
         clear_assets();
-    } else if matches.is_present("config-dir") {
-        writeln!(io::stdout(), "{}", config_dir())?;
-    } else if matches.is_present("cache-dir") {
-        writeln!(io::stdout(), "{}", cache_dir())?;
     }
 
     Ok(())
@@ -234,6 +230,12 @@ fn run() -> Result<bool> {
             } else if app.matches.is_present("config-file") {
                 println!("{}", config_file().to_string_lossy());
 
+                Ok(true)
+            } else if app.matches.is_present("config-dir") {
+                writeln!(io::stdout(), "{}", config_dir())?;
+                Ok(true)
+            } else if app.matches.is_present("cache-dir") {
+                writeln!(io::stdout(), "{}", cache_dir())?;
                 Ok(true)
             } else {
                 run_controller(&config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ mod errors {
 use errors::*;
 
 fn run_cache_subcommand(matches: &clap::ArgMatches) -> Result<()> {
-    if matches.is_present("init") {
+    if matches.is_present("build") {
         let source_dir = matches.value_of("source").map(Path::new);
         let target_dir = matches.value_of("target").map(Path::new);
 


### PR DESCRIPTION
* Rename `bat cache --init` to `bat cache --build`
* Move `--config-dir` and `--cache-dir` from 'bat cache' to 'bat' and hide them from the help text.

@lavifb FYI