### PR TITLE
doc: Add Ubuntu/Debian bat package to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,13 @@ The [`prettybat`](https://github.com/eth-p/bat-extras/blob/master/doc/prettybat.
 ### On Ubuntu
 *... and other Debian-based Linux distributions.*
 
-Download the latest `.deb` package from the [release page](https://github.com/sharkdp/bat/releases)
+You can install [the Ubuntu `bat` package](https://packages.ubuntu.com/eoan/bat) or [the Debian `bat` package](https://packages.debian.org/sid/bat) since Ubuntu Eoan 19.10 or Debian unstable sid.
+
+```bash
+apt install bat
+```
+
+On older releases, download the latest `.deb` package from the [release page](https://github.com/sharkdp/bat/releases)
 and install it via:
 ```bash
 sudo dpkg -i bat_0.12.1_amd64.deb  # adapt version number and architecture

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can install [the Ubuntu `bat` package](https://packages.ubuntu.com/eoan/bat)
 apt install bat
 ```
 
-On older releases, download the latest `.deb` package from the [release page](https://github.com/sharkdp/bat/releases)
+If you want to run the latest release of bat or if you are on older versions of Ubuntu/Debian, download the latest `.deb` package from the [release page](https://github.com/sharkdp/bat/releases)
 and install it via:
 ```bash
 sudo dpkg -i bat_0.12.1_amd64.deb  # adapt version number and architecture


### PR DESCRIPTION
Documentation update to fix #323


To install:

```
# apt-get install bat -y -q && bat /etc/os-release  
Reading package lists...
Building dependency tree...
Reading state information...
bat is already the newest version (0.11.0-2).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
───────┬────────────────────────────────────────────────────
       │ File: /etc/os-release
───────┼────────────────────────────────────────────────────
   1   │ NAME="Ubuntu"
   2   │ VERSION="19.10 (Eoan Ermine)"
   3   │ ID=ubuntu
   4   │ ID_LIKE=debian
   5   │ PRETTY_NAME="Ubuntu 19.10"
   6   │ VERSION_ID="19.10"
   7   │ HOME_URL="https://www.ubuntu.com/"
   8   │ SUPPORT_URL="https://help.ubuntu.com/"
   9   │ BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
  10   │ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/te
       │ rms-and-policies/privacy-policy"
  11   │ VERSION_CODENAME=eoan
  12   │ UBUNTU_CODENAME=eoan
───────┴────────────────────────────────────────────────────
