### PR TITLE
Display binary file content for bat -A

### DIFF
--- a/assets/syntaxes/show-nonprintable.sublime-syntax
+++ b/assets/syntaxes/show-nonprintable.sublime-syntax
@@ -25,3 +25,7 @@ contexts:
       scope: entity.other.attribute-name.show-nonprintable.escape
     - match: "␈"
       scope: entity.other.attribute-name.show-nonprintable.backspace
+    - match: "\\\\x[A-Z0-9][A-Z0-9]"
+      scope: comment.block.show-nonprintable.backspace
+    - match: "\\\\u\\{[a-z0-9]+\\}"
+      scope: comment.block.show-nonprintable.backspace

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -170,7 +170,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .help("Show non-printable characters (space, tab, newline, ..).")
                 .long_help(
                     "Show non-printable characters like space, tab or newline. \
-                     Use '--tabs' to control the width of the tab-placeholders.",
+                     Use '--tabs' to control the width of the tab-placeholders. \
+                     This option can also be used to print binary files.",
                 ),
         )
         .arg(

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -170,8 +170,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .help("Show non-printable characters (space, tab, newline, ..).")
                 .long_help(
                     "Show non-printable characters like space, tab or newline. \
-                     Use '--tabs' to control the width of the tab-placeholders. \
-                     This option can also be used to print binary files.",
+                     This option can also be used to print binary files. \
+                     Use '--tabs' to control the width of the tab-placeholders."
                 ),
         )
         .arg(

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -197,7 +197,7 @@ impl<'a> InteractivePrinter<'a> {
 impl<'a> Printer for InteractivePrinter<'a> {
     fn print_header(&mut self, handle: &mut dyn Write, file: InputFile) -> Result<()> {
         if !self.config.output_components.header() {
-            if Some(ContentType::BINARY) == self.content_type {
+            if Some(ContentType::BINARY) == self.content_type && !self.config.show_nonprintable {
                 let input = match file {
                     InputFile::Ordinary(filename) => format!("file '{}'", filename),
                     _ => "STDIN".into(),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,4 +1,3 @@
-use std::ascii;
 use std::io::Write;
 use std::vec::Vec;
 
@@ -207,7 +206,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
                 writeln!(
                     handle,
                     "{}: Binary content from {} will not be printed to the terminal \
-                     (but will be present if the output of 'bat' is piped).",
+                     (but will be present if the output of 'bat' is piped). You can use 'bat -A' \
+                     to show the binary file contents.",
                     Yellow.paint("[bat warning]"),
                     input
                 )?;
@@ -256,7 +256,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
         )?;
 
         if self.config.output_components.grid() {
-            if self.content_type.map_or(false, |c| c.is_text()) {
+            if self.content_type.map_or(false, |c| c.is_text()) || self.config.show_nonprintable {
                 self.print_horizontal_line(handle, '┼')?;
             } else {
                 self.print_horizontal_line(handle, '┴')?;
@@ -267,7 +267,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
     }
 
     fn print_footer(&mut self, handle: &mut dyn Write) -> Result<()> {
-        if self.config.output_components.grid() && self.content_type.map_or(false, |c| c.is_text())
+        if self.config.output_components.grid()
+            && (self.content_type.map_or(false, |c| c.is_text()) || self.config.show_nonprintable)
         {
             self.print_horizontal_line(handle, '┴')
         } else {
@@ -282,31 +283,22 @@ impl<'a> Printer for InteractivePrinter<'a> {
         line_number: usize,
         line_buffer: &[u8],
     ) -> Result<()> {
-        let mut line = match self.content_type {
-            None => {
-                return Ok(());
+        let line = if self.config.show_nonprintable {
+            replace_nonprintable(&line_buffer, self.config.tab_width)
+        } else {
+            match self.content_type {
+                Some(ContentType::BINARY) | None => {
+                    return Ok(());
+                }
+                Some(ContentType::UTF_16LE) => UTF_16LE
+                    .decode(&line_buffer, DecoderTrap::Replace)
+                    .map_err(|_| "Invalid UTF-16LE")?,
+                Some(ContentType::UTF_16BE) => UTF_16BE
+                    .decode(&line_buffer, DecoderTrap::Replace)
+                    .map_err(|_| "Invalid UTF-16BE")?,
+                _ => String::from_utf8_lossy(&line_buffer).to_string(),
             }
-            Some(ContentType::BINARY) => String::from_utf8(
-                line_buffer
-                    .as_ref()
-                    .iter()
-                    .map(|b| ascii::escape_default(*b))
-                    .flatten()
-                    .collect(),
-            )
-            .unwrap(),
-            Some(ContentType::UTF_16LE) => UTF_16LE
-                .decode(&line_buffer, DecoderTrap::Replace)
-                .map_err(|_| "Invalid UTF-16LE")?,
-            Some(ContentType::UTF_16BE) => UTF_16BE
-                .decode(&line_buffer, DecoderTrap::Replace)
-                .map_err(|_| "Invalid UTF-16BE")?,
-            _ => String::from_utf8_lossy(&line_buffer).to_string(),
         };
-
-        if self.config.show_nonprintable {
-            line = replace_nonprintable(&line, self.config.tab_width);
-        }
 
         let regions = {
             let highlighter = match self.highlighter {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,3 +1,4 @@
+use std::ascii;
 use std::io::Write;
 use std::vec::Vec;
 
@@ -134,7 +135,10 @@ impl<'a> InteractivePrinter<'a> {
 
         let mut line_changes = None;
 
-        let highlighter = if reader.content_type.map_or(false, |c| c.is_binary()) {
+        let highlighter = if reader
+            .content_type
+            .map_or(false, |c| c.is_binary() && !config.show_nonprintable)
+        {
             None
         } else {
             // Get the Git modifications
@@ -279,9 +283,18 @@ impl<'a> Printer for InteractivePrinter<'a> {
         line_buffer: &[u8],
     ) -> Result<()> {
         let mut line = match self.content_type {
-            Some(ContentType::BINARY) | None => {
+            None => {
                 return Ok(());
             }
+            Some(ContentType::BINARY) => String::from_utf8(
+                line_buffer
+                    .as_ref()
+                    .iter()
+                    .map(|b| ascii::escape_default(*b))
+                    .flatten()
+                    .collect(),
+            )
+            .unwrap(),
             Some(ContentType::UTF_16LE) => UTF_16LE
                 .decode(&line_buffer, DecoderTrap::Replace)
                 .map_err(|_| "Invalid UTF-16LE")?,


### PR DESCRIPTION
Closes #623. When the `-A` flag is supplied, attempts to print hex-escaped lines for binary files. The one caveat is it escapes non-ASCII characters, not just non-UTF-8.

From what I could tell printing the hex-escaped version of UTF-8 text would be a lot more involved, but if there's an option I missed here I'm happy to make changes