### PR TITLE
Re-enable aarch64 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,12 @@ matrix:
         - TARGET=arm-unknown-linux-gnueabihf
         - CC_arm_unknown_linux_gnueabihf=/usr/bin/arm-linux-gnueabihf-gcc-4.8
         - CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc-4.8
-
-    ##### Temporarily disabled due to a build failure of onig_sys
-    # - os: linux
-    #   rust: stable
-    #   env:
-    #     - TARGET=aarch64-unknown-linux-gnu
-    #     - CC_aarch64-unknown-linux-gnu=/usr/bin/aarch64-linux-gnu-gcc-4.8
-    #     - CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc-4.8
+    - os: linux
+      rust: stable
+      env:
+        - TARGET=aarch64-unknown-linux-gnu
+        - CC_aarch64-unknown-linux-gnu=/usr/bin/aarch64-linux-gnu-gcc-4.8
+        - CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc-4.8
 
     # Minimum Rust supported channel.
     - os: linux

--- a/ci/before_install.bash
+++ b/ci/before_install.bash
@@ -33,5 +33,6 @@ if [[ $TARGET == aarch64-unknown-linux-gnu ]]; then
     sudo apt-get install -y \
         gcc-4.8-aarch64-linux-gnu \
         binutils-aarch64-linux-gnu \
-        gcc-aarch64-linux-gnu
+        gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross
 fi


### PR DESCRIPTION
This PR is a reminder to re-enable aarch64 builds. There is currently a problem with the cross-compilation of `onig_sys`.