### PR TITLE
Add syntax detection unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,6 @@ dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/syntax_detection.rs
+++ b/tests/syntax_detection.rs
@@ -1,0 +1,78 @@
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+
+use tempdir::TempDir;
+
+use bat::assets::HighlightingAssets;
+use bat::inputfile::InputFile;
+use bat::syntax_mapping::SyntaxMapping;
+
+struct SyntaxDetectionTest {
+    assets: HighlightingAssets,
+    pub syntax_mapping: SyntaxMapping,
+    temp_dir: TempDir,
+}
+
+impl SyntaxDetectionTest {
+    fn new() -> Self {
+        SyntaxDetectionTest {
+            assets: HighlightingAssets::new(),
+            syntax_mapping: SyntaxMapping::new(),
+            temp_dir: TempDir::new("bat_syntax_detection_tests")
+                .expect("creation of temporary directory"),
+        }
+    }
+
+    fn syntax_name_with_content(&self, file_name: &str, first_line: &str) -> String {
+        let file_path = self.temp_dir.path().join(file_name);
+        {
+            let mut temp_file = File::create(&file_path).unwrap();
+            writeln!(temp_file, "{}", first_line).unwrap();
+        }
+
+        let input_file = InputFile::Ordinary(OsStr::new(&file_path));
+        let syntax = self.assets.get_syntax(
+            None,
+            input_file,
+            &mut input_file.get_reader(&io::stdin()).unwrap(),
+            &self.syntax_mapping,
+        );
+
+        syntax.name.clone()
+    }
+
+    fn syntax_name(&self, file_name: &str) -> String {
+        self.syntax_name_with_content(file_name, "")
+    }
+}
+
+#[test]
+fn syntax_detection_basic() {
+    let test = SyntaxDetectionTest::new();
+
+    assert_eq!(test.syntax_name("test.rs"), "Rust");
+    assert_eq!(test.syntax_name("test.cpp"), "C++");
+    assert_eq!(test.syntax_name("PKGBUILD"), "Bourne Again Shell (bash)");
+}
+
+#[test]
+fn syntax_detection_first_line() {
+    let test = SyntaxDetectionTest::new();
+
+    assert_eq!(
+        test.syntax_name_with_content("my_script", "#!/bin/bash"),
+        "Bourne Again Shell (bash)"
+    );
+    assert_eq!(test.syntax_name_with_content("my_script", "<?php"), "PHP");
+}
+
+#[test]
+fn syntax_detection_with_custom_mapping() {
+    let mut test = SyntaxDetectionTest::new();
+
+    assert_ne!(test.syntax_name("test.h"), "C++");
+    test.syntax_mapping.insert("h", "cpp");
+    assert_eq!(test.syntax_name("test.h"), "C++");
+}


### PR DESCRIPTION
This adds some basic tests for our syntax detection. In the future, this should be expanded to contain a comprehensive list of cases that we want to cover.

Once #592 is implemented, we can also add path => syntax mappings within these tests.