### PR TITLE
Add syntax highlighting for /etc/group and /etc/passwd

### DIFF
--- a/assets/syntaxes/Group.sublime-syntax
+++ b/assets/syntaxes/Group.sublime-syntax
@@ -1,0 +1,48 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: group
+file_extensions:
+  - group
+scope: source.group
+
+contexts:
+  main:
+    - comment: name
+      match: ^[^:]+
+      scope: keyword
+
+    - comment: password
+      match: ":"
+      push: password
+
+  password:
+    - comment: uid
+      match: ":"
+      set: gid
+
+    - comment: shadowpassword
+      match: "[^:]+"
+      scope: invalid
+
+  gid:
+    - comment: gid
+      match: ":"
+      set: users
+
+    - comment: number
+      match: "[0-9]+"
+      scope: constant.numeric
+
+  users:
+    - comment: newline
+      match: "\n"
+      pop: true
+
+    - comment: directory
+      match: "[^:\n]+"
+      scope: variable.parameter
+
+    - comment: separator
+      match: ","
+      scope: punctuation

--- a/assets/syntaxes/Passwd.sublime-syntax
+++ b/assets/syntaxes/Passwd.sublime-syntax
@@ -1,0 +1,71 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: passwd
+file_extensions:
+  - passwd
+scope: source.passwd
+
+contexts:
+  main:
+    - comment: name
+      match: ^[^:]+
+      scope: keyword
+
+    - comment: password
+      match: ":"
+      push: password
+
+  password:
+    - comment: uid
+      match: ":"
+      set: uid
+
+    - comment: shadowpassword
+      match: "[^:]+"
+      scope: invalid
+
+  uid:
+    - comment: gid
+      match: ":"
+      set: gid
+
+    - comment: number
+      match: "[0-9]+"
+      scope: constant.numeric
+
+  gid:
+    - comment: comment
+      match: ":"
+      set: comment
+
+    - comment: number
+      match: "[0-9]+"
+      scope: constant.language
+
+  comment:
+    - comment: directory
+      match: ":"
+      set: directory
+
+    - comment: comment
+      match: "[^:]+"
+      scope: entity.name
+
+  directory:
+    - comment: shell
+      match: ":"
+      set: shell
+
+    - comment: directory
+      match: "[^:]+"
+      scope: string.unquoted
+
+  shell:
+    - comment: newline
+      match: "\n"
+      pop: true
+
+    - comment: directory
+      match: "[^:\n]+"
+      scope: variable.parameter


### PR DESCRIPTION
These syntax files do not follow any good [scope naming](https://www.sublimetext.com/docs/3/scope_naming.html). I have just tried to make everything look distinct.
![image](https://user-images.githubusercontent.com/22955872/67423209-5c735180-f5c3-11e9-8fba-db4e29d9029d.png)
![image](https://user-images.githubusercontent.com/22955872/67423432-ce4b9b00-f5c3-11e9-84c9-e0d02b0f6ee4.png)