### PR TITLE
Factor out writing the output so it can be used in a lib

### DIFF
--- a/examples/capturingoutput.rs
+++ b/examples/capturingoutput.rs
@@ -1,0 +1,39 @@
+/// An example of running as a library and capturing the output.
+/// Here we just print the output, but you could use it in your application.
+use bat::{
+    config::{Config, InputFile, StyleComponent, StyleComponents},
+    errors::default_error_handler,
+    Controller, HighlightingAssets,
+};
+use std::process;
+
+fn main() {
+    let files = std::env::args_os().skip(1).collect::<Vec<_>>();
+
+    if files.is_empty() {
+        eprintln!("No input files specified");
+        process::exit(1);
+    }
+
+    let mut output = Vec::new();
+
+    let config = Config {
+        term_width: 80,
+        colored_output: true, // you can still get coloured output
+        true_color: true,
+        style_components: StyleComponents::new(&[
+            StyleComponent::Numbers,
+        ]),
+        files: files.iter().map(|file| InputFile::Ordinary(file)).collect(),
+        ..Default::default()
+    };
+    let assets = HighlightingAssets::from_binary();
+
+    let no_errors = Controller::new(&config, &assets).run_with_writer(&mut output, default_error_handler);
+    if !no_errors {
+        eprintln!("There were errors!");
+        process::exit(1);
+    }
+
+    println!("{}", String::from_utf8(output).unwrap());
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -19,6 +19,19 @@ impl<'b> Controller<'b> {
         Controller { config, assets }
     }
 
+    pub fn get_output<'a>(&self) -> Result<Vec<u8>> {
+        let stdin = io::stdin();
+
+        let mut buf = Vec::new();
+
+        for input_file in self.config.files.iter() {
+            let mut reader = input_file.get_reader(&stdin)?;
+            while reader.read_line(&mut buf)? {}
+        }
+
+        Ok(buf)
+    }
+
     pub fn run(&self) -> Result<bool> {
         self.run_with_error_handler(default_error_handler)
     }


### PR DESCRIPTION
Hey!

This PR is largely just moving the actual reading/writing logic into a separate function that takes a writer. Going along with the librarizing theme, this allows other libraries to cleanly capture and use the output. I added an example for how this might be used.

I'm not a huge fan of the error handling, but didn't see any better options. It looks like for multiple files, we don't let a single file fail the whole operation. Given that, we can't use standard `Result`s.

I also didn't make with/default error_handler variants. I figure this is a library, people can just pass in the default (it is public, after all). I didn't want to create even more function-nesting.

Let me know what you think -