### PR TITLE
Split long long lines into slices.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-words 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ wild = "2.0"
 content_inspector = "0.2.4"
 encoding = "0.2"
 shell-words = "0.1.0"
+memchr = "2.2.1"
 
 [dependencies.git2]
 version = "0.10"

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -186,7 +186,7 @@ impl HighlightingAssets {
                     .find_syntax_by_extension(&file_name)
                     .or_else(|| self.syntax_set.find_syntax_by_extension(&extension));
                 let line_syntax = if ext_syntax.is_none() {
-                    String::from_utf8(reader.first_line.clone())
+                    String::from_utf8(reader.current_line.clone())
                         .ok()
                         .and_then(|l| self.syntax_set.find_syntax_by_first_line(&l))
                 } else {
@@ -195,7 +195,7 @@ impl HighlightingAssets {
 
                 ext_syntax.or(line_syntax)
             }
-            (None, InputFile::StdIn) => String::from_utf8(reader.first_line.clone())
+            (None, InputFile::StdIn) => String::from_utf8(reader.current_line.clone())
                 .ok()
                 .and_then(|l| self.syntax_set.find_syntax_by_first_line(&l)),
             (_, InputFile::ThemePreviewFile) => self.syntax_set.find_syntax_by_name("Rust"),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -135,7 +135,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                         t.parse::<i32>()
                             .map_err(|_e| "must be an offset or number")
                             .and_then(|v| if v == 0 && !is_offset {
-                                Err("terminal width cannot be zero".into())
+                                Err("terminal width cannot be zero")
                             } else {
                                 Ok(())
                             })

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -59,7 +59,7 @@ pub fn list_languages(config: &Config) -> Result<()> {
 
     if config.loop_through {
         for lang in languages {
-            write!(stdout, "{}:{}\n", lang.name, lang.file_extensions.join(","))?;
+            writeln!(stdout, "{}:{}", lang.name, lang.file_extensions.join(","))?;
         }
     } else {
         let longest = languages

--- a/src/inputfile.rs
+++ b/src/inputfile.rs
@@ -1,52 +1,159 @@
 use std::fs::File;
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, ErrorKind};
 
 use content_inspector::{self, ContentType};
 
 use crate::errors::*;
 
 const THEME_PREVIEW_FILE: &[u8] = include_bytes!("../assets/theme_preview.rs");
+const MAXIMUM_LINE_LENGTH: usize = 1024 * 1024;
+
+/// This function is like the read until present in the standard library
+/// but with a limit in the read buffer size
+fn read_until<R: BufRead + ?Sized>(
+    r: &mut R,
+    buf: &mut Vec<u8>,
+    pattern: u8,
+) -> io::Result<ReadStatus> {
+    let mut read = 0;
+    let limit = MAXIMUM_LINE_LENGTH;
+    loop {
+        let (done, used) = {
+            let available = match r.fill_buf() {
+                Ok(n) => n,
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            };
+            match memchr::memchr(pattern, available) {
+                Some(i) => {
+                    buf.extend_from_slice(&available[..=i]);
+                    (true, i + 1)
+                }
+                None => {
+                    buf.extend_from_slice(available);
+                    (false, available.len())
+                }
+            }
+        };
+        r.consume(used);
+        read += used;
+        if read == 0 {
+            return Ok(ReadStatus::Eof);
+        }
+        if done || used == 0 {
+            return Ok(ReadStatus::Ok);
+        }
+        if read > limit {
+            return Ok(ReadStatus::Overflow);
+        }
+    }
+}
 
 pub struct InputFileReader<'a> {
     inner: Box<dyn BufRead + 'a>,
-    pub first_line: Vec<u8>,
+    pub current_line: Vec<u8>,
     pub content_type: Option<ContentType>,
+    pub line_number: usize,
+    last_status: ReadStatus,
+    first_read: bool,
 }
 
-impl<'a> InputFileReader<'a> {
-    fn new<R: BufRead + 'a>(mut reader: R) -> InputFileReader<'a> {
-        let mut first_line = vec![];
-        reader.read_until(b'\n', &mut first_line).ok();
+#[derive(Debug, PartialEq, Copy, Clone)]
+enum ReadStatus {
+    Ok,
+    Eof,
+    Overflow,
+}
 
-        let content_type = if first_line.is_empty() {
-            None
-        } else {
-            Some(content_inspector::inspect(&first_line[..]))
-        };
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum ReadPosition {
+    FullLine,
+    Start,
+    Middle,
+    End,
+    Eof,
+}
 
-        if content_type == Some(ContentType::UTF_16LE) {
-            reader.read_until(0x00, &mut first_line).ok();
-        }
-
-        InputFileReader {
-            inner: Box::new(reader),
-            first_line,
-            content_type,
+impl ReadPosition {
+    pub fn is_begin_of_line(self) -> bool {
+        match self {
+            ReadPosition::FullLine | ReadPosition::Start => true,
+            _ => false,
         }
     }
 
-    pub fn read_line(&mut self, buf: &mut Vec<u8>) -> io::Result<bool> {
-        if self.first_line.is_empty() {
-            let res = self.inner.read_until(b'\n', buf).map(|size| size > 0)?;
+    pub fn is_end_of_line(self) -> bool {
+        match self {
+            ReadPosition::FullLine | ReadPosition::End => true,
+            _ => false,
+        }
+    }
+}
 
-            if self.content_type == Some(ContentType::UTF_16LE) {
-                self.inner.read_until(0x00, buf).ok();
+impl<'a> InputFileReader<'a> {
+    fn new<R: BufRead + 'a>(mut reader: R) -> Result<InputFileReader<'a>> {
+        let mut current_line = vec![];
+        let last_status = read_until(&mut reader, &mut current_line, b'\n')?;
+
+        let content_type = if current_line.is_empty() {
+            None
+        } else {
+            Some(content_inspector::inspect(&current_line[..]))
+        };
+
+        if content_type == Some(ContentType::UTF_16LE) {
+            read_until(&mut reader, &mut current_line, 0x00)?;
+        }
+
+        Ok(InputFileReader {
+            inner: Box::new(reader),
+            current_line,
+            content_type,
+            last_status,
+            line_number: 0,
+            first_read: true,
+        })
+    }
+
+    pub fn read_line(&mut self) -> Result<ReadPosition> {
+        if self.current_line.is_empty() {
+            return Ok(ReadPosition::Eof);
+        }
+
+        if self.first_read {
+            self.first_read = false;
+            if self.last_status != ReadStatus::Overflow {
+                self.line_number += 1;
+            }
+            let pos = match self.last_status {
+                ReadStatus::Eof => ReadPosition::Eof,
+                ReadStatus::Ok => ReadPosition::FullLine,
+                ReadStatus::Overflow => ReadPosition::Start,
+            };
+            Ok(pos)
+        } else {
+            self.current_line.clear();
+            let this_status = read_until(&mut self.inner, &mut self.current_line, b'\n')?;
+
+            if this_status != ReadStatus::Overflow
+                && self.content_type == Some(ContentType::UTF_16LE)
+            {
+                read_until(&mut self.inner, &mut self.current_line, 0x00)?;
             }
 
+            let res = match (self.last_status, this_status) {
+                (ReadStatus::Ok, ReadStatus::Ok) => ReadPosition::FullLine,
+                (ReadStatus::Ok, ReadStatus::Overflow) => ReadPosition::Start,
+                (ReadStatus::Overflow, ReadStatus::Ok) => ReadPosition::End,
+                (ReadStatus::Overflow, ReadStatus::Overflow) => ReadPosition::Middle,
+                (ReadStatus::Eof, _) => ReadPosition::Eof,
+                (_, ReadStatus::Eof) => ReadPosition::Eof,
+            };
+            if res.is_begin_of_line() {
+                self.line_number += 1;
+            }
+            self.last_status = this_status;
             Ok(res)
-        } else {
-            buf.append(&mut self.first_line);
-            Ok(true)
         }
     }
 }
@@ -61,7 +168,7 @@ pub enum InputFile<'a> {
 impl<'a> InputFile<'a> {
     pub fn get_reader(&self, stdin: &'a io::Stdin) -> Result<InputFileReader> {
         match self {
-            InputFile::StdIn => Ok(InputFileReader::new(stdin.lock())),
+            InputFile::StdIn => InputFileReader::new(stdin.lock()),
             InputFile::Ordinary(filename) => {
                 let file = File::open(filename).map_err(|e| format!("'{}': {}", filename, e))?;
 
@@ -69,9 +176,9 @@ impl<'a> InputFile<'a> {
                     return Err(format!("'{}' is a directory.", filename).into());
                 }
 
-                Ok(InputFileReader::new(BufReader::new(file)))
+                InputFileReader::new(BufReader::new(file))
             }
-            InputFile::ThemePreviewFile => Ok(InputFileReader::new(THEME_PREVIEW_FILE)),
+            InputFile::ThemePreviewFile => InputFileReader::new(THEME_PREVIEW_FILE),
         }
     }
 }
@@ -79,57 +186,45 @@ impl<'a> InputFile<'a> {
 #[test]
 fn basic() {
     let content = b"#!/bin/bash\necho hello";
-    let mut reader = InputFileReader::new(&content[..]);
+    let mut reader = InputFileReader::new(&content[..]).unwrap();
 
-    assert_eq!(b"#!/bin/bash\n", &reader.first_line[..]);
+    assert_eq!(b"#!/bin/bash\n", &reader.current_line[..]);
 
-    let mut buffer = vec![];
-
-    let res = reader.read_line(&mut buffer);
+    let res = reader.read_line();
     assert!(res.is_ok());
-    assert_eq!(true, res.unwrap());
-    assert_eq!(b"#!/bin/bash\n", &buffer[..]);
+    assert_eq!(ReadPosition::FullLine, res.unwrap());
+    assert_eq!(b"#!/bin/bash\n", &reader.current_line[..]);
 
-    buffer.clear();
-
-    let res = reader.read_line(&mut buffer);
+    let res = reader.read_line();
     assert!(res.is_ok());
-    assert_eq!(true, res.unwrap());
-    assert_eq!(b"echo hello", &buffer[..]);
+    assert_eq!(ReadPosition::FullLine, res.unwrap());
+    assert_eq!(b"echo hello", &reader.current_line[..]);
 
-    buffer.clear();
-
-    let res = reader.read_line(&mut buffer);
+    let res = reader.read_line();
     assert!(res.is_ok());
-    assert_eq!(false, res.unwrap());
-    assert!(buffer.is_empty());
+    assert_eq!(ReadPosition::Eof, res.unwrap());
+    assert!(reader.current_line.is_empty());
 }
 
 #[test]
 fn utf16le() {
     let content = b"\xFF\xFE\x73\x00\x0A\x00\x64\x00";
-    let mut reader = InputFileReader::new(&content[..]);
+    let mut reader = InputFileReader::new(&content[..]).unwrap();
 
-    assert_eq!(b"\xFF\xFE\x73\x00\x0A\x00", &reader.first_line[..]);
+    assert_eq!(b"\xFF\xFE\x73\x00\x0A\x00", &reader.current_line[..]);
 
-    let mut buffer = vec![];
-
-    let res = reader.read_line(&mut buffer);
+    let res = reader.read_line();
     assert!(res.is_ok());
-    assert_eq!(true, res.unwrap());
-    assert_eq!(b"\xFF\xFE\x73\x00\x0A\x00", &buffer[..]);
+    assert_eq!(ReadPosition::FullLine, res.unwrap());
+    assert_eq!(b"\xFF\xFE\x73\x00\x0A\x00", &reader.current_line[..]);
 
-    buffer.clear();
-
-    let res = reader.read_line(&mut buffer);
+    let res = reader.read_line();
     assert!(res.is_ok());
-    assert_eq!(true, res.unwrap());
-    assert_eq!(b"\x64\x00", &buffer[..]);
+    assert_eq!(ReadPosition::FullLine, res.unwrap());
+    assert_eq!(b"\x64\x00", &reader.current_line[..]);
 
-    buffer.clear();
-
-    let res = reader.read_line(&mut buffer);
+    let res = reader.read_line();
     assert!(res.is_ok());
-    assert_eq!(false, res.unwrap());
-    assert!(buffer.is_empty());
+    assert_eq!(ReadPosition::Eof, res.unwrap());
+    assert!(reader.current_line.is_empty());
 }


### PR DESCRIPTION
this should fix #636 

Now lines are read using the buffer of BufRead. 
I added an enum to set if the current line is an entire line or a subpart.

(If a line is longer than 1024*1024 the highlight does not work as expected) 