### PR TITLE
Prevent `--terminal-width=0` and invalid forms of `--terminal-width`.

### DIFF
--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -331,8 +331,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .hidden_short_help(true)
                 .validator(
                     |t| {
-                        let sign = t.chars().next().unwrap();
-                        let num = if (sign == '+') || (sign == '-') {
+                        let is_offset = t.starts_with('+') || t.starts_with('-');
+                        let num = if is_offset {
                             t.chars().skip(1).collect()
                         } else {
                             t
@@ -340,7 +340,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
 
                         num.parse::<u32>()
                             .map_err(|_e| "must be an offset or number")
-                            .and_then(|v| if v == 0 && sign != '+' && sign != '-' {
+                            .and_then(|v| if v == 0 && !is_offset {
                                 Err("terminal width cannot be zero".into())
                             } else {
                                 Ok(())

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -332,13 +332,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .validator(
                     |t| {
                         let is_offset = t.starts_with('+') || t.starts_with('-');
-                        let num = if is_offset {
-                            t.chars().skip(1).collect()
-                        } else {
-                            t
-                        };
-
-                        num.parse::<u32>()
+                        t.parse::<i32>()
                             .map_err(|_e| "must be an offset or number")
                             .and_then(|v| if v == 0 && !is_offset {
                                 Err("terminal width cannot be zero".into())

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -329,6 +329,24 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .takes_value(true)
                 .value_name("width")
                 .hidden_short_help(true)
+                .validator(
+                    |t| {
+                        let sign = t.chars().next().unwrap();
+                        let num = if (sign == '+') || (sign == '-') {
+                            t.chars().skip(1).collect()
+                        } else {
+                            t
+                        };
+
+                        num.parse::<u32>()
+                            .map_err(|_e| "must be an offset or number")
+                            .and_then(|v| if v == 0 && sign != '+' && sign != '-' {
+                                Err("terminal width cannot be zero".into())
+                            } else {
+                                Ok(())
+                            })
+                            .map_err(|e| e.to_string())
+                    })
                 .help(
                     "Explicitly set the width of the terminal instead of determining it \
                      automatically. If prefixed with '+' or '-', the value will be treated \


### PR DESCRIPTION
My proposed solution to #535, which involves validating `--terminal-width` to report an error if somebody provides a width of zero.

## Why this approach, and not having it disable wrapping?
User convenience is definitely something to consider, but in this instance I believe having `--terminal-width=0` being analogous to `--wrap=never` would be more of a quirky behaviour than a quality-of-life feature.

1. Having such a feature would dilute the meaning of `--terminal-width`.
2. Using `--terminal-width=0` as `--wrap=never` isn't very clear or intuitive.
3. Using `--terminal-width=0` as a way to disable wrapping results in a conflict when you don't want wrapping, but do want to specify a specific terminal width.
4. It's more explicit (and less characters) to type `--wrap=never`.