### PR TITLE
Add issue templates and a `info.sh` tool for helping collect and report system info.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 \-------------------------------------------------------------------------------------------------
 **Hey there, thanks for creating an issue!**  
-In order to replicate your issue, we might need to know a little bit more about the environment
+In order to reproduce your issue, we might need to know a little bit more about the environment
 which you're running `bat` on.
 
 **If you're on Linux or MacOS:**  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,6 +37,7 @@ Please remove this header and continue.
 **How did you install `bat`?**  
 apt-get, homebrew, GitHub release, etc.
 
-**If applicable, can you tell us more about your system?**
-...
+---
+
+[paste the output of `info.sh` here]
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,28 +8,30 @@ assignees: ''
 ---
 
 \-------------------------------------------------------------------------------------------------
-**IS THIS BUG RELATED TO EXTERNAL TOOLS? (e.g. git, less, etc.)**
-
-If it is, there's a good chance we might need to know a little bit more about the environment
+**Hey there, thanks for creating an issue!**  
+In order to replicate your issue, we might need to know a little bit more about the environment
 which you're running `bat` on.
-
-**If you're on Windows:**  
-Please tell us about your:
-
-- Windows Version
 
 **If you're on Linux or MacOS:**  
 Please run the script at https://github.com/sharkdp/bat/blob/diag-tools/diagnostics/info.sh and
 paste the output at the bottom of the bug report.
 
+**If you're on Windows:**  
+Please tell us about the following at the bottom of the bug report:
+
+- Windows Version (e.g. "Windows 10 1908")
+
 **Once you're done:**  
 Please remove this header and continue.
 \-------------------------------------------------------------------------------------------------
 
-**What do you expect to happen?**  
+**What version of `bat` are you using?**
+[paste the output of `bat --version` here]
+
+**Describe the bug you encountered:**  
 ...
 
-**What actually happens?**  
+**Describe what you expected to happen?**  
 ...
 
 **How did you install `bat`?**  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report a bug.
+title: "[Bug] "
+labels: bug
+assignees: ''
+
+---
+
+\-------------------------------------------------------------------------------------------------
+**IS THIS BUG RELATED TO EXTERNAL TOOLS? (e.g. git, less, etc.)**
+
+If it is, there's a good chance we might need to know a little bit more about the environment
+which you're running `bat` on.
+
+**If you're on Windows:**  
+Please tell us about your:
+
+- Windows Version
+
+**If you're on Linux or MacOS:**  
+Please run the script at https://github.com/sharkdp/bat/blob/diag-tools/diagnostics/info.sh and
+paste the output at the bottom of the bug report.
+
+**Once you're done:**  
+Please remove this header and continue.
+\-------------------------------------------------------------------------------------------------
+
+**What do you expect to happen?**  
+...
+
+**What actually happens?**  
+...
+
+**How did you install `bat`?**  
+apt-get, homebrew, GitHub release, etc.
+
+**If applicable, can you tell us more about your system?**
+...
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+

--- a/.github/ISSUE_TEMPLATE/syntax_request.md
+++ b/.github/ISSUE_TEMPLATE/syntax_request.md
@@ -15,9 +15,17 @@ Bat supports locally-installed language definitions. See the link below:
 
 https://github.com/sharkdp/bat#adding-new-syntaxes--language-definitions
 
-If you think adding this syntax would help others as well, please remove this header and continue.
+If you think adding this syntax would help others as well, please make sure that it meets our
+guidelines for adding new syntaxes:
+
+ - 10,000 downloads on packagecontrol.io
+
+Once you have confirmed that it meets our guidelines, you can remove this header and continue.
 \-------------------------------------------------------------------------------------------------
 
 
 **Syntax:** syntax/language name
+
+**Guideline Criteria:**
+[packagecontro.io link here]
 

