### PR TITLE
use buffered output by default and implement -u option for unbuffered output

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -82,6 +82,9 @@ pub struct Config<'a> {
 
     /// Lines to highlight
     pub highlight_lines: Vec<usize>,
+
+    /// Use unbuffered output
+    pub unbuffered: bool,
 }
 
 fn is_truecolor_terminal() -> bool {
@@ -274,6 +277,7 @@ impl App {
                 .values_of("highlight-line")
                 .and_then(|ws| ws.map(|w| w.parse().ok()).collect())
                 .unwrap_or_default(),
+            unbuffered: self.matches.is_present("unbuffered"),
         })
     }
 

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -321,9 +321,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long("unbuffered")
                 .hidden_short_help(true)
                 .long_help(
-                    "This option exists for POSIX-compliance reasons ('u' is for \
-                     'unbuffered'). The output is always unbuffered - this option \
-                     is simply ignored.",
+                    "Use unbuffered output.",
                 ),
         )
         .arg(

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
 use crate::app::{Config, PagingMode};
@@ -36,7 +36,13 @@ impl<'b> Controller<'b> {
         }
 
         let mut output_type = OutputType::from_mode(paging_mode, self.config.pager)?;
-        let writer = output_type.handle()?;
+        let mut buf_writer;
+        let writer: &mut Write = if self.config.unbuffered {
+            output_type.handle()?
+        } else {
+            buf_writer = BufWriter::new(output_type.handle()?);
+            &mut buf_writer
+        };
         let mut no_errors: bool = true;
 
         let stdin = io::stdin();


### PR DESCRIPTION
This commit speeds up output by using buffering.

Currently, the downside is that output data is also buffered if there is no input data pending.