### PR TITLE
Add GraphQL sublime syntax submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -141,3 +141,6 @@
 [submodule "assets/syntaxes/ssh-config"]
 	path = assets/syntaxes/ssh-config
 	url = https://github.com/robballou/sublimetext-sshconfig.git
+[submodule "assets/syntaxes/GraphQL"]
+	path = assets/syntaxes/GraphQL
+	url = https://github.com/dncrews/GraphQL-SublimeText3.git


### PR DESCRIPTION
Thanks for bat! This appeared to be the GraphQL sublime syntax project with the most traction and in my limited testing so far I have not seen any problems:

![image](https://user-images.githubusercontent.com/52205/62660843-1bed2b80-b924-11e9-85b3-fd400148436a.png)
