### PR TITLE
Allow using bat-as-a-library with older syntect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-features = false
 features = []
 
 [dependencies.syntect]
-version = "3.3.0"
+version = "3.2.0"
 default-features = false
 features = ["parsing", "yaml-load", "dump-load", "dump-create"]
 


### PR DESCRIPTION
Fixes #896. The "3.2.0" requirement means the same thing as \>=3.2.0 \<4.0.0. This way:

- the bat application will continue using 3.3.0 as per the lockfile;
- bat-as-a-library will pull in the most recent semver compatible version in that range just like before;
- downstream code is free to pin older versions as needed.