### PR TITLE
Add option to generate a default config file, fixes #870

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,11 @@ non-default location of the configuration file:
 export BAT_CONFIG_PATH="/path/to/bat.conf"
 ```
 
+A default configuration file can be created with the `--generate-config-file` option.
+```bash
+bat --generate-config-file
+```
+
 ### Format
 
 The configuration file is a simple list of command line arguments. Use `bat --help` to see a full list of possible options and values. In addition, you can add comments by prepending a line with the `#` character.

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -371,6 +371,14 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .help("Show path to the configuration file."),
         )
         .arg(
+            Arg::with_name("generate-config-file")
+                .long("generate-config-file")
+                .conflicts_with("list-languages")
+                .conflicts_with("list-themes")
+                .hidden(true)
+                .help("Generates a default configuration file."),
+        )
+        .arg(
             Arg::with_name("config-dir")
                 .long("config-dir")
                 .hidden(true)

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -22,7 +22,7 @@ use std::process;
 use ansi_term::Colour::Green;
 use ansi_term::Style;
 
-use crate::{app::App, config::config_file};
+use crate::{app::App, config::{config_file, generate_config_file}};
 use assets::{assets_from_cache_or_binary, cache_dir, clear_assets, config_dir};
 use bat::Controller;
 use directories::PROJECT_DIRS;
@@ -187,6 +187,10 @@ fn run() -> Result<bool> {
                 Ok(true)
             } else if app.matches.is_present("config-file") {
                 println!("{}", config_file().to_string_lossy());
+
+                Ok(true)
+            } else if app.matches.is_present("generate-config-file") {
+                generate_config_file();
 
                 Ok(true)
             } else if app.matches.is_present("config-dir") {

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -179,19 +179,15 @@ fn run() -> Result<bool> {
 
             if app.matches.is_present("list-languages") {
                 list_languages(&config)?;
-
                 Ok(true)
             } else if app.matches.is_present("list-themes") {
                 list_themes(&config)?;
-
                 Ok(true)
             } else if app.matches.is_present("config-file") {
                 println!("{}", config_file().to_string_lossy());
-
                 Ok(true)
             } else if app.matches.is_present("generate-config-file") {
-                generate_config_file();
-
+                generate_config_file()?;
                 Ok(true)
             } else if app.matches.is_present("config-dir") {
                 writeln!(io::stdout(), "{}", config_dir())?;


### PR DESCRIPTION
I took a shot at implementing the `--generate-config-file` feature request per #870.

This is my 1st foray into Rust so I'm open to feedback/suggestions for improvement.  Also... thoughts on if the default config file content is sufficient or should be modified?

Thanks!