--- a/.github/ISSUE_TEMPLATE/syntax_request.md
+++ b/.github/ISSUE_TEMPLATE/syntax_request.md
@@ -1,0 +1,23 @@
+---
+name: Syntax Request
+about: Request adding a new syntax to bat.
+title: "[Syntax Request] "
+labels: new-syntax
+assignees: ''
+
+---
+
+\-------------------------------------------------------------------------------------------------
+**BEFORE YOU MAKE A REQUEST:**
+
+Are you looking to add a new syntax to use on one of your devices?
+Bat supports locally-installed language definitions. See the link below:
+
+https://github.com/sharkdp/bat#adding-new-syntaxes--language-definitions
+
+If you think adding this syntax would help others as well, please remove this header and continue.
+\-------------------------------------------------------------------------------------------------
+
+
+**Syntax:** syntax/language name
+

--- a/diagnostics/info.sh
+++ b/diagnostics/info.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+_modules=('system' 'bat' 'bat_config' 'bat_wrapper' 'tool')
+_modules_consented=()
+
+
+# -----------------------------------------------------------------------------
+# Modules:
+# -----------------------------------------------------------------------------
+
+_bat_:description() {
+	_collects "Version information for 'bat'."
+}
+
+_bat_config_:description() {
+	_collects "The environment variables used by 'bat'."
+	_collects "The 'bat' configuration file."
+}
+
+_bat_wrapper_:description() {
+	_collects "Any wrapper script used by 'bat'."
+}
+
+_system_:description() {
+	_collects "Operating system name."
+	_collects "Operating system version."
+}
+
+_tool_:description() {
+	_collects "Version information for 'less'."
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+_bat_:run() {
+	_out bat --version
+	_out env | grep '^BAT_\|^PAGER='
+}
+
+_bat_config_:run() {
+	if [[ -f "$(bat --config-file)" ]]; then 
+		_out cat "$(bat --config-file)"; 
+	fi
+}
+
+_bat_wrapper_:run() {
+	if file "$(which bat)" | grep "text executable" &>/dev/null; then
+		_out cat "$(which bat)"
+	fi
+}
+
+_system_:run() {
+	_out uname -srm
+
+	if command -v "sw_vers" &>/dev/null; then _out sw_vers; fi
+	if command -v "lsb_release" &>/dev/null; then _out lsb_release -a; fi
+}
+
+_tool_:run() {
+	_out less --version | head -n1
+}
+
+
+# -----------------------------------------------------------------------------
+# Functions:
+# -----------------------------------------------------------------------------
+
+_out() {
+	printf "\n+" 1>&2
+	printf " %s" "$@" 1>&2
+	printf "\n" 1>&2
+
+	"$@" 2>&1
+}
+
+_tput() {
+	tput "$@" 1>&2 2>/dev/null
+}
+
+_collects() {
+	printf " - %s\n" "$1" 1>&2
+}
+
+_ask_module() {
+	_tput clear
+	_tput cup 0 0
+
+cat 1>&2 <<EOF
+--------------------------------------------------------------------------------
+This script will collect information to help assist in issue resolution.
+You will be provided with a description of the data collected, and will be
+offered the opportunity to give consent for each piece of information collected.
+--------------------------------------------------------------------------------
+EOF
+
+	# Print description.
+	_tput setaf 3
+	printf "The following data will be collected:\n" 1>&2
+	_tput sgr0
+	"_$1_:description"
+	_tput sgr0
+	
+	# Print preview.
+	_tput setaf 3
+	printf "\nThe following commands will be run:\n" 1>&2
+	_tput sgr0
+	declare -f "_$1_:run" \
+		| sed 's/^ *//; s/;$//' \
+		| grep '^_out ' \
+		| sed 's/^_out //' 1>&2
+
+	# Prompt
+	printf "\n" 1>&2
+	local response
+	while true; do
+		_tput cup "$(( $(tput lines 2>/dev/null || echo 22) - 1 ))"
+		_tput el
+		read -er -p "Collect $(sed 's/_/ /' <<< "$1") data? [Y/n] " response
+		case "$response" in
+			Y|y|yes|'') return 0 ;;
+			N|n|no)     return 1 ;;
+			*) continue
+		esac
+	done
+}
+
+_run_module() {
+	printf "========== %s ==========\n" "$1"
+	"_$1_:run"
+}
+
+
+# -----------------------------------------------------------------------------
+# Functions:
+# -----------------------------------------------------------------------------
+
+# Ask for consent.
+if [[ "$1" = '-y' ]]; then
+	_modules_consented=("${_modules[@]}")
+else
+	trap '_tput rmcup; exit 1' INT
+	_tput smcup
+	for _module in "${_modules[@]}"; do
+		if _ask_module "$_module"; then
+			_modules_consented+=("$_module")
+		fi
+	done
+	_tput rmcup
+fi
+
+# Collect information.
+for _module in "${_modules_consented[@]}"; do
+	_run_module "$_module"
+	printf "\n"
+done
+
+

