### PR TITLE
bat --diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,15 @@ matrix:
 
     # Minimum Rust supported channel.
     - os: linux
-      rust: 1.37.0
+      rust: 1.40.0
       env: TARGET=x86_64-unknown-linux-gnu
     - os: linux
-      rust: 1.37.0
+      rust: 1.40.0
       env:
         - TARGET=x86_64-unknown-linux-musl
         - CC_x86_64_unknown_linux_musl=/usr/bin/musl-gcc
     - os: osx
-      rust: 1.37.0
+      rust: 1.40.0
       env: TARGET=x86_64-apple-darwin
 
     # Disable nightly for now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 
 ## Features
+
+- Add a new `--diff` option that can be used to only show lines surrounding
+  Git changes, i.e. added, removed or modified lines. The amount of additional
+  context can be controlled with `--diff-context=N`. See #23 and #940
+
 ## Bugfixes
 ## Other
 ## `bat` as a library

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ binaries are also available: look for archives with `musl` in the file name.
 
 ### From source
 
-If you want to build `bat` from source, you need Rust 1.37 or
+If you want to build `bat` from source, you need Rust 1.40 or
 higher. You can then use `cargo` to build everything:
 
 ```bash

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -15,7 +15,7 @@ use console::Term;
 
 use bat::{
     assets::HighlightingAssets,
-    config::Config,
+    config::{Config, VisibleLines},
     error::*,
     input::Input,
     line_range::{HighlightedLineRanges, LineRange, LineRanges},
@@ -196,13 +196,23 @@ impl App {
                     }
                 })
                 .unwrap_or_else(|| String::from(HighlightingAssets::default_theme())),
-            line_ranges: self
-                .matches
-                .values_of("line-range")
-                .map(|vs| vs.map(LineRange::from).collect())
-                .transpose()?
-                .map(LineRanges::from)
-                .unwrap_or_default(),
+            visible_lines: if self.matches.is_present("diff") {
+                VisibleLines::DiffContext(
+                    self.matches
+                        .value_of("diff-context")
+                        .and_then(|t| t.parse().ok())
+                        .unwrap_or(2),
+                )
+            } else {
+                VisibleLines::Ranges(
+                    self.matches
+                        .values_of("line-range")
+                        .map(|vs| vs.map(LineRange::from).collect())
+                        .transpose()?
+                        .map(LineRanges::from)
+                        .unwrap_or_default(),
+                )
+            },
             style_components,
             syntax_mapping,
             pager: self.matches.value_of("pager"),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -106,6 +106,34 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                             the filename."),
         )
         .arg(
+            Arg::with_name("diff")
+                .long("diff")
+                .help("Only show lines that have been added/removed/modified.")
+                .long_help(
+                    "Only show lines that have been added/removed/modified with respect \
+                     to the Git index. Use --diff-context=N to control how much context you want to see.",
+                ),
+        )
+        .arg(
+            Arg::with_name("diff-context")
+                .long("diff-context")
+                .overrides_with("diff-context")
+                .takes_value(true)
+                .value_name("N")
+                .validator(
+                    |n| {
+                        n.parse::<usize>()
+                            .map_err(|_| "must be a number")
+                            .map(|_| ()) // Convert to Result<(), &str>
+                            .map_err(|e| e.to_string())
+                    }, // Convert to Result<(), String>
+                )
+                .hidden_short_help(true)
+                .long_help(
+                    "Include N lines of context around added/removed/modified lines when using '--diff'.",
+                ),
+        )
+        .arg(
             Arg::with_name("tabs")
                 .long("tabs")
                 .overrides_with("tabs")
@@ -339,6 +367,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .takes_value(true)
                 .number_of_values(1)
                 .value_name("N:M")
+                .conflicts_with("diff")
                 .help("Only print the lines from N to M.")
                 .long_help(
                     "Only print the specified range of lines for each file. \

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,32 @@ use crate::style::StyleComponents;
 use crate::syntax_mapping::SyntaxMapping;
 use crate::wrapping::WrappingMode;
 
+#[derive(Debug, Clone)]
+pub enum VisibleLines {
+    /// Show all lines which are included in the line ranges
+    Ranges(LineRanges),
+
+    #[cfg(feature = "git")]
+    /// Only show lines surrounding added/deleted/modified lines
+    DiffContext(usize),
+}
+
+impl VisibleLines {
+    pub fn diff_context(&self) -> bool {
+        match self {
+            Self::Ranges(_) => false,
+            #[cfg(feature = "git")]
+            Self::DiffContext(_) => true,
+        }
+    }
+}
+
+impl Default for VisibleLines {
+    fn default() -> Self {
+        VisibleLines::Ranges(LineRanges::default())
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Config<'a> {
     /// The explicitly configured language, if any
@@ -39,8 +65,8 @@ pub struct Config<'a> {
     #[cfg(feature = "paging")]
     pub paging_mode: PagingMode,
 
-    /// Specifies the lines that should be printed
-    pub line_ranges: LineRanges,
+    /// Specifies which lines should be printed
+    pub visible_lines: VisibleLines,
 
     /// The syntax highlighting theme
     pub theme: String,
@@ -62,10 +88,7 @@ pub struct Config<'a> {
 fn default_config_should_include_all_lines() {
     use crate::line_range::RangeCheckResult;
 
-    assert_eq!(
-        Config::default().line_ranges.check(17),
-        RangeCheckResult::InRange
-    );
+    assert_eq!(LineRanges::default().check(17), RangeCheckResult::InRange);
 }
 
 #[test]

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -6,7 +6,7 @@ use syntect::parsing::SyntaxReference;
 
 use crate::{
     assets::HighlightingAssets,
-    config::Config,
+    config::{Config, VisibleLines},
     controller::Controller,
     error::Result,
     input::Input,
@@ -205,7 +205,7 @@ impl<'a> PrettyPrinter<'a> {
 
     /// Specify the lines that should be printed (default: all)
     pub fn line_ranges(&mut self, ranges: LineRanges) -> &mut Self {
-        self.config.line_ranges = ranges;
+        self.config.visible_lines = VisibleLines::Ranges(ranges);
         self
     }
 


### PR DESCRIPTION
This PR adds a new `--diff` option that can be used to only show lines close to Git changes, i.e. added, removed or modified lines.

The amount of additional context can be controlled with `--diff-context=N`.

Using this like
``` bash
batdiff() {
    git diff --name-only --diff-filter=d | xargs bat --diff
}
```
essentially results in a version of `git diff` with syntax highlighting (but without being able to see the old version).

![image](https://user-images.githubusercontent.com/4209276/80153173-5c2d3080-85bd-11ea-9fe4-15cb3f7ea032.png)

closes #23