### PR TITLE
Add 'batcat' detection and notice to 'info.sh'

### DIFF
--- a/diagnostics/info.sh
+++ b/diagnostics/info.sh
@@ -217,12 +217,17 @@ _run_module() {
 
 # Tell the user if their executable isn't named "bat".
 if [[ "$BAT" != "bat" ]] && [[ "$1" != '-y' ]]; then
+	trap '_tput rmcup; exit 1' INT
+	_tput smcup
+	_tput clear
+	_tput cup 0 0
 	_tput setaf 1
 	printf "The %s executable on your system is named '%s'.\n%s\n" "bat" "$BAT" \
 		"If your issue is related to installation, please check that this isn't the issue."
 	_tput sgr0
 	printf "Press any key to continue...\n"
 	read -rsn1
+	_tput rmcup
 fi
 
 # Ask for consent.

--- a/diagnostics/info.sh
+++ b/diagnostics/info.sh
@@ -7,10 +7,18 @@ set -o pipefail
 export LC_ALL=C
 export LANG=C
 
-if command -v batcat &> /dev/null; then
-	BAT="batcat"
-else
-	BAT="bat"
+BAT="bat"
+if ! command -v bat &>/dev/null; then
+	if command -v batcat &> /dev/null; then
+		BAT="batcat"
+	else
+		tput setaf 1
+		printf "%s\n%s\n" \
+			"Unable to find a bat executable on your PATH." \
+			"Please ensure that 'bat' exists and is not named something else."
+		tput sgr0
+		exit 1
+	fi
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request changes `info.sh` to detect and use `batcat` if `bat` is unavailable, and also adds a warning if `bat` was not found and `batcat` was. This should help with diagnosing any current and future issues when `bat` was installed through the Debian repository.