### PR TITLE
Fix '日本文' to '日本語'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="#installation">Installation</a> •
   <a href="#customization">Customization</a> •
   <a href="#project-goals-and-alternatives">Project goals, alternatives</a> •
-  Translation [<a href="https://github.com/chinanf-boy/bat-zh">中文</a>][<a href="doc/README-ja.md">日本文</a>]
+  Translation [<a href="https://github.com/chinanf-boy/bat-zh">中文</a>][<a href="doc/README-ja.md">日本語</a>]
 </p>
 
 ### Syntax highlighting

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -13,7 +13,7 @@
   <a href="#installation">インストール</a> •
   <a href="#customization">カスタマイズ</a> •
   <a href="#project-goals-and-alternatives">プロジェクトの目標と既存の類似したOSS</a> •
-  翻訳 [<a href="https://github.com/chinanf-boy/bat-zh">中文</a>][<a href="README-ja">日本文</a>]
+  翻訳 [<a href="https://github.com/chinanf-boy/bat-zh">中文</a>][<a href="README-ja">日本語</a>]
 </p>
 
 ### シンタックスハイライト


### PR DESCRIPTION
Hi.

`Japanese` is `日本語` in Japanese. And, `日本文` is `Japanese` in Chinese. This commit fix this wrong expression.