### PR TITLE
glob-based syntax mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-words 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -199,6 +200,14 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -541,6 +550,18 @@ dependencies = [
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "globset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1453,6 +1474,7 @@ dependencies = [
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+"checksum bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
@@ -1495,6 +1517,7 @@ dependencies = [
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum git2 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7da16ceafe24cedd9ba02c4463a2b506b6493baf4317c79c5acb553134a3c15"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+"checksum globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ content_inspector = "0.2.4"
 encoding = "0.2"
 shell-words = "0.1.0"
 unicode-width = "0.1.7"
+globset = "0.4"
 
 [dependencies.git2]
 version = "0.13"

--- a/README.md
+++ b/README.md
@@ -500,11 +500,11 @@ Example configuration file:
 # Use italic text on the terminal (not supported on all terminals)
 --italic-text=always
 
-# Use C++ syntax (instead of C) for .h header files
---map-syntax h:cpp
+# Use C++ syntax for .ino files
+--map-syntax "*.ino:C++"
 
-# Use "gitignore" highlighting for ".ignore" files
---map-syntax .ignore:.gitignore
+# Use ".gitignore"-style highlighting for ".ignore" files
+--map-syntax ".ignore:Git Ignore"
 ```
 
 ## Using `bat` on Windows

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -100,12 +100,12 @@ Determine which pager is used. This option will overwrite the PAGER and BAT_PAGE
 environment variables. The default pager is 'less'. To disable the pager completely, use
 the '\-\-paging' option. Example: '\-\-pager "less \fB\-RF\fR"'.
 .HP
-\fB\-m\fR, \fB\-\-map\-syntax\fR <from:to>...
+\fB\-m\fR, \fB\-\-map\-syntax\fR <glob-pattern:syntax-name>...
 .IP
-Map a file extension or file name to an existing syntax (specified by a file extension
-or file name). For example, to highlight *.build files with the Python syntax, use '\-m
-build:py'. To highlight files named '.myignore' with the Git Ignore syntax, use '\-m
-\&.myignore:gitignore'.
+Map a glob pattern to an existing syntax name. The glob pattern is matched on the full
+path and the filename. For example, to highlight *.build files with the Python syntax,
+use -m '*.build:Python'. To highlight files named '.myignore' with the Git Ignore
+syntax, use -m '.myignore:Git Ignore'.
 .HP
 \fB\-\-theme\fR <theme>
 .IP

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -500,11 +500,11 @@ export BAT_CONFIG_PATH="/path/to/bat.conf"
 # Use italic text on the terminal (not supported on all terminals)
 --italic-text=always
 
-# Use C++ syntax (instead of C) for .h header files
---map-syntax h:cpp
+# Use C++ syntax for .ino files
+--map-syntax "*.ino:C++"
 
-# Use "gitignore" highlighting for ".ignore" files
---map-syntax .ignore:.gitignore
+# Use ".gitignore"-style highlighting for ".ignore" files
+--map-syntax ".ignore:Git Ignore"
 ```
 
 ## Windows での `bat` の利用

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -452,11 +452,11 @@ export BAT_CONFIG_PATH="/path/to/bat.conf"
 # Use italic text on the terminal (not supported on all terminals)
 --italic-text=always
 
-# Use C++ syntax (instead of C) for .h header files
---map-syntax h:cpp
+# Use C++ syntax for .ino files
+--map-syntax "*.ino:C++"
 
-# Use "gitignore" highlighting for ".ignore" files
---map-syntax .ignore:.gitignore
+# Use ".gitignore"-style highlighting for ".ignore" files
+--map-syntax ".ignore:Git Ignore"
 ```
 
 ##  Windows에서 사용하기

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -246,7 +246,7 @@ mod tests {
             }
         }
 
-        fn syntax_name_with_content(&self, file_name: &str, first_line: &str) -> String {
+        fn synax_for_file_with_content(&self, file_name: &str, first_line: &str) -> String {
             let file_path = self.temp_dir.path().join(file_name);
             {
                 let mut temp_file = File::create(&file_path).unwrap();
@@ -264,8 +264,8 @@ mod tests {
             syntax.name.clone()
         }
 
-        fn syntax_name(&self, file_name: &str) -> String {
-            self.syntax_name_with_content(file_name, "")
+        fn syntax_for_file(&self, file_name: &str) -> String {
+            self.synax_for_file_with_content(file_name, "")
         }
     }
 
@@ -273,22 +273,25 @@ mod tests {
     fn syntax_detection_basic() {
         let test = SyntaxDetectionTest::new();
 
-        assert_eq!(test.syntax_name("test.rs"), "Rust");
-        assert_eq!(test.syntax_name("test.cpp"), "C++");
-        assert_eq!(test.syntax_name("test.build"), "NAnt Build File");
-        assert_eq!(test.syntax_name("PKGBUILD"), "Bourne Again Shell (bash)");
-        assert_eq!(test.syntax_name(".bashrc"), "Bourne Again Shell (bash)");
-        assert_eq!(test.syntax_name("Makefile"), "Makefile");
+        assert_eq!(test.syntax_for_file("test.rs"), "Rust");
+        assert_eq!(test.syntax_for_file("test.cpp"), "C++");
+        assert_eq!(test.syntax_for_file("test.build"), "NAnt Build File");
+        assert_eq!(
+            test.syntax_for_file("PKGBUILD"),
+            "Bourne Again Shell (bash)"
+        );
+        assert_eq!(test.syntax_for_file(".bashrc"), "Bourne Again Shell (bash)");
+        assert_eq!(test.syntax_for_file("Makefile"), "Makefile");
     }
 
     #[test]
     fn syntax_detection_well_defined_mapping_for_duplicate_extensions() {
         let test = SyntaxDetectionTest::new();
 
-        assert_eq!(test.syntax_name("test.h"), "C++");
-        assert_eq!(test.syntax_name("test.sass"), "Sass");
-        assert_eq!(test.syntax_name("test.hs"), "Haskell (improved)");
-        assert_eq!(test.syntax_name("test.js"), "JavaScript (Babel)");
+        assert_eq!(test.syntax_for_file("test.h"), "C++");
+        assert_eq!(test.syntax_for_file("test.sass"), "Sass");
+        assert_eq!(test.syntax_for_file("test.hs"), "Haskell (improved)");
+        assert_eq!(test.syntax_for_file("test.js"), "JavaScript (Babel)");
     }
 
     #[test]
@@ -296,35 +299,38 @@ mod tests {
         let test = SyntaxDetectionTest::new();
 
         assert_eq!(
-            test.syntax_name_with_content("my_script", "#!/bin/bash"),
+            test.synax_for_file_with_content("my_script", "#!/bin/bash"),
             "Bourne Again Shell (bash)"
         );
         assert_eq!(
-            test.syntax_name_with_content("build", "#!/bin/bash"),
+            test.synax_for_file_with_content("build", "#!/bin/bash"),
             "Bourne Again Shell (bash)"
         );
-        assert_eq!(test.syntax_name_with_content("my_script", "<?php"), "PHP");
+        assert_eq!(
+            test.synax_for_file_with_content("my_script", "<?php"),
+            "PHP"
+        );
     }
 
     #[test]
     fn syntax_detection_with_custom_mapping() {
         let mut test = SyntaxDetectionTest::new();
 
-        assert_eq!(test.syntax_name("test.h"), "C++");
+        assert_eq!(test.syntax_for_file("test.h"), "C++");
         test.syntax_mapping
             .insert("*.h", MappingTarget::MapTo("C"))
             .ok();
-        assert_eq!(test.syntax_name("test.h"), "C");
+        assert_eq!(test.syntax_for_file("test.h"), "C");
     }
 
     #[test]
     fn syntax_detection_is_case_sensitive() {
         let mut test = SyntaxDetectionTest::new();
 
-        assert_ne!(test.syntax_name("README.MD"), "Markdown");
+        assert_ne!(test.syntax_for_file("README.MD"), "Markdown");
         test.syntax_mapping
             .insert("*.MD", MappingTarget::MapTo("Markdown"))
             .ok();
-        assert_eq!(test.syntax_name("README.MD"), "Markdown");
+        assert_eq!(test.syntax_for_file("README.MD"), "Markdown");
     }
 }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -285,6 +285,7 @@ mod tests {
     fn syntax_detection_well_defined_mapping_for_duplicate_extensions() {
         let test = SyntaxDetectionTest::new();
 
+        assert_eq!(test.syntax_name("test.h"), "C++");
         assert_eq!(test.syntax_name("test.sass"), "Sass");
         assert_eq!(test.syntax_name("test.hs"), "Haskell (improved)");
         assert_eq!(test.syntax_name("test.js"), "JavaScript (Babel)");
@@ -309,11 +310,11 @@ mod tests {
     fn syntax_detection_with_custom_mapping() {
         let mut test = SyntaxDetectionTest::new();
 
-        assert_ne!(test.syntax_name("test.h"), "C++");
-        test.syntax_mapping
-            .insert("*.h", MappingTarget::MapTo("C++"))
-            .ok();
         assert_eq!(test.syntax_name("test.h"), "C++");
+        test.syntax_mapping
+            .insert("*.h", MappingTarget::MapTo("C"))
+            .ok();
+        assert_eq!(test.syntax_name("test.h"), "C");
     }
 
     #[test]

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -196,8 +196,8 @@ impl HighlightingAssets {
                     .ok()
                     .and_then(|l| self.syntax_set.find_syntax_by_first_line(&l));
 
-                dbg!(path);
-                match dbg!(mapping.get_syntax_for(path)) {
+                let absolute_path = path.canonicalize().ok().unwrap_or(path.to_owned());
+                match mapping.get_syntax_for(absolute_path) {
                     Some(MappingTarget::MapTo(syntax_name)) => {
                         // TODO: we should probably return an error here if this syntax can not be
                         // found. Currently, we just fall back to 'plain'.
@@ -275,6 +275,7 @@ mod tests {
 
         assert_eq!(test.syntax_name("test.rs"), "Rust");
         assert_eq!(test.syntax_name("test.cpp"), "C++");
+        assert_eq!(test.syntax_name("test.build"), "NAnt Build File");
         assert_eq!(test.syntax_name("PKGBUILD"), "Bourne Again Shell (bash)");
         assert_eq!(test.syntax_name(".bashrc"), "Bourne Again Shell (bash)");
         assert_eq!(test.syntax_name("Makefile"), "Makefile");

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -18,8 +18,8 @@ use ansi_term;
 
 use bat::{
     config::{
-        Config, HighlightedLineRanges, InputFile, LineRange, LineRanges, OutputWrap, PagingMode,
-        StyleComponent, StyleComponents, SyntaxMapping,
+        Config, HighlightedLineRanges, InputFile, LineRange, LineRanges, MappingTarget, OutputWrap,
+        PagingMode, StyleComponent, StyleComponents, SyntaxMapping,
     },
     errors::*,
     HighlightingAssets,
@@ -104,7 +104,7 @@ impl App {
             }
         };
 
-        let mut syntax_mapping = SyntaxMapping::new();
+        let mut syntax_mapping = SyntaxMapping::builtin();
 
         if let Some(values) = self.matches.values_of("map-syntax") {
             for from_to in values {
@@ -114,7 +114,7 @@ impl App {
                     return Err("Invalid syntax mapping. The format of the -m/--map-syntax option is 'from:to'.".into());
                 }
 
-                syntax_mapping.insert(parts[0], parts[1]);
+                syntax_mapping.insert(parts[0], MappingTarget::MapTo(parts[1]))?;
             }
         }
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -111,7 +111,7 @@ impl App {
                 let parts: Vec<_> = from_to.split(':').collect();
 
                 if parts.len() != 2 {
-                    return Err("Invalid syntax mapping. The format of the -m/--map-syntax option is 'from:to'.".into());
+                    return Err("Invalid syntax mapping. The format of the -m/--map-syntax option is '<glob-pattern>:<syntax-name>'. For example: '*.cpp:C++'.".into());
                 }
 
                 syntax_mapping.insert(parts[0], MappingTarget::MapTo(parts[1]))?;

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -248,13 +248,13 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .multiple(true)
                 .takes_value(true)
                 .number_of_values(1)
-                .value_name("from:to")
-                .help("Map a file extension or name to an existing syntax.")
+                .value_name("glob:syntax")
+                .help("Use the specified syntax for files matching the glob pattern ('*.cpp:C++').")
                 .long_help(
-                    "Map a file extension or file name to an existing syntax (specified by a file \
-                     extension or file name). For example, to highlight *.build files with the \
-                     Python syntax, use '-m build:py'. To highlight files named '.myignore' with \
-                     the Git Ignore syntax, use '-m .myignore:gitignore'.",
+                    "Map a glob pattern to an existing syntax name. The glob pattern is matched \
+                     on the full path and the filename. For example, to highlight *.build files \
+                     with the Python syntax, use -m '*.build:Python'. To highlight files named \
+                     '.myignore' with the Git Ignore syntax, use -m '.myignore:Git Ignore'.",
                 )
                 .takes_value(true),
         )
@@ -281,7 +281,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("style")
                 .long("style")
-                .value_name("style-components")
+                .value_name("components")
                 // Need to turn this off for overrides_with to work as we want. See the bottom most
                 // example at https://docs.rs/clap/2.32.0/clap/struct.Arg.html#method.overrides_with
                 .use_delimiter(false)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 pub use crate::inputfile::InputFile;
 pub use crate::line_range::{HighlightedLineRanges, LineRange, LineRanges};
 pub use crate::style::{StyleComponent, StyleComponents};
-pub use crate::syntax_mapping::SyntaxMapping;
+pub use crate::syntax_mapping::{MappingTarget, SyntaxMapping};
 pub use crate::wrap::OutputWrap;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -60,7 +60,7 @@ pub struct Config<'a> {
     pub theme: String,
 
     /// File extension/name mappings
-    pub syntax_mapping: SyntaxMapping,
+    pub syntax_mapping: SyntaxMapping<'a>,
 
     /// Command to start the pager
     pub pager: Option<&'a str>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ error_chain! {
         Io(::std::io::Error);
         SyntectError(::syntect::LoadingError);
         ParseIntError(::std::num::ParseIntError);
+        GlobParsingError(::globset::Error);
     }
 }
 

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -1,35 +1,85 @@
-use std::borrow::Cow;
-use std::collections::HashMap;
+use std::path::Path;
+
+use crate::errors::Result;
+
+use globset::{Candidate, GlobBuilder, GlobMatcher};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MappingTarget<'a> {
+    MapTo(&'a str),
+    MapToUnknown,
+}
 
 #[derive(Debug, Clone, Default)]
-pub struct SyntaxMapping(HashMap<String, String>);
+pub struct SyntaxMapping<'a> {
+    mappings: Vec<(GlobMatcher, MappingTarget<'a>)>,
+}
 
-impl SyntaxMapping {
-    pub fn new() -> SyntaxMapping {
+impl<'a> SyntaxMapping<'a> {
+    pub fn empty() -> SyntaxMapping<'a> {
         Default::default()
     }
 
-    pub fn insert(&mut self, from: impl Into<String>, to: impl Into<String>) -> Option<String> {
-        self.0.insert(from.into(), to.into())
+    pub fn builtin() -> SyntaxMapping<'a> {
+        let mut mapping = Self::empty();
+        mapping
+            .insert("build", MappingTarget::MapToUnknown)
+            .unwrap();
+
+        mapping
     }
 
-    pub(crate) fn replace<'a>(&self, input: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-        let input = input.into();
-        match self.0.get(input.as_ref()) {
-            Some(s) => Cow::from(s.clone()),
-            None => input,
+    pub fn insert(&mut self, from: &str, to: MappingTarget<'a>) -> Result<()> {
+        let glob = GlobBuilder::new(from)
+            .case_insensitive(false)
+            .literal_separator(true)
+            .build()?;
+        self.mappings.push((glob.compile_matcher(), to));
+        Ok(())
+    }
+
+    pub(crate) fn get_syntax_for(&self, path: impl AsRef<Path>) -> Option<MappingTarget<'a>> {
+        let candidate = Candidate::new(path.as_ref());
+        let canddidate_filename = path.as_ref().file_name().map(Candidate::new);
+        for (ref glob, ref syntax) in &self.mappings {
+            if glob.is_match_candidate(&candidate)
+                || canddidate_filename
+                    .as_ref()
+                    .map_or(false, |filename| glob.is_match_candidate(filename))
+            {
+                return Some(*syntax);
+            }
         }
+        None
     }
 }
 
 #[test]
 fn basic() {
-    let mut map = SyntaxMapping::new();
-    map.insert("Cargo.lock", "toml");
-    map.insert(".ignore", ".gitignore");
+    let mut map = SyntaxMapping::empty();
+    map.insert("/path/to/Cargo.lock", MappingTarget::MapTo("TOML"))
+        .ok();
+    map.insert("/path/to/.ignore", MappingTarget::MapTo("Git Ignore"))
+        .ok();
 
-    assert_eq!("toml", map.replace("Cargo.lock"));
-    assert_eq!("other.lock", map.replace("other.lock"));
+    assert_eq!(
+        map.get_syntax_for("/path/to/Cargo.lock"),
+        Some(MappingTarget::MapTo("TOML"))
+    );
+    assert_eq!(map.get_syntax_for("/path/to/other.lock"), None);
 
-    assert_eq!(".gitignore", map.replace(".ignore"));
+    assert_eq!(
+        map.get_syntax_for("/path/to/.ignore"),
+        Some(MappingTarget::MapTo("Git Ignore"))
+    );
+}
+
+#[test]
+fn builtin_mappings() {
+    let map = SyntaxMapping::builtin();
+
+    assert_eq!(
+        map.get_syntax_for("/path/to/build"),
+        Some(MappingTarget::MapToUnknown)
+    );
 }


### PR DESCRIPTION
This PR changes the way `--map-syntax` works. The option now works like this:
```
--map-syntax <glob-pattern>:<syntax-name>
```
(this is a breaking change, users will have to adapt their config files)

This PR also adds a builtin database of syntax mappings to `bat` to handle cases such as:

* Glob-based lookups for paths:
  * `/proc/cpuinfo` => `CpuInfo syntax`
  * `**/.ssh/config` => `SSHConfig`
  * `/etc/profile` => `Bash`
  * `*.h` => `C++` (I assume this is a better default than "Objective C")
* Files named `build` are no longer mapped to "NAnt Build File" (which should only match `*.build` files). Instead, we use the first-line detection mechanism on such files.

closes #592, closes #685  
see also:  #501