### PR TITLE
Only print contents of file if not empty.

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -43,7 +43,6 @@ impl<'b> Controller<'b> {
 
         for input_file in &self.config.files {
             match input_file.get_reader(&stdin) {
-                Err(Error(ErrorKind::ImmediateEOF, _)) => (),
                 Err(error) => {
                     handle_error(&error);
                     no_errors = false;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -80,7 +80,9 @@ impl<'b> Controller<'b> {
         input_file: InputFile<'a>,
     ) -> Result<()> {
         printer.print_header(writer, input_file)?;
-        self.print_file_ranges(printer, writer, reader, &self.config.line_ranges)?;
+        if !reader.first_line.is_empty() {
+            self.print_file_ranges(printer, writer, reader, &self.config.line_ranges)?;
+        }
         printer.print_footer(writer)?;
 
         Ok(())

--- a/src/inputfile.rs
+++ b/src/inputfile.rs
@@ -14,11 +14,9 @@ pub struct InputFileReader<'a> {
 }
 
 impl<'a> InputFileReader<'a> {
-    fn new<R: BufRead + 'a>(mut reader: R) -> Result<InputFileReader<'a>> {
+    fn new<R: BufRead + 'a>(mut reader: R) -> InputFileReader<'a> {
         let mut first_line = vec![];
-        if reader.read_until(b'\n', &mut first_line)? == 0 {
-            return Err(ErrorKind::ImmediateEOF.into());
-        }
+        reader.read_until(b'\n', &mut first_line).ok();
 
         let content_type = content_inspector::inspect(&first_line[..]);
 
@@ -26,11 +24,11 @@ impl<'a> InputFileReader<'a> {
             reader.read_until(0x00, &mut first_line).ok();
         }
 
-        Ok(InputFileReader {
+        InputFileReader {
             inner: Box::new(reader),
             first_line,
             content_type,
-        })
+        }
     }
 
     pub fn read_line(&mut self, buf: &mut Vec<u8>) -> io::Result<bool> {
@@ -59,7 +57,7 @@ pub enum InputFile<'a> {
 impl<'a> InputFile<'a> {
     pub fn get_reader(&self, stdin: &'a io::Stdin) -> Result<InputFileReader> {
         match self {
-            InputFile::StdIn => InputFileReader::new(stdin.lock()),
+            InputFile::StdIn => Ok(InputFileReader::new(stdin.lock())),
             InputFile::Ordinary(filename) => {
                 let file = File::open(filename).map_err(|e| format!("'{}': {}", filename, e))?;
 
@@ -67,9 +65,9 @@ impl<'a> InputFile<'a> {
                     return Err(format!("'{}' is a directory.", filename).into());
                 }
 
-                InputFileReader::new(BufReader::new(file))
+                Ok(InputFileReader::new(BufReader::new(file)))
             }
-            InputFile::ThemePreviewFile => InputFileReader::new(THEME_PREVIEW_FILE),
+            InputFile::ThemePreviewFile => Ok(InputFileReader::new(THEME_PREVIEW_FILE)),
         }
     }
 }
@@ -77,7 +75,7 @@ impl<'a> InputFile<'a> {
 #[test]
 fn basic() {
     let content = b"#!/bin/bash\necho hello";
-    let mut reader = InputFileReader::new(&content[..]).unwrap();
+    let mut reader = InputFileReader::new(&content[..]);
 
     assert_eq!(b"#!/bin/bash\n", &reader.first_line[..]);
 
@@ -106,7 +104,7 @@ fn basic() {
 #[test]
 fn utf16le() {
     let content = b"\xFF\xFE\x73\x00\x0A\x00\x64\x00";
-    let mut reader = InputFileReader::new(&content[..]).unwrap();
+    let mut reader = InputFileReader::new(&content[..]);
 
     assert_eq!(b"\xFF\xFE\x73\x00\x0A\x00", &reader.first_line[..]);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,6 @@ mod errors {
             SyntectError(::syntect::LoadingError);
             ParseIntError(::std::num::ParseIntError);
         }
-        errors {
-            ImmediateEOF
-        }
     }
 
     pub fn handle_error(error: &Error) {


### PR DESCRIPTION
This avoids waiting for a second EOF from stdin, and preserves header and footer for empty stdin and files. This is an alternative to #492 (reverted) as a solution to #477.