### PR TITLE
Strip dependencies of bat-as-a-library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,11 @@ application = [
     "git",
     "lazy_static",
     "liquid",
+    "paging",
     "wild",
 ]
 git = ["git2"] # Support indicating git modifications
+paging = ["shell-words"] # Support applying a pager on the output
 
 [dependencies]
 atty = { version = "0.2.14", optional = true }
@@ -40,7 +42,7 @@ lazy_static = { version = "1.4", optional = true }
 wild = { version = "2.0", optional = true }
 content_inspector = "0.2.4"
 encoding = "0.2"
-shell-words = "0.1.0"
+shell-words = { version = "0.1.0", optional = true }
 unicode-width = "0.1.7"
 globset = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,27 @@ exclude = [
 build = "build.rs"
 edition = '2018'
 
+[features]
+default = ["application"]
+# Feature required for bat the application. Should be disabled when depending on
+# bat as a library.
+application = [
+    "atty",
+    "clap",
+    "dirs",
+    "lazy_static",
+    "liquid",
+    "wild",
+]
+
 [dependencies]
-atty = "0.2.14"
+atty = { version = "0.2.14", optional = true }
 ansi_term = "^0.12.1"
 ansi_colours = "^1.0"
 console = "0.10"
-dirs = "2.0"
-lazy_static = "1.4"
-wild = "2.0"
+dirs = { version = "2.0", optional = true }
+lazy_static = { version = "1.4", optional = true }
+wild = { version = "2.0", optional = true }
 content_inspector = "0.2.4"
 encoding = "0.2"
 shell-words = "0.1.0"
@@ -32,7 +45,6 @@ globset = "0.4"
 [dependencies.git2]
 version = "0.13"
 default-features = false
-features = []
 
 [dependencies.syntect]
 version = "3.3.0"
@@ -41,22 +53,22 @@ features = ["parsing", "yaml-load", "dump-load", "dump-create"]
 
 [dependencies.clap]
 version = "2.33"
+optional = true
 default-features = false
 features = ["suggestions", "color", "wrap_help"]
 
 [dependencies.error-chain]
 version = "0.12"
 default-features = false
-features = []
 
 [dev-dependencies]
 tempdir = "0.3"
 assert_cmd = "0.12.0"
 
 [build-dependencies]
-clap = "2.33"
-liquid = "0.20"
-lazy_static = "1.4"
+clap = { version = "2.33", optional = true }
+liquid = { version = "0.20", optional = true }
+lazy_static = { version = "1.4", optional = true }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ application = [
     "atty",
     "clap",
     "dirs",
+    "git",
     "lazy_static",
     "liquid",
     "wild",
 ]
+git = ["git2"] # Support indicating git modifications
 
 [dependencies]
 atty = { version = "0.2.14", optional = true }
@@ -44,6 +46,7 @@ globset = "0.4"
 
 [dependencies.git2]
 version = "0.13"
+optional = true
 default-features = false
 
 [dependencies.syntect]

--- a/ci/script.bash
+++ b/ci/script.bash
@@ -16,3 +16,4 @@ fi
 # Check bat-as-a-library, which has a smaller set of dependencies
 cargo check --target "$TARGET" --verbose --lib --no-default-features
 cargo check --target "$TARGET" --verbose --lib --no-default-features --features git
+cargo check --target "$TARGET" --verbose --lib --no-default-features --features paging

--- a/ci/script.bash
+++ b/ci/script.bash
@@ -17,3 +17,4 @@ fi
 cargo check --target "$TARGET" --verbose --lib --no-default-features
 cargo check --target "$TARGET" --verbose --lib --no-default-features --features git
 cargo check --target "$TARGET" --verbose --lib --no-default-features --features paging
+cargo check --target "$TARGET" --verbose --lib --no-default-features --features git,paging

--- a/ci/script.bash
+++ b/ci/script.bash
@@ -15,3 +15,4 @@ fi
 
 # Check bat-as-a-library, which has a smaller set of dependencies
 cargo check --target "$TARGET" --verbose --lib --no-default-features
+cargo check --target "$TARGET" --verbose --lib --no-default-features --features git

--- a/ci/script.bash
+++ b/ci/script.bash
@@ -12,3 +12,6 @@ if [[ $TARGET != arm-unknown-linux-gnueabihf ]] && [[ $TARGET != aarch64-unknown
     # Run 'bat' on its own source code and the README
     cargo run --target "$TARGET" -- src/bin/bat/main.rs README.md --paging=never
 fi
+
+# Check bat-as-a-library, which has a smaller set of dependencies
+cargo check --target "$TARGET" --verbose --lib --no-default-features

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -9,12 +9,8 @@ use crate::{
     config::{get_args_from_config_file, get_args_from_env_var},
 };
 use clap::ArgMatches;
-use wild;
 
 use console::Term;
-
-#[cfg(windows)]
-use ansi_term;
 
 use bat::{
     config::{

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -1,4 +1,4 @@
-use clap::{App as ClapApp, AppSettings, Arg, ArgGroup, SubCommand};
+use clap::{crate_name, crate_version, App as ClapApp, AppSettings, Arg, ArgGroup, SubCommand};
 use std::path::Path;
 
 pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -4,8 +4,6 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-use shell_words;
-
 use crate::directories::PROJECT_DIRS;
 
 pub fn config_file() -> PathBuf {

--- a/src/bin/bat/directories.rs
+++ b/src/bin/bat/directories.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-use dirs;
 use lazy_static::lazy_static;
 
 /// Wrapper for 'dirs' that treats MacOS more like Linux, by following the XDG specification.

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -1,11 +1,6 @@
 // `error_chain!` can recurse deeply
 #![recursion_limit = "1024"]
 
-#[macro_use]
-extern crate clap;
-
-extern crate dirs as dirs_rs;
-
 mod app;
 mod assets;
 mod clap_app;

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,14 +5,14 @@ pub use crate::syntax_mapping::{MappingTarget, SyntaxMapping};
 pub use crate::wrap::OutputWrap;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg(feature = "paging")]
 pub enum PagingMode {
-    #[cfg(feature = "paging")]
     Always,
-    #[cfg(feature = "paging")]
     QuitIfOneScreen,
     Never,
 }
 
+#[cfg(feature = "paging")]
 impl Default for PagingMode {
     fn default() -> Self {
         PagingMode::Never
@@ -53,6 +53,7 @@ pub struct Config<'a> {
     pub output_wrap: OutputWrap,
 
     /// Pager or STDOUT
+    #[cfg(feature = "paging")]
     pub paging_mode: PagingMode,
 
     /// Specifies the lines that should be printed

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,9 @@ pub use crate::wrap::OutputWrap;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PagingMode {
+    #[cfg(feature = "paging")]
     Always,
+    #[cfg(feature = "paging")]
     QuitIfOneScreen,
     Never,
 }

--- a/src/decorations.rs
+++ b/src/decorations.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "git")]
 use crate::diff::LineChange;
 use crate::printer::{Colors, InteractivePrinter};
 use ansi_term::Style;
@@ -68,6 +69,7 @@ impl Decoration for LineNumberDecoration {
     }
 }
 
+#[cfg(feature = "git")]
 pub struct LineChangesDecoration {
     cached_none: DecorationText,
     cached_added: DecorationText,
@@ -76,6 +78,7 @@ pub struct LineChangesDecoration {
     cached_modified: DecorationText,
 }
 
+#[cfg(feature = "git")]
 impl LineChangesDecoration {
     #[inline]
     fn generate_cached(style: Style, text: &str) -> DecorationText {
@@ -96,6 +99,7 @@ impl LineChangesDecoration {
     }
 }
 
+#[cfg(feature = "git")]
 impl Decoration for LineChangesDecoration {
     fn generate(
         &self,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "git")]
+
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,57 +2,24 @@ use error_chain::error_chain;
 
 error_chain! {
     foreign_links {
-        Clap(clap::Error);
-        Io(std::io::Error);
-        SyntectError(syntect::LoadingError);
-        ParseIntError(std::num::ParseIntError);
-        GlobParsingError(globset::Error);
+        Clap(::clap::Error) #[cfg(feature = "application")];
+        Io(::std::io::Error);
+        SyntectError(::syntect::LoadingError);
+        ParseIntError(::std::num::ParseIntError);
+        GlobParsingError(::globset::Error);
     }
 }
 
 pub fn default_error_handler(error: &Error) {
     match error {
         Error(ErrorKind::Io(ref io_error), _)
-            if io_error.kind() == std::io::ErrorKind::BrokenPipe =>
+            if io_error.kind() == ::std::io::ErrorKind::BrokenPipe =>
         {
-            std::process::exit(0);
+            ::std::process::exit(0);
         }
         _ => {
             use ansi_term::Colour::Red;
             eprintln!("{}: {}", Red.paint("[bat error]"), error);
         }
     };
-}
-
-// Mock out a type for clap::Error if we aren't pulling in a dependency on clap.
-//
-// This can be removed after migrating away from error_chain to some modern
-// derive-based error library such as thiserror, in favor of:
-//
-//     #[derive(Error)]
-//     pub enum Error {
-//         #[cfg(feature = "application")]
-//         Clap(clap::Error),
-//         ...
-//     }
-//
-#[cfg(not(feature = "application"))]
-mod clap {
-    use std::fmt::{self, Debug, Display};
-
-    pub struct Error(());
-
-    impl Display for Error {
-        fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
-            unreachable!()
-        }
-    }
-
-    impl Debug for Error {
-        fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
-            unreachable!()
-        }
-    }
-
-    impl std::error::Error for Error {}
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,24 +2,57 @@ use error_chain::error_chain;
 
 error_chain! {
     foreign_links {
-        Clap(::clap::Error);
-        Io(::std::io::Error);
-        SyntectError(::syntect::LoadingError);
-        ParseIntError(::std::num::ParseIntError);
-        GlobParsingError(::globset::Error);
+        Clap(clap::Error);
+        Io(std::io::Error);
+        SyntectError(syntect::LoadingError);
+        ParseIntError(std::num::ParseIntError);
+        GlobParsingError(globset::Error);
     }
 }
 
 pub fn default_error_handler(error: &Error) {
     match error {
         Error(ErrorKind::Io(ref io_error), _)
-            if io_error.kind() == ::std::io::ErrorKind::BrokenPipe =>
+            if io_error.kind() == std::io::ErrorKind::BrokenPipe =>
         {
-            ::std::process::exit(0);
+            std::process::exit(0);
         }
         _ => {
             use ansi_term::Colour::Red;
             eprintln!("{}: {}", Red.paint("[bat error]"), error);
         }
     };
+}
+
+// Mock out a type for clap::Error if we aren't pulling in a dependency on clap.
+//
+// This can be removed after migrating away from error_chain to some modern
+// derive-based error library such as thiserror, in favor of:
+//
+//     #[derive(Error)]
+//     pub enum Error {
+//         #[cfg(feature = "application")]
+//         Clap(clap::Error),
+//         ...
+//     }
+//
+#[cfg(not(feature = "application"))]
+mod clap {
+    use std::fmt::{self, Debug, Display};
+
+    pub struct Error(());
+
+    impl Display for Error {
+        fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
+            unreachable!()
+        }
+    }
+
+    impl Debug for Error {
+        fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
+            unreachable!()
+        }
+    }
+
+    impl std::error::Error for Error {}
 }

--- a/src/less.rs
+++ b/src/less.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "paging")]
+
 use std::process::Command;
 
 pub fn retrieve_less_version() -> Option<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,6 @@
 // `error_chain!` can recurse deeply
 #![recursion_limit = "1024"]
 
-extern crate ansi_term;
-extern crate atty;
-extern crate console;
-extern crate content_inspector;
-extern crate dirs as dirs_rs;
-extern crate encoding;
-extern crate git2;
-extern crate shell_words;
-extern crate syntect;
-extern crate wild;
-
 pub(crate) mod assets;
 pub mod config;
 pub(crate) mod controller;

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,6 +2,7 @@ use std::io::{self, Write};
 #[cfg(feature = "paging")]
 use std::process::Child;
 
+#[cfg(feature = "paging")]
 use crate::config::PagingMode;
 use crate::errors::*;
 #[cfg(feature = "paging")]
@@ -15,13 +16,12 @@ pub enum OutputType {
 }
 
 impl OutputType {
+    #[cfg(feature = "paging")]
     pub fn from_mode(mode: PagingMode, pager: Option<&str>) -> Result<Self> {
-        let _ = pager;
+        use self::PagingMode::*;
         Ok(match mode {
-            #[cfg(feature = "paging")]
-            PagingMode::Always => OutputType::try_pager(false, pager)?,
-            #[cfg(feature = "paging")]
-            PagingMode::QuitIfOneScreen => OutputType::try_pager(true, pager)?,
+            Always => OutputType::try_pager(false, pager)?,
+            QuitIfOneScreen => OutputType::try_pager(true, pager)?,
             _ => OutputType::stdout(),
         })
     }
@@ -116,7 +116,7 @@ impl OutputType {
         }
     }
 
-    fn stdout() -> Self {
+    pub(crate) fn stdout() -> Self {
         OutputType::Stdout(io::stdout())
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,8 +4,6 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 
-use shell_words;
-
 use crate::config::PagingMode;
 use crate::errors::*;
 use crate::less::retrieve_less_version;

--- a/src/style.rs
+++ b/src/style.rs
@@ -68,6 +68,7 @@ impl StyleComponents {
         StyleComponents(components.iter().cloned().collect())
     }
 
+    #[cfg(feature = "git")]
     pub fn changes(&self) -> bool {
         self.0.contains(&StyleComponent::Changes)
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,5 +1,3 @@
-extern crate ansi_colours;
-
 use ansi_term::Colour::{Fixed, RGB};
 use ansi_term::{self, Style};
 

--- a/tests/tester.rs
+++ b/tests/tester.rs
@@ -4,13 +4,11 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-extern crate tempdir;
-use self::tempdir::TempDir;
+use tempdir::TempDir;
 
-extern crate git2;
-use self::git2::build::CheckoutBuilder;
-use self::git2::Repository;
-use self::git2::Signature;
+use git2::build::CheckoutBuilder;
+use git2::Repository;
+use git2::Signature;
 
 pub struct BatTester {
     /// Temporary working directory


### PR DESCRIPTION
Fixes #895. This PR introduces a `features = ["application"]` which is enabled by default and pulls in everything required by bat the application. When depending on bat as a library, downstream Cargo.toml should disable this feature to cut out inapplicable heavy dependencies like liquid.

```toml
[dependencies]
bat = { version = "0.13", default-features = false }
```

I've put some other optional functionality behind features as well: paging and git support, neither of which I would want for cargo-expand.