### PR TITLE
Improved logic when encountering ANSI/VT100 in character wrap mode

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -367,7 +367,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
                     match chunk {
                         // ANSI escape passthrough.
                         (text, true) => {
-                            let is_ansi_csi = text.chars().skip(1).nth(0).map_or(false, |c|c == '[');
+                            let is_ansi_csi =
+                                text.chars().skip(1).nth(0).map_or(false, |c| c == '[');
 
                             if is_ansi_csi && text.chars().last().map_or(false, |c| c == 'm') {
                                 // It's an ANSI SGR sequence.

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -367,10 +367,9 @@ impl<'a> Printer for InteractivePrinter<'a> {
                     match chunk {
                         // ANSI escape passthrough.
                         (text, true) => {
-                            let is_ansi_csi =
-                                text.chars().skip(1).nth(0).map_or(false, |c| c == '[');
+                            let is_ansi_csi = text.starts_with("\x1B[");
 
-                            if is_ansi_csi && text.chars().last().map_or(false, |c| c == 'm') {
+                            if is_ansi_csi && text.ends_with('m') {
                                 // It's an ANSI SGR sequence.
                                 // We should be mostly safe to just append these together.
                                 ansi_prefix.push_str(text);


### PR DESCRIPTION
Fixes #551.

It turns out that I made a couple mistakes when initially implementing escape passthrough. This improved implementation is still making a few assumptions about the escape sequences (CSI/SGR sequences are safe to concatenate and use as a prefix, and all others are safe to pass through), but it should be a bit more reliable when fed any other sequences.
