### PR TITLE
Allow 'bat' application to built without git feature, remove PrettyPrint git support when feature not enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ## New syntaxes
 ## New themes
 ## `bat` as a library
+
+- `PrettyPrinter::vcs_modification_markers` is no longer available without the `git` feature, see #997 (@eth-p)
+
 ## Packaging
 
 # v0.15.1

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -198,22 +198,23 @@ impl App {
                     }
                 })
                 .unwrap_or_else(|| String::from(HighlightingAssets::default_theme())),
-            visible_lines: if self.matches.is_present("diff") {
-                VisibleLines::DiffContext(
+            visible_lines: match self.matches.is_present("diff") {
+                #[cfg(feature = "git")]
+                true => VisibleLines::DiffContext(
                     self.matches
                         .value_of("diff-context")
                         .and_then(|t| t.parse().ok())
                         .unwrap_or(2),
-                )
-            } else {
-                VisibleLines::Ranges(
+                ),
+
+                _ => VisibleLines::Ranges(
                     self.matches
                         .values_of("line-range")
                         .map(|vs| vs.map(LineRange::from).collect())
                         .transpose()?
                         .map(LineRanges::from)
                         .unwrap_or_default(),
-                )
+                ),
             },
             style_components,
             syntax_mapping,

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -166,6 +166,7 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     /// Whether to show modification markers for VCS changes
+    #[cfg(feature = "git")]
     pub fn vcs_modification_markers(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.vcs_modification_markers = yes;
         self

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -270,6 +270,7 @@ impl<'a> PrettyPrinter<'a> {
             style_components.push(StyleComponent::Snip);
         }
         if self.active_style_components.vcs_modification_markers {
+            #[cfg(feature = "git")]
             style_components.push(StyleComponent::Changes);
         }
         self.config.style_components = StyleComponents::new(&style_components);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -111,8 +111,7 @@ impl<'a> InteractivePrinter<'a> {
         config: &'a Config,
         assets: &'a HighlightingAssets,
         input: &mut OpenedInput,
-        #[cfg(feature = "git")]
-        line_changes: &'a Option<LineChanges>,
+        #[cfg(feature = "git")] line_changes: &'a Option<LineChanges>,
     ) -> Self {
         let theme = assets.get_theme(&config.theme);
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -6,6 +6,7 @@ use crate::error::*;
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum StyleComponent {
     Auto,
+    #[cfg(feature = "git")]
     Changes,
     Grid,
     Header,
@@ -25,12 +26,14 @@ impl StyleComponent {
                     StyleComponent::Plain.components(interactive_terminal)
                 }
             }
+            #[cfg(feature = "git")]
             StyleComponent::Changes => &[StyleComponent::Changes],
             StyleComponent::Grid => &[StyleComponent::Grid],
             StyleComponent::Header => &[StyleComponent::Header],
             StyleComponent::LineNumbers => &[StyleComponent::LineNumbers],
             StyleComponent::Snip => &[StyleComponent::Snip],
             StyleComponent::Full => &[
+                #[cfg(feature = "git")]
                 StyleComponent::Changes,
                 StyleComponent::Grid,
                 StyleComponent::Header,
@@ -48,6 +51,7 @@ impl FromStr for StyleComponent {
     fn from_str(s: &str) -> Result<Self> {
         match s {
             "auto" => Ok(StyleComponent::Auto),
+            #[cfg(feature = "git")]
             "changes" => Ok(StyleComponent::Changes),
             "grid" => Ok(StyleComponent::Grid),
             "header" => Ok(StyleComponent::Header),


### PR DESCRIPTION
This pull request changes two things:

1. *(bat-as-a-library; breaking change)*
When the `git` feature is not enabled, it removes `PrettyPrinter::vcs_modification_markers`. This function was previously being exposed when the feature was disabled, despite not having any effect when used.

2. *(bat)*
Adds `cfg` flags to allow the `bat` application to build without requiring the `git` feature. This would allow people to build `bat` without git support if they don't feel they would need or use it.
Caveats: Unfortunately, disabling the feature doesn't change the help text or generated manpage.