### PR TITLE
Leave blank lines blank for terminal output.

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -27,6 +27,10 @@ pub fn as_terminal_escaped(
     italics: bool,
     background_color: Option<highlighting::Color>,
 ) -> String {
+    if text.is_empty() {
+        return text.to_string();
+    }
+
     let mut style = if !colored {
         Style::default()
     } else {


### PR DESCRIPTION
This fixes bug #601. Simply prevents empty strings passed to `as_terminal_escaped` from being escaped.