### PR TITLE
Enforce the creation of the full cache dir path

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -117,7 +117,7 @@ impl HighlightingAssets {
 
     pub fn save(&self, dir: Option<&Path>) -> Result<()> {
         let target_dir = dir.unwrap_or_else(|| PROJECT_DIRS.cache_dir());
-        let _ = fs::create_dir(target_dir);
+        let _ = fs::create_dir_all(target_dir);
         let theme_set_path = target_dir.join("themes.bin");
         let syntax_set_path = target_dir.join("syntaxes.bin");
 


### PR DESCRIPTION
Fixes #576

I'm assuming no tests are needed, since I've found none re this.