### PR TITLE
Add syntax highlighting for /etc/resolv.conf

### DIFF
--- a/assets/syntaxes/Resolv.sublime-syntax
+++ b/assets/syntaxes/Resolv.sublime-syntax
@@ -1,0 +1,21 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: resolv
+file_extensions:
+  - resolv.conf
+scope: source.resolv
+
+contexts:
+  main:
+    - scope: comment.line.number-sign
+      match: \#.*
+      comment: comment
+
+    - comment: configuration
+      match: "(nameserver|domain|search|sortlist|options)"
+      scope: keyword.control
+
+    - comment: options
+      match: "(debug|ndots|timeout|attempts|rotate|no-check-names|inet6|ip6-bytestring|ip6-dotint|no-ip6-dotint|edns0|single-request|single-request-reopen|no-tld-query|use-vc|no-reload)"
+      scope: entity.name


### PR DESCRIPTION
Added simple keyword highlighting for /etc/resolv.conf
![Screenshot_2019-10-25_18-45-23](https://user-images.githubusercontent.com/22955872/67574209-8a72a600-f729-11e9-8845-ee1eff413011.png)
