### PR TITLE
Specify cache dir with BAT_CACHE_DIR

### DIFF
--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -33,10 +33,8 @@ impl BatProjectDirs {
 
     pub fn get_cache_dir() -> Option<PathBuf> {
         // on all OS prefer BAT_CACHE_PATH if set
-        let cache_dir_op = env::var_os("BAT_CACHE_PATH")
-            .map(PathBuf::from)
-            .filter(|p| p.is_absolute());
-        if !cache_dir_op.is_none() {
+        let cache_dir_op = env::var_os("BAT_CACHE_PATH").map(PathBuf::from);
+        if cache_dir_op.is_some() {
             return cache_dir_op;
         }
 

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -47,7 +47,7 @@ impl BatProjectDirs {
         #[cfg(not(target_os = "macos"))]
         let cache_dir_op = dirs_rs::cache_dir();
 
-        Some(cache_dir_op.map(|d| d.join("bat")))?
+        cache_dir_op.map(|d| d.join("bat"))
     }
 
     pub fn cache_dir(&self) -> &Path {


### PR DESCRIPTION
- if set, BAT_CACHE_DIR is used. otherwise use OS default.

Closes #829 