### PR TITLE
Add script to find slow-to-highlight files

### DIFF
--- a/tests/scripts/find-slow-to-highlight-files.py
+++ b/tests/scripts/find-slow-to-highlight-files.py
@@ -1,9 +1,23 @@
+#!/usr/bin/env python
+#
+# This script goes through all languages that are supported by 'bat'. For each
+# language, it loops over the correspoinding file extensions and searches a
+# given folder for matching files. It calls 'bat' for each of these files and
+# measures the highlighting speed (number of characters per second). The script
+# reports files which lead to slow highlighting speeds or errors during the
+# execution of 'bat'.
+#
+# Requirements (external programs):
+#   - bat (in the $PATH)
+#   - fd (https://github.com/sharkdp/fd)
+#   - wc
+
 import time
 import os
 import subprocess as sp
 
 
-# Threshold speed in chars per second
+# Threshold speed, characters per second
 THRESHOLD_SPEED = 20000
 
 # Maximum time we allow `bat` to run

--- a/tests/scripts/find-slow-to-highlight-files.py
+++ b/tests/scripts/find-slow-to-highlight-files.py
@@ -1,0 +1,101 @@
+import time
+import os
+import subprocess as sp
+
+
+# Threshold speed in chars per second
+THRESHOLD_SPEED = 20000
+
+# Maximum time we allow `bat` to run
+BAT_TIMEOUT_SEC = 10
+
+# Maximum number of files to measure
+MAX_NUM_FILES = 100
+
+# Root folder for the search
+SEARCH_ROOT = os.getenv("HOME")
+
+
+def find_slow_files(startup_time, language, glob_pattern):
+    out = sp.check_output(
+        [
+            "fd",
+            "--hidden",
+            "--no-ignore",
+            "--type=file",
+            "--max-results",
+            str(MAX_NUM_FILES),
+            "--glob",
+            glob_pattern,
+            SEARCH_ROOT,
+        ]
+    )
+
+    paths = out.split(b"\n")[:-1]
+    print(f"Language: {language}, glob pattern: {glob_pattern} ({len(paths)} matches)")
+
+    for path in paths:
+        num_chars = int(sp.check_output(["wc", "-c", path]).split(b" ")[0].decode())
+
+        if num_chars < 500:
+            # It is hard to measure the exact speed for short files
+            continue
+
+        try:
+            start = time.time()
+            sp.check_output(["bat", "--color=always", path], timeout=BAT_TIMEOUT_SEC)
+            duration = time.time() - start - startup_time
+
+            if duration <= 0:
+                continue
+
+            highlighting_speed = num_chars / duration
+
+            if highlighting_speed < THRESHOLD_SPEED:
+                print(f"  {highlighting_speed:10.0f} chars/s:  {path.decode()}")
+
+        except sp.CalledProcessError:
+            print(f"  Error while highlighting file '{path.decode()}'.")
+
+        except sp.TimeoutExpired:
+            if num_chars < THRESHOLD_SPEED * BAT_TIMEOUT_SEC:
+                print(f"  Error: bat timed out on file '{path.decode()}'.")
+            else:
+                print(
+                    f"  Warning: bat timed out on file '{path.decode()} (but the file is large)."
+                )
+
+
+def measure_bat_startup_speed():
+    min_duration = None
+    for _ in range(20):
+        start = time.time()
+        p = sp.Popen(
+            ["bat", "--color=always", "--language=py"], stdin=sp.PIPE, stdout=sp.PIPE
+        )
+        p.communicate(input=b"test")
+        duration = time.time() - start
+
+        if not min_duration or duration < min_duration:
+            min_duration = duration
+
+    return min_duration
+
+
+def main():
+    print("Measuring 'bat' startup speed ... ", flush=True, end="")
+    startup_time = measure_bat_startup_speed()
+    print(f"{startup_time * 1000:.1f} ms")
+
+    output = sp.check_output(["bat", "--list-languages"]).decode()
+
+    for line in output.strip().split("\n"):
+        language, extensions = line.split(":")
+        for ext in extensions.split(","):
+            find_slow_files(startup_time, language, ext)
+            if not ext.startswith("."):
+                find_slow_files(startup_time, language, f"*.{ext}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a script that goes through all languages that are supported by 'bat'. For each language, it loops over the correspoinding file extensions and searches a given folder for matching files. It calls 'bat' for each of these files and measures the highlighting speed (number of characters per second). The script reports files which lead to slow highlighting speeds or errors during the execution of 'bat'.

Here are some results:

- I found a couple of C# `*.cs` files. This was expected and will be fixed in the next release (see #677)
- I found a couple of `*.gemspec` and `*.rake` files (Ruby) which lead to a panic. This is a minified example:
  ```ruby
  <<END_DESC
  Test
  END_DESC
  ```
  Apparently, there is a problem with heredocs in the Ruby syntax: https://github.com/sublimehq/Packages/blob/f36b8f807d5f30d2b8ef639232a9fc5960f550fa/Ruby/Ruby.sublime-syntax#L4-L17
  (note how GitHub also highlights this incorrectly)

  Nevertheless, we obviously shouldn't panic here:
  ```
  thread 'main' panicked at 'regex string should be pre-tested: Error(-208, invalid backref number/name)', /home/shark/.cargo/registry/src/github.com-1ecc6299db9ec823/syntect-4.1.0/src/parsing/regex.rs:70:17
  ```
  For some reason, this was not caught when creating the syntax binary dump where the regex should have been pretested. The offending regex is `^\1$`. Bug ticket: #914 
- I found a `*.vue` file that leads to a panic:
  ```
  thread 'main' panicked at 'Can only call resolve on linked references: ByScope { scope: <source.stylus>, sub_context: None }', /home/shark/.cargo/registry/src/github.com-1ecc6299db9ec823/syntect-4.1.0/src/parsing/syntax_definition.rs:188:18
  ```
  The minified example looks like this:
  ``` vue
  <style lang="stylus">
  </style>
  ```
  Bug ticket: #915 
- I found a couple of files which are highlighted rather slowly, but nothing as drastic as the `Makefile` (#750) and C# (#677) issues