### PR TITLE
Improve SimplePrinter throughput

### DIFF
--- a/src/inputfile.rs
+++ b/src/inputfile.rs
@@ -49,6 +49,24 @@ impl<'a> InputFileReader<'a> {
             Ok(true)
         }
     }
+
+    pub fn read_chunk(& mut self, buf: &mut Vec<u8>) -> io::Result<bool> {
+        assert_eq!(buf.len(), 0);
+        if self.first_line.is_empty() {
+            let filled_buf = self.inner.fill_buf()?;
+            let filled_buf_len = filled_buf.len();
+            if filled_buf_len > 0 {
+                buf.extend(filled_buf);
+                self.inner.consume(filled_buf_len);
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        } else {
+            buf.append(&mut self.first_line);
+            Ok(true)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
bat performance is very slow for `loop_through` compared to native `cat`, which means I have to switch to `/bin/cat` for some tasks.

The reason it's so slow is that bat always reads line-by-line, even if the input is printed as-is (SimplePrinter). This PR addresses that problem by changing abstractions: Reading should be part of the Printers so we can use fast reading for `loop_through` workloads.

Note that the code probably has some weird stuff in it since I'n not very familiar with Rust and its ecosystem; also I didn't change the tests