### PR TITLE
Add delta to related projects

### DIFF
--- a/doc/alternatives.md
+++ b/doc/alternatives.md
@@ -20,5 +20,6 @@ If you think that some entries in this table are outdated or wrong, please open 
 request.
 
 Some other alternatives that are also related, but not yet included in the table:
+- [delta](https://github.com/dandavison/delta)
 - [lesspipe](https://github.com/wofr06/lesspipe)
 - [vimpager](https://github.com/rkitover/vimpager)


### PR DESCRIPTION
@sharkdp This PR adds my project  [delta](https://github.com/dandavison/delta) to the list of related projects.

Delta is related to bat in that it honors `BAT_PAGER`, and it uses exactly the same mechanism of including binary syntax and theme definition files (In fact, the delta README instructs users to use bat to create new versions of these files), and I plan to add support for reading custom syntax/theme files from `~/.cache/bat` (https://github.com/dandavison/delta/issues/19). Indeed, delta copies some of your code to do this! I plan to investigate whether I can avoid some of the copying by using bat's new library architecture.

Also, when I first heard of bat and that it had git integration, one thing I wondered was whether bat would syntax-highlight diffs sections according to their language. So it may also make sense to list delta as a related project on the basis that others may have the same thought. 