### PR TITLE
Add completions for `--language` when using the fish shell.

### DIFF
--- a/assets/completions/bat.fish
+++ b/assets/completions/bat.fish
@@ -24,7 +24,7 @@ function __bat_autocomplete_languages --description "A helper function used by "
 				sub(/^ +/, "", ext); # Trim leading whitespace.
 				sub(/ +$/, "", ext); # Trim trailing whitespace.
 
-				if (ext != "") {
+				if ((ext != "") && (ext !~ /[A-Z].*/)) {
 					print ext"\t"lang
 				}
 			}

--- a/assets/completions/bat.fish
+++ b/assets/completions/bat.fish
@@ -1,6 +1,38 @@
 # Fish Shell Completions
-
 # Place or symlink to $XDG_CONFIG_HOME/fish/completions/bat.fish ($XDG_CONFIG_HOME is usually set to ~/.config)
+
+# Helper function:
+function __bat_autocomplete_languages --description "A helper function used by "(status filename)
+	bat --list-languages | awk '
+		NR == 1 {
+			dc = 0;
+			while (substr($0, dc, 2) != "  ") dc++;
+			while (substr($0, dc, 1) == " ")  dc++;
+		}
+		
+		{
+			langField = substr($0, 0, dc - 2);
+			if (langField !~ /^ *$/) {
+				lang = langField;
+				sub(/ +$/, "", lang);
+			}
+
+			split(substr($0, dc), exts, ",");
+			for (i in exts) {
+				ext = exts[i]
+
+				sub(/^ +/, "", ext); # Trim leading whitespace.
+				sub(/ +$/, "", ext); # Trim trailing whitespace.
+
+				if (ext != "") {
+					print ext"\t"lang
+				}
+			}
+		}
+	' | sort
+end
+
+# Completions:
 
 complete -c bat -l color -xka "auto never always" -d "Specify when to use colored output (default: auto)" -n "not __fish_seen_subcommand_from cache"
 
@@ -16,9 +48,7 @@ complete -c bat -s H -l highlight-line -x -d "<N> Highlight the N-th line with a
 
 complete -c bat -l italic-text -xka "always never" -d "Specify when to use ANSI sequences for italic text (default: never)" -n "not __fish_seen_subcommand_from cache"
 
-# TODO: add parameter completion for available languages using option:  -xka "(bat --list-languages | cat)"
-# but replace 'cat' with some sed/awk like command that only outputs lines of valid options for this flag
-complete -c bat -s l -l language -d "Set the language for syntax highlighting" -n "not __fish_seen_subcommand_from cache"
+complete -c bat -s l -l language -d "Set the language for syntax highlighting" -n "not __fish_seen_subcommand_from cache" -xa "(__bat_autocomplete_languages)" 
 
 complete -c bat -s r -l line-range -x -d "<N:M> Only print the specified range of lines for each file" -n "not __fish_seen_subcommand_from cache"
 

--- a/assets/completions/bat.fish
+++ b/assets/completions/bat.fish
@@ -3,28 +3,14 @@
 
 # Helper function:
 function __bat_autocomplete_languages --description "A helper function used by "(status filename)
