### PR TITLE
Add `-pp` for plain styling and no pager

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -143,7 +143,10 @@ impl App {
             Some("always") => PagingMode::Always,
             Some("never") => PagingMode::Never,
             Some("auto") | _ => {
-                if files.contains(&InputFile::StdIn) {
+                if self.matches.occurrences_of("plain") > 1 {
+                    // If we have -pp as an option when in auto mode, the pager should be disabled.
+                    PagingMode::Never
+                } else if files.contains(&InputFile::StdIn) {
                     // If we are reading from stdin, only enable paging if we write to an
                     // interactive terminal and if we do not *read* from an interactive
                     // terminal.

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -143,10 +143,11 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .overrides_with("number")
                 .short("p")
                 .long("plain")
+                .multiple(true)
                 .help("Show plain style (alias for '--style=plain').")
                 .long_help(
-                    "Only show plain style, no decorations. This is an alias for \
-                     '--style=plain'",
+                    "Only show plain style, no decorations. When '-p' is used, this is an alias for \
+                     '--style=plain'. When '-pp' is used, this is an alias for '--style=plain --pager=never'.",
                 ),
         )
         .arg(


### PR DESCRIPTION
A potential solution to #552 without breaking backwards compatibility or `cat` compatibility.

This introduces the `-pp` option, which does the following:

1. `--style=plain` (carried over from `-p`)
2. `--paging=never`
