### PR TITLE
Fix #798

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -79,7 +79,10 @@ impl<'b> Controller<'b> {
         writer: &mut dyn Write,
         input_file: InputFile<'a>,
     ) -> Result<()> {
-        printer.print_header(writer, input_file)?;
+        if !reader.first_line.is_empty() || self.config.output_components.header() {
+            printer.print_header(writer, input_file)?;
+        }
+
         if !reader.first_line.is_empty() {
             self.print_file_ranges(printer, writer, reader, &self.config.line_ranges)?;
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -504,3 +504,15 @@ fn snip() {
 ",
         );
 }
+
+#[test]
+fn empty_file_leads_to_empty_output_with_grid_enabled() {
+    bat()
+        .arg("empty.txt")
+        .arg("--style=grid")
+        .arg("--decorations=always")
+        .arg("--terminal-width=80")
+        .assert()
+        .success()
+        .stdout("");
+}


### PR DESCRIPTION
With this fix, `bat` no longer prints an incomplete header if the file is empty and the `header` output component is disabled.