### PR TITLE
Add new style component to separate multiple '--line-range's

### DIFF
--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -110,7 +110,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .validator(|val| {
                     let mut invalid_vals = val.split(',').filter(|style| {
                         !&[
-                            "auto", "full", "plain", "changes", "header", "grid", "numbers",
+                            "auto", "full", "plain", "changes", "header", "grid", "numbers", "snip"
                         ]
                         .contains(style)
                     });
@@ -123,7 +123,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*auto*, full, plain, changes, header, grid, numbers).",
+                     (*auto*, full, plain, changes, header, grid, numbers, snip).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -133,7 +133,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      pre-defined style ('full'). To set a default style, add the \
                      '--style=\"..\"' option to the configuration file or export the \
                      BAT_STYLE environment variable (e.g.: export BAT_STYLE=\"..\"). \
-                     Possible values: *auto*, full, plain, changes, header, grid, numbers.",
+                     Possible values: *auto*, full, plain, changes, header, grid, numbers, snip.",
                 ),
         )
         .arg(

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -61,7 +61,7 @@ impl Printer for SimplePrinter {
         Ok(())
     }
 
-    fn print_snip(&mut self, _handle: &mut Write) -> Result<()> {
+    fn print_snip(&mut self, _handle: &mut dyn Write) -> Result<()> {
         Ok(())
     }
 
@@ -296,7 +296,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
         }
     }
 
-    fn print_snip(&mut self, handle: &mut Write) -> Result<()> {
+    fn print_snip(&mut self, handle: &mut dyn Write) -> Result<()> {
         let panel = self.create_fake_panel(" ...");
         let panel_count = panel.chars().count();
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -303,12 +303,11 @@ impl<'a> Printer for InteractivePrinter<'a> {
         let title = "8<";
         let title_count = title.chars().count();
 
-        let snip_left =
-            "─ ".repeat((self.config.term_width - panel_count - (title_count / 2)) / 4);
+        let snip_left = "─ ".repeat((self.config.term_width - panel_count - (title_count / 2)) / 4);
         let snip_left_count = snip_left.chars().count(); // Can't use .len() with Unicode.
 
-        let snip_right = " ─"
-            .repeat((self.config.term_width - panel_count - snip_left_count - title_count) / 2);
+        let snip_right =
+            " ─".repeat((self.config.term_width - panel_count - snip_left_count - title_count) / 2);
 
         write!(
             handle,

--- a/src/style.rs
+++ b/src/style.rs
@@ -10,6 +10,7 @@ pub enum OutputComponent {
     Grid,
     Header,
     Numbers,
+    Snip,
     Full,
     Plain,
 }
@@ -34,11 +35,13 @@ impl OutputComponent {
             OutputComponent::Grid => &[OutputComponent::Grid],
             OutputComponent::Header => &[OutputComponent::Header],
             OutputComponent::Numbers => &[OutputComponent::Numbers],
+            OutputComponent::Snip => &[OutputComponent::Snip],
             OutputComponent::Full => &[
                 OutputComponent::Changes,
                 OutputComponent::Grid,
                 OutputComponent::Header,
                 OutputComponent::Numbers,
+                OutputComponent::Snip,
             ],
             OutputComponent::Plain => &[],
         }
@@ -55,6 +58,7 @@ impl FromStr for OutputComponent {
             "grid" => Ok(OutputComponent::Grid),
             "header" => Ok(OutputComponent::Header),
             "numbers" => Ok(OutputComponent::Numbers),
+            "snip" => Ok(OutputComponent::Snip),
             "full" => Ok(OutputComponent::Full),
             "plain" => Ok(OutputComponent::Plain),
             _ => Err(format!("Unknown style '{}'", s).into()),
@@ -80,6 +84,10 @@ impl OutputComponents {
 
     pub fn numbers(&self) -> bool {
         self.0.contains(&OutputComponent::Numbers)
+    }
+
+    pub fn snip(&self) -> bool {
+        self.0.contains(&OutputComponent::Snip)
     }
 
     pub fn plain(&self) -> bool {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -463,3 +463,22 @@ fn can_print_file_named_cache() {
 fn does_not_print_unwanted_file_named_cache() {
     bat_with_config().arg("cach").assert().failure();
 }
+
+#[test]
+fn snip() {
+    bat()
+        .arg("multiline.txt")
+        .arg("--style=numbers,snip")
+        .arg("--decorations=always")
+        .arg("--line-range=1:2")
+        .arg("--line-range=4:")
+        .assert()
+        .success()
+        .stdout(
+            "   1 line 1
+   2 line 2
+ ...─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ 8< ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+   4 line 4
+",
+        );
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -472,6 +472,7 @@ fn snip() {
         .arg("--decorations=always")
         .arg("--line-range=1:2")
         .arg("--line-range=4:")
+        .arg("--terminal-width=80")
         .assert()
         .success()
         .stdout(


### PR DESCRIPTION
My solution to my own issue, #569.

## Reasoning

When specifying multiple line ranges with `--line-range=... --line-range=...`, the printed lines tend to blend together and make it difficult to determine the scope of each range.

Example which makes parts of three functions look as though they're a single function:

![image](https://user-images.githubusercontent.com/32112321/58362966-60ebe080-7e52-11e9-867f-af6ed7996288.png)


## Implementation

The "snip" separator is implemented as another style component much like header and grid. I chose to include it in the `full` style by default, since doing otherwise would no longer make it "full".

When not using the `full` style, it can be added as `snip`.


## Preview

![image](https://user-images.githubusercontent.com/32112321/58362974-84169000-7e52-11e9-8407-eab118fbb279.png)

