### PR TITLE
Update to syntect 4.1, fancy-regex support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,10 +81,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -131,7 +131,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell-words 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntect 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntect 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wild 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -167,6 +167,19 @@ dependencies = [
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -474,13 +487,22 @@ name = "failure"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fancy-regex"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "flate2"
@@ -575,6 +597,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +619,14 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -894,12 +929,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "plist"
-version = "0.4.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "line-wrap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1169,17 +1204,18 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "3.3.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fancy-regex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "plist 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plist 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1435,12 +1471,14 @@ dependencies = [
 "checksum assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6283bac8dd7226470d491bc4737816fea4ca1fba7a2847f2e9097fd6bfb4624c"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum backtrace 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
-"checksum backtrace-sys 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
+"checksum backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)" = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+"checksum backtrace-sys 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bindgen 0.50.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cb0e5a5f74b2bafe0b39379f616b5975e08bcaca4e779c078d5c31324147e9ba"
+"checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
+"checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -1479,6 +1517,7 @@ dependencies = [
 "checksum escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74cf96bec282dcdb07099f7e31d9fed323bca9435a09aba7b6d99b7617bca96d"
 "checksum failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fancy-regex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b0e2de1b89ad299d536b7cefc5d177f5c005957fa2266ce58eca4d189e74bff5"
 "checksum flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -1490,8 +1529,10 @@ dependencies = [
 "checksum globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+"checksum humantime 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9b6c53306532d3c8e8087b44e6580e10db51a023cf9b433cea2ac38066b92da"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+"checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
@@ -1529,7 +1570,7 @@ dependencies = [
 "checksum pest_generator 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 "checksum pest_meta 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-"checksum plist 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a9f075f6394100e7c105ed1af73fb1859d6fd14e49d4290d578120beb167f"
+"checksum plist 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f219a7232ab1ee6c6d4d59541af1e04052178f818f09e521677cefd11cc3e6e4"
 "checksum predicates 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
 "checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
@@ -1564,7 +1605,7 @@ dependencies = [
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
-"checksum syntect 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "955e9da2455eea5635f7032fc3a229908e6af18c39600313866095e07db0d8b8"
+"checksum syntect 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "274f5e6be6e730e919e4e371dba490cd35cf7401fad41dac4a39a8d88884c731"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,12 @@ application = [
     "liquid",
     "paging",
     "wild",
+    "regex-onig",
 ]
 git = ["git2"] # Support indicating git modifications
 paging = ["shell-words"] # Support applying a pager on the output
+regex-onig = ["syntect/regex-onig"] # Use the "oniguruma" regex engine
+regex-fancy = ["syntect/regex-fancy"] # Use the rust-only "fancy-regex" engine
 
 [dependencies]
 atty = { version = "0.2.14", optional = true }
@@ -52,7 +55,7 @@ optional = true
 default-features = false
 
 [dependencies.syntect]
-version = "3.2.0"
+version = "4.1.0"
 default-features = false
 features = ["parsing", "yaml-load", "dump-load", "dump-create"]
 

--- a/ci/script.bash
+++ b/ci/script.bash
@@ -14,7 +14,7 @@ if [[ $TARGET != arm-unknown-linux-gnueabihf ]] && [[ $TARGET != aarch64-unknown
 fi
 
 # Check bat-as-a-library, which has a smaller set of dependencies
-cargo check --target "$TARGET" --verbose --lib --no-default-features
-cargo check --target "$TARGET" --verbose --lib --no-default-features --features git
-cargo check --target "$TARGET" --verbose --lib --no-default-features --features paging
-cargo check --target "$TARGET" --verbose --lib --no-default-features --features git,paging
+cargo check --target "$TARGET" --verbose --lib --no-default-features --features regex-onig
+cargo check --target "$TARGET" --verbose --lib --no-default-features --features regex-onig,git
+cargo check --target "$TARGET" --verbose --lib --no-default-features --features regex-onig,paging
+cargo check --target "$TARGET" --verbose --lib --no-default-features --features regex-onig,git,paging


### PR DESCRIPTION
This PR updates the `syntect` dependency to 4.1.

It also adds a `regex-onig` feature (enabled for the application) and a `regex-fancy` feature, which can be enabled to use `fancy-regex` as an engine in `syntect`.

With this change, applications which depend on `bat` as a library, can use
``` toml
[dependencies.bat]
version = "…"
default-features = false
features = ["regex-fancy"]
```
to remove the `onig` dependency. The full dependency tree after this update is attached below.

One problem that has not yet been resolved is the included set of syntaxes, which is *not* fully compatible with `regex-fancy` (due to regex rewriting, as described in the [syntect 4.0 release notes](https://github.com/trishume/syntect/releases/tag/v4.0.0)) because it has been built with a version of `bat` that uses `regex-onig`. Fixing this would probably require us to
* build two versions of `bat` (`bat-onig` and `bat-fancy`)
* Adapt `assets/create.sh` to run `bat cache --build …` with both versions, creating two different binary dumps
* Adapt `assets.rs` to read the respective binary, depending on the chosen feature:

https://github.com/sharkdp/bat/blob/3355aeba22948df238c1f7a4495b01e3bcb2bc81/src/assets.rs#L96-L98

Unfortunately, that is currently not possible (with the full syntax set), due to https://github.com/trishume/syntect/issues/287


FYI: @dtolnay 

Full dependency tree when using `features = ["regex-fancy"]`

```
└── bat
    ├── ansi_colours v1.0.1
    │   [build-dependencies]
    │   └── cc v1.0.50
    ├── ansi_term v0.12.1
    ├── console v0.10.0
    │   ├── clicolors-control v1.0.1
    │   │   ├── lazy_static v1.4.0
    │   │   └── libc v0.2.68
    │   ├── lazy_static v1.4.0 (*)
    │   ├── libc v0.2.68 (*)
    │   ├── regex v1.3.6
    │   │   ├── aho-corasick v0.7.10
    │   │   │   └── memchr v2.3.3
    │   │   ├── memchr v2.3.3 (*)
    │   │   ├── regex-syntax v0.6.17
    │   │   └── thread_local v1.0.1
    │   │       └── lazy_static v1.4.0 (*)
    │   ├── termios v0.3.1
    │   │   └── libc v0.2.68 (*)
    │   └── unicode-width v0.1.7
    ├── content_inspector v0.2.4
    │   └── memchr v2.3.3 (*)
    ├── encoding v0.2.33
    │   ├── encoding-index-japanese v1.20141219.5
    │   │   └── encoding_index_tests v0.1.4
    │   ├── encoding-index-korean v1.20141219.5
    │   │   └── encoding_index_tests v0.1.4 (*)
    │   ├── encoding-index-simpchinese v1.20141219.5
    │   │   └── encoding_index_tests v0.1.4 (*)
    │   ├── encoding-index-singlebyte v1.20141219.5
    │   │   └── encoding_index_tests v0.1.4 (*)
    │   └── encoding-index-tradchinese v1.20141219.5
    │       └── encoding_index_tests v0.1.4 (*)
    ├── error-chain v0.12.2
    │   [build-dependencies]
    │   └── version_check v0.9.1
    ├── globset v0.4.5
    │   ├── aho-corasick v0.7.10 (*)
    │   ├── bstr v0.2.12
    │   │   └── memchr v2.3.3 (*)
    │   ├── fnv v1.0.6
    │   ├── log v0.4.8
    │   │   └── cfg-if v0.1.10
    │   └── regex v1.3.6 (*)
    ├── syntect v4.1.0
    │   ├── bincode v1.2.1
    │   │   ├── byteorder v1.3.4
    │   │   └── serde v1.0.105
    │   ├── bitflags v1.2.1
    │   ├── fancy-regex v0.3.3
    │   │   ├── bit-set v0.5.1
    │   │   │   └── bit-vec v0.5.1
    │   │   └── regex v1.3.6 (*)
    │   ├── flate2 v1.0.14
    │   │   ├── cfg-if v0.1.10 (*)
    │   │   ├── crc32fast v1.2.0
    │   │   │   └── cfg-if v0.1.10 (*)
    │   │   ├── libc v0.2.68 (*)
    │   │   └── miniz_oxide v0.3.6
    │   │       └── adler32 v1.0.4
    │   ├── fnv v1.0.6 (*)
    │   ├── lazy_static v1.4.0 (*)
    │   ├── lazycell v1.2.1
    │   ├── plist v0.5.3
    │   │   ├── base64 v0.10.1
    │   │   │   └── byteorder v1.3.4 (*)
    │   │   ├── humantime v2.0.0
    │   │   ├── indexmap v1.3.2
    │   │   │   [build-dependencies]
    │   │   │   └── autocfg v1.0.0
    │   │   ├── line-wrap v0.1.1
    │   │   │   └── safemem v0.3.3
    │   │   ├── serde v1.0.105 (*)
    │   │   └── xml-rs v0.8.1
    │   ├── regex-syntax v0.6.17 (*)
    │   ├── serde v1.0.105 (*)
    │   ├── serde_derive v1.0.105
    │   │   ├── proc-macro2 v1.0.10
    │   │   │   └── unicode-xid v0.2.0
    │   │   ├── quote v1.0.3
    │   │   │   └── proc-macro2 v1.0.10 (*)
    │   │   └── syn v1.0.17
    │   │       ├── proc-macro2 v1.0.10 (*)
    │   │       ├── quote v1.0.3 (*)
    │   │       └── unicode-xid v0.2.0 (*)
    │   ├── serde_json v1.0.50
    │   │   ├── itoa v0.4.5
    │   │   ├── ryu v1.0.3
    │   │   └── serde v1.0.105 (*)
    │   ├── walkdir v2.3.1
    │   │   └── same-file v1.0.6
    │   └── yaml-rust v0.4.3
    │       └── linked-hash-map v0.5.2
    └── unicode-width v0.1.7 (*)
```