### PR TITLE
Pass '--mouse' to less versions >= 551

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   in the header. This is useful when piping input into `bat`. See #654 (@neuronull).
 - Added a new `--generate-config-file` option to creat an initial configuration file
   at the right place. See #870 (@jmick414)
+- When using `less` version 551 or newer, `bat` will now pass the `--mouse` argument, allowing
+  for (better) mouse scrolling support in some terminals, see #904
 
 ## Bugfixes
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -82,16 +82,28 @@ impl OutputType {
                             p.arg("--quit-if-one-screen");
                         }
 
+                        let less_version = retrieve_less_version();
+
                         // Passing '--no-init' fixes a bug with '--quit-if-one-screen' in older
                         // versions of 'less'. Unfortunately, it also breaks mouse-wheel support.
                         //
                         // See: http://www.greenwoodsoftware.com/less/news.530.html
-                        match retrieve_less_version() {
+                        match less_version {
                             None => {
                                 p.arg("--no-init");
                             }
                             Some(version) if version < 530 => {
                                 p.arg("--no-init");
+                            }
+                            _ => {}
+                        }
+
+                        // Passing '--mouse' allows mouse scrolling in terminals which do not
+                        // support "fake scrolling", see https://github.com/sharkdp/bat/issues/904
+                        // The '--mouse' argument is only supported in less 551 or higher.
+                        match less_version {
+                            Some(version) if version >= 551 => {
+                                p.arg("--mouse");
                             }
                             _ => {}
                         }


### PR DESCRIPTION
When using `less` version 551 or newer, `bat` will now pass the `--mouse` argument, allowing
for (better) mouse scrolling support in some terminals.

closes #904