### PR TITLE
Updated manual to include -H, --highlight-line <N>

### DIFF
--- a/doc/bat.1
+++ b/doc/bat.1
@@ -70,6 +70,10 @@ prints lines 1 to 40
 prints lines 40 to the end of the file
 .RE
 .HP
+\fB\-H\fR, \fB\-\-highlight\-line\fR <N>...
+.IP
+Highlight the N-th line with a different background color
+.HP
 \fB\-\-color\fR <when>
 .IP
 Specify when to use colored output. The automatic mode only enables colors if an


### PR DESCRIPTION
The `--highlight-line` option is missing from the manual. 
Issue: https://github.com/sharkdp/bat/issues/546

I have not checked if more options are missing but this is still a improvement over previous manual.