### PR TITLE
Fix broken link in issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ In order to reproduce your issue, we might need to know a little bit more about 
 which you're running `bat` on.
 
 If you're on Linux or MacOS:
-  Please run the script at https://github.com/sharkdp/bat/blob/diag-tools/diagnostics/info.sh and
+  Please run the script at https://github.com/sharkdp/bat/blob/master/diagnostics/info.sh and
   paste the output at the bottom of the bug report.
 
 If you're on Windows:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: Feature Request
+about: Suggest an idea for this project.
 title: ''
 labels: feature-request
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about 'bat'
+about: Ask a question about 'bat'.
 title: ''
 labels: question
 assignees: ''


### PR DESCRIPTION
This fixes the `diagnostics/info.sh` link in the Bug Report template, and changes the other template names/descriptions to be more consistent in casing and punctuation.