### PR TITLE
Adds range syntax for line highlights

### DIFF
--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -215,11 +215,13 @@ impl App {
                 Some("always") => true,
                 _ => false,
             },
-            highlight_lines: self
-                .matches
-                .values_of("highlight-line")
-                .and_then(|ws| ws.map(|w| w.parse().ok()).collect())
-                .unwrap_or_default(),
+            highlight_lines: LineRanges::from(
+                self.matches
+                    .values_of("highlight-line")
+                    .map(|ws| ws.map(LineRange::from).collect())
+                    .transpose()?
+                    .unwrap_or_else(|| vec![LineRange { lower: 0, upper: 0 }]),
+            ),
         })
     }
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -87,10 +87,10 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long_help(
                     "Highlight the specified line ranges with a different background color \
                      For example:\n  \
+                     '--highlight-line 40' highlights line 40\n  \
                      '--highlight-line 30:40' highlights lines 30 to 40\n  \
                      '--highlight-line :40' highlights lines 1 to 40\n  \
-                     '--highlight-line 40:' highlights lines 40 to the end of the file\n  \
-                     '--highlight-line 40' highlights only line 40",
+                     '--highlight-line 40:' highlights lines 40 to the end of the file"
                 ),
         )
         .arg(
@@ -334,7 +334,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      '--line-range 30:40' prints lines 30 to 40\n  \
                      '--line-range :40' prints lines 1 to 40\n  \
                      '--line-range 40:' prints lines 40 to the end of the file\n  \
-                     '--line-range 40' prints only line 40",
+                     '--line-range 40' only prints line 40",
                 ),
         )
         .arg(

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -82,10 +82,15 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .takes_value(true)
                 .number_of_values(1)
                 .multiple(true)
-                .value_name("N")
-                .help("Highlight the given line.")
+                .value_name("N:M")
+                .help("Highlight lines N through M.")
                 .long_help(
-                    "Highlight the N-th line with a different background color",
+                    "Highlight the specified line ranges with a different background color \
+                     For example:\n  \
+                     '--highlight-line 30:40' highlights lines 30 to 40\n  \
+                     '--highlight-line :40' highlights lines 1 to 40\n  \
+                     '--highlight-line 40:' highlights lines 40 to the end of the file\n  \
+                     '--highlight-line 40' highlights only line 40",
                 ),
         )
         .arg(
@@ -328,7 +333,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      For example:\n  \
                      '--line-range 30:40' prints lines 30 to 40\n  \
                      '--line-range :40' prints lines 1 to 40\n  \
-                     '--line-range 40:' prints lines 40 to the end of the file",
+                     '--line-range 40:' prints lines 40 to the end of the file\n  \
+                     '--line-range 40' prints only line 40",
                 ),
         )
         .arg(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,5 +128,5 @@ pub struct Config<'a> {
     pub use_italic_text: bool,
 
     /// Lines to highlight
-    pub highlight_lines: Vec<usize>,
+    pub highlight_lines: LineRanges,
 }

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -41,7 +41,7 @@ impl LineRange {
                 new_range.upper = line_numbers[1].parse()?;
                 Ok(new_range)
             },
-            _ => Err("expected at most single ':' character".into()),
+            _ => Err("Line range contained more than one ':' character. Expected format: 'N' or 'N:M'".into()),
         }
     }
 

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -30,13 +30,19 @@ impl LineRange {
         }
 
         let line_numbers: Vec<&str> = range_raw.split(':').collect();
-        if line_numbers.len() == 2 {
-            new_range.lower = line_numbers[0].parse()?;
-            new_range.upper = line_numbers[1].parse()?;
-            return Ok(new_range);
+        match line_numbers.len() {
+            1 => {
+                new_range.lower = line_numbers[0].parse()?;
+                new_range.upper = new_range.lower;
+                Ok(new_range)
+            },
+            2 => {
+                new_range.lower = line_numbers[0].parse()?;
+                new_range.upper = line_numbers[1].parse()?;
+                Ok(new_range)
+            },
+            _ => Err("expected at most single ':' character".into()),
         }
-
-        Err("expected single ':' character".into())
     }
 
     pub fn is_inside(&self, line: usize) -> bool {
@@ -66,14 +72,19 @@ fn test_parse_partial_max() {
 }
 
 #[test]
+fn test_parse_single() {
+    let range = LineRange::from("40").expect("Shouldn't fail on test!");
+    assert_eq!(40, range.lower);
+    assert_eq!(40, range.upper);
+}
+
+#[test]
 fn test_parse_fail() {
     let range = LineRange::from("40:50:80");
     assert!(range.is_err());
     let range = LineRange::from("40::80");
     assert!(range.is_err());
     let range = LineRange::from(":40:");
-    assert!(range.is_err());
-    let range = LineRange::from("40");
     assert!(range.is_err());
 }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -24,6 +24,7 @@ use crate::diff::get_git_diff;
 use crate::diff::LineChanges;
 use crate::errors::*;
 use crate::inputfile::{InputFile, InputFileReader};
+use crate::line_range::RangeCheckResult;
 use crate::preprocessor::{expand_tabs, replace_nonprintable};
 use crate::style::OutputWrap;
 use crate::terminal::{as_terminal_escaped, to_ansi_color};
@@ -369,11 +370,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
         let mut panel_wrap: Option<String> = None;
 
         // Line highlighting
-        let highlight_this_line = self
-            .config
-            .highlight_lines
-            .iter()
-            .any(|&l| l == line_number);
+        let highlight_this_line =
+            self.config.highlight_lines.check(line_number) == RangeCheckResult::InRange;
 
         let background_color = self
             .background_color_highlight


### PR DESCRIPTION
`--highlight-line` now accepts line ranges like the `--line-range` option.
