### PR TITLE
Do not pass '--no-init' on newer less versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,18 +435,19 @@ export BAT_PAGER="less -RF"
 Instead of using environment variables, you can also use `bat`s [configuration file](https://github.com/sharkdp/bat#configuration-file) to configure the pager (`--pager` option).
 
 **Note**: By default, if the pager is set to `less` (and no command-line options are specified),
-`bat` will pass the following command line
-options to the pager: `-R`/`--RAW-CONTROL-CHARS`, `-F`/`--quit-if-one-screen` and `-X`/`--no-init`.
-The first (`-R`) is needed to interpret ANSI colors correctly. The second option (`-F`) instructs
+`bat` will pass the following command line options to the pager: `-R`/`--RAW-CONTROL-CHARS`,
+`-F`/`--quit-if-one-screen` and `-X`/`--no-init`. The last option (`-X`) is only used for `less`
+versions older than 530.
+
+The `-R` option is needed to interpret ANSI colors correctly. The second option (`-F`) instructs
 less to exit immediately if the output size is smaller than the vertical size of the terminal.
 This is convenient for small files because you do not have to press `q` to quit the pager. The
 third option (`-X`) is needed to fix a bug with the `--quit-if-one-screen` feature in old versions
-of `less`. Unfortunately, it also breaks mouse-wheel support in `less`. If you want to enable
-mouse-wheel scrolling, you can either pass just `-R` (as in the example above, this will disable
-the quit-if-one-screen feature), or you can use a recent version of `less` and pass `-RF` which
-will hopefully enable both quit-if-one-screen and mouse-wheel scrolling.
+of `less`. Unfortunately, it also breaks mouse-wheel support in `less`.
 
-If scrolling still doesn't work for you, you can try to pass the `-S` option in addition.
+If you want to enable mouse-wheel scrolling on older versions of `less`, you can pass just `-R` (as
+in the example above, this will disable the quit-if-one-screen feature). For less 530 or newer,
+it should work out of the box.
 
 ### Dark mode
 

--- a/README.md
+++ b/README.md
@@ -488,10 +488,6 @@ Example configuration file:
 # Use italic text on the terminal (not supported on all terminals)
 --italic-text=always
 
-# Add mouse scrolling support in less (does not work with older
-# versions of "less")
---pager="less -FR"
-
 # Use C++ syntax (instead of C) for .h header files
 --map-syntax h:cpp
 

--- a/src/less.rs
+++ b/src/less.rs
@@ -1,0 +1,49 @@
+use std::process::Command;
+
+pub fn retrieve_less_version() -> Option<usize> {
+    let cmd = Command::new("less").arg("--version").output().ok()?;
+    parse_less_version(&cmd.stdout)
+}
+
+fn parse_less_version(output: &[u8]) -> Option<usize> {
+    if output.starts_with(b"less ") {
+        let version = std::str::from_utf8(&output[5..]).ok()?;
+        let end = version.find(' ')?;
+        version[..end].parse::<usize>().ok()
+    } else {
+        None
+    }
+}
+
+#[test]
+fn test_parse_less_version_487() {
+    let output = b"less 487 (GNU regular expressions)
+Copyright (C) 1984-2016  Mark Nudelman
+
+less comes with NO WARRANTY, to the extent permitted by law.
+For information about the terms of redistribution,
+see the file named README in the less distribution.
+Homepage: http://www.greenwoodsoftware.com/less";
+
+    assert_eq!(Some(487), parse_less_version(output));
+}
+
+#[test]
+fn test_parse_less_version_551() {
+    let output = b"less 551 (PCRE regular expressions)
+Copyright (C) 1984-2019  Mark Nudelman
+
+less comes with NO WARRANTY, to the extent permitted by law.
+For information about the terms of redistribution,
+see the file named README in the less distribution.
+Home page: http://www.greenwoodsoftware.com/less";
+
+    assert_eq!(Some(551), parse_less_version(output));
+}
+
+#[test]
+fn test_parse_less_version_wrong_program() {
+    let output = b"more from util-linux 2.34";
+
+    assert_eq!(None, parse_less_version(output));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod decorations;
 mod diff;
 pub mod dirs;
 pub mod inputfile;
+mod less;
 pub mod line_range;
 mod output;
 mod preprocessor;

--- a/src/output.rs
+++ b/src/output.rs
@@ -81,6 +81,9 @@ impl OutputType {
                         //
                         // See: http://www.greenwoodsoftware.com/less/news.530.html
                         match retrieve_less_version() {
+                            None => {
+                                p.arg("--no-init");
+                            }
                             Some(version) if version < 530 => {
                                 p.arg("--no-init");
                             }


### PR DESCRIPTION
With this change, we do not pass the `--no-init` option in newer
versions of less (530 or higher).

This fixes #749