--- a/diagnostics/info.sh
+++ b/diagnostics/info.sh
@@ -87,9 +87,10 @@ _ask_module() {
 
 cat 1>&2 <<EOF
 --------------------------------------------------------------------------------
-This script will collect information to help assist in issue resolution.
-You will be provided with a description of the data collected, and will be
-offered the opportunity to give consent for each piece of information collected.
+This script runs some harmless commands to collect information about your
+system and bat configuration. It will give you a small preview of the commands
+that will be run, and ask consent before running them. Once completed, it will
+output a small report that you can review and copy into the issue description.
 --------------------------------------------------------------------------------
 EOF
 
@@ -113,7 +114,7 @@ EOF
 	printf "\n" 1>&2
 	local response
 	while true; do
-		_tput cup "$(( $(tput lines 2>/dev/null || echo 22) - 1 ))"
+		_tput cup "$(( $(tput lines || echo 22) - 2 ))"
 		_tput el
 		read -er -p "Collect $(sed 's/_/ /' <<< "$1") data? [Y/n] " response
 		case "$response" in

--- a/diagnostics/info.sh
+++ b/diagnostics/info.sh
@@ -20,7 +20,7 @@ _bat_wrapper_:description() {
 	_collects "Any wrapper script used by 'bat'."
 }
 
-_bat_wrapper_function_description() {
+_bat_wrapper_function_:description() {
 	_collects "The wrapper function surrounding 'bat' (if applicable)."
 }
 


### PR DESCRIPTION
The shell script is intended to be used to help maintainers and contributors diagnose issues that other people are having with `bat` and/or integration with external tools.

It asks for consent to collect data, and will print the following if everything is allowed:

```
========== system ==========

+ uname -srm
Darwin 18.7.0 x86_64

+ sw_vers # or lab_release on Linux
ProductName:	Mac OS X
ProductVersion:	10.14.6
BuildVersion:	18G95

========== bat ==========

+ bat --version
bat 0.12.1

+ env
BAT_PAGER=
PAGER=/usr/local/bin/less

========== bat_config ==========

+ cat /Users/eth-p/.config/bat/config
--tabs 4

# Syntaxes
#--map-syntax From:to


========== bat_wrapper ==========

+ cat /Users/eth-p/.local/bin/bat
#!/usr/bin/env bash
ARGS=()
case "$(defaults read -globalDomain AppleInterfaceStyle 2>/dev/null || echo "Light")" in
	Light)  ARGS+=(--theme OneHalfLight) ;;
	Dark|*) : ;;
esac
ARGS+=("$@")

exec /usr/local/bin/bat "${ARGS[@]}"


========== tool ==========

+ less --version
less 530 (PCRE regular expressions)
```

The data collected is as follows:

- Kernel name and version.
- Operating system details (distro, release name).
- `bat` version
- `less` version
- `bat` environment variables.
- `bat` config file.
- Any wrapper script ~~(but not function)~~ around `bat`.