-	bat --list-languages | awk '
-		NR == 1 {
-			dc = 0;
-			while (substr($0, dc, 2) != "  ") dc++;
-			while (substr($0, dc, 1) == " ")  dc++;
-		}
-		
+	bat --list-languages | awk -F':' '
 		{
-			langField = substr($0, 0, dc - 2);
-			if (langField !~ /^ *$/) {
-				lang = langField;
-				sub(/ +$/, "", lang);
-			}
+			lang=$1
+			split($2, exts, ",")
 
-			split(substr($0, dc), exts, ",");
 			for (i in exts) {
-				ext = exts[i]
-
-				sub(/^ +/, "", ext); # Trim leading whitespace.
-				sub(/ +$/, "", ext); # Trim trailing whitespace.
-
-				if ((ext != "") && (ext !~ /[A-Z].*/)) {
+				ext=exts[i]
+				if (ext !~ /[A-Z].*/ && ext !~ /^\..*rc$/) {
 					print ext"\t"lang
 				}
 			}

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,48 +108,54 @@ pub fn list_languages(config: &Config) -> Result<()> {
         .collect::<Vec<_>>();
     languages.sort_by_key(|lang| lang.name.to_uppercase());
 
-    let longest = languages
-        .iter()
-        .map(|syntax| syntax.name.len())
-        .max()
-        .unwrap_or(32); // Fallback width if they have no language definitions.
-
-    let comma_separator = ", ";
-    let separator = " ";
-    // Line-wrapping for the possible file extension overflow.
-    let desired_width = config.term_width - longest - separator.len();
-
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
 
-    let style = if config.colored_output {
-        Green.normal()
-    } else {
-        Style::default()
-    };
-
-    for lang in languages {
-        write!(stdout, "{:width$}{}", lang.name, separator, width = longest)?;
-
-        // Number of characters on this line so far, wrap before `desired_width`
-        let mut num_chars = 0;
-
-        let mut extension = lang.file_extensions.iter().peekable();
-        while let Some(word) = extension.next() {
-            // If we can't fit this word in, then create a line break and align it in.
-            let new_chars = word.len() + comma_separator.len();
-            if num_chars + new_chars >= desired_width {
-                num_chars = 0;
-                write!(stdout, "\n{:width$}{}", "", separator, width = longest)?;
-            }
-
-            num_chars += new_chars;
-            write!(stdout, "{}", style.paint(&word[..]))?;
-            if extension.peek().is_some() {
-                write!(stdout, "{}", comma_separator)?;
-            }
+    if config.loop_through {
+        for lang in languages {
+            write!(stdout, "{}:{}\n", lang.name, lang.file_extensions.join(","));
         }
-        writeln!(stdout)?;
+    } else {
+        let longest = languages
+            .iter()
+            .map(|syntax| syntax.name.len())
+            .max()
+            .unwrap_or(32); // Fallback width if they have no language definitions.
+
+        let comma_separator = ", ";
+        let separator = " ";
+        // Line-wrapping for the possible file extension overflow.
+        let desired_width = config.term_width - longest - separator.len();
+
+        let style = if config.colored_output {
+            Green.normal()
+        } else {
+            Style::default()
+        };
+
+        for lang in languages {
+            write!(stdout, "{:width$}{}", lang.name, separator, width = longest)?;
+
+            // Number of characters on this line so far, wrap before `desired_width`
+            let mut num_chars = 0;
+
+            let mut extension = lang.file_extensions.iter().peekable();
+            while let Some(word) = extension.next() {
+                // If we can't fit this word in, then create a line break and align it in.
+                let new_chars = word.len() + comma_separator.len();
+                if num_chars + new_chars >= desired_width {
+                    num_chars = 0;
+                    write!(stdout, "\n{:width$}{}", "", separator, width = longest)?;
+                }
+
+                num_chars += new_chars;
+                write!(stdout, "{}", style.paint(&word[..]))?;
+                if extension.peek().is_some() {
+                    write!(stdout, "{}", comma_separator)?;
+                }
+            }
+            writeln!(stdout)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This a pull request to solve the TODO at line 19 in the fish shell completions.

https://github.com/sharkdp/bat/blob/e7c5561df736d42734c39712c52abc19ec9aa8d5/assets/completions/bat.fish#L19-L20


The basic principle of the solution is the same as what I described in #553, and it has the same caveats, but this is a better implementation that only uses `awk`.

## Features:

![image](https://user-images.githubusercontent.com/32112321/57062440-f68db900-6c74-11e9-9b1c-386c40224fb2.png)

- Lists all languages from `bat --list-languages`.
- Displays the full name of the language.
- Filters out languages that are probably config files (starts with an upper case letter).

## Caveats:

In order to properly parse the output of `bat --list-languages`, two conditions need to be met with the first language that appears in the list.

1. There is at least two spaces after the language name (i.e. is not the longest name).
2. The language name does not contain two consecutive spaces in it.
