### PR TITLE
Simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,37 +7,33 @@ assignees: ''
 
 ---
 
-\-------------------------------------------------------------------------------------------------
-**Hey there, thanks for creating an issue!**  
+<!--
+Hey there, thanks for creating an issue!
+
 In order to reproduce your issue, we might need to know a little bit more about the environment
 which you're running `bat` on.
 
-**If you're on Linux or MacOS:**  
-Please run the script at https://github.com/sharkdp/bat/blob/diag-tools/diagnostics/info.sh and
-paste the output at the bottom of the bug report.
+If you're on Linux or MacOS:
+  Please run the script at https://github.com/sharkdp/bat/blob/diag-tools/diagnostics/info.sh and
+  paste the output at the bottom of the bug report.
 
-**If you're on Windows:**  
-Please tell us about the following at the bottom of the bug report:
-
-- Windows Version (e.g. "Windows 10 1908")
-
-**Once you're done:**  
-Please remove this header and continue.
-\-------------------------------------------------------------------------------------------------
+If you're on Windows:
+  Please tell us about your Windows Version (e.g. "Windows 10 1908") at the
+  bottom of the bug report.
+-->
 
 **What version of `bat` are you using?**
 [paste the output of `bat --version` here]
 
-**Describe the bug you encountered:**  
+**Describe the bug you encountered:**
 ...
 
-**Describe what you expected to happen?**  
+**Describe what you expected to happen?**
 ...
 
-**How did you install `bat`?**  
+**How did you install `bat`?**
 apt-get, homebrew, GitHub release, etc.
 
 ---
 
 [paste the output of `info.sh` here]
-

--- a/.github/ISSUE_TEMPLATE/syntax_request.md
+++ b/.github/ISSUE_TEMPLATE/syntax_request.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-\-------------------------------------------------------------------------------------------------
-**BEFORE YOU MAKE A REQUEST:**
+<!--
+BEFORE YOU MAKE A REQUEST:
 
 Are you looking to add a new syntax to use on one of your devices?
 Bat supports locally-installed language definitions. See the link below:
@@ -19,13 +19,11 @@ If you think adding this syntax would help others as well, please make sure that
 guidelines for adding new syntaxes:
 
  - 10,000 downloads on packagecontrol.io
-
-Once you have confirmed that it meets our guidelines, you can remove this header and continue.
-\-------------------------------------------------------------------------------------------------
+-->
 
 
-**Syntax:** syntax/language name
+**Syntax:**
+[Name or description of the syntax/language here]
 
 **Guideline Criteria:**
 [packagecontro.io link here]
-


### PR DESCRIPTION
Just a few small things that I thought about after looking how the new templates look like on GitHub.

The main change is that I made the "header" section into a HTML comment. This way, users will not have to remove the header part.

@eth-p What do you think?