### PR TITLE
Make InputDescription into API, remove special input kind for theme previews.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 - `PrettyPrinter::vcs_modification_markers` has been marked deprecated when building without the `git` feature, see #997 and #1020 (@eth-p, @sharkdp)
 - Add APIs to provide `Input` descriptions with `InputDescription` (@eth-p)
+- Add function to directly provide `Input`s to `PrettyPrinter` (@eth-p)
 
 ## Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 ## `bat` as a library
 
 - `PrettyPrinter::vcs_modification_markers` has been marked deprecated when building without the `git` feature, see #997 and #1020 (@eth-p, @sharkdp)
+- Add APIs to provide `Input` descriptions with `InputDescription` (@eth-p)
 
 ## Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 ## New syntaxes
 ## New themes
 ## `bat` as a library
+
+- Add APIs to provide `Input` descriptions with `InputDescription` (@eth-p)
+- Add function to directly provide `Input`s to `PrettyPrinter` (@eth-p)
+- <font color="red">`Input::theme_preview_file` is no longer available.</font> (@eth-p)
+
+Changes colored <font color="red">red</font> are breaking changes.
+
 ## Packaging
 
 # v0.15.4
@@ -46,11 +53,6 @@
 ## `bat` as a library
 
 - `PrettyPrinter::vcs_modification_markers` has been marked deprecated when building without the `git` feature, see #997 and #1020 (@eth-p, @sharkdp)
-- Add APIs to provide `Input` descriptions with `InputDescription` (@eth-p)
-- Add function to directly provide `Input`s to `PrettyPrinter` (@eth-p)
-- <font color="red">`Input::theme_preview_file` is no longer available.</font> (@eth-p)
-
-Changes colored <font color="red">red</font> are breaking changes.
 
 ## Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@
 
 - Add APIs to provide `Input` descriptions with `InputDescription` (@eth-p)
 - Add function to directly provide `Input`s to `PrettyPrinter` (@eth-p)
-- <font color="red">`Input::theme_preview_file` is no longer available.</font> (@eth-p)
-
-Changes colored <font color="red">red</font> are breaking changes.
+- **Breaking:** `Input::theme_preview_file` is no longer available. (@eth-p)
 
 ## Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
 - `PrettyPrinter::vcs_modification_markers` has been marked deprecated when building without the `git` feature, see #997 and #1020 (@eth-p, @sharkdp)
 - Add APIs to provide `Input` descriptions with `InputDescription` (@eth-p)
 - Add function to directly provide `Input`s to `PrettyPrinter` (@eth-p)
+- <font color="red">`Input::theme_preview_file` is no longer available.</font> (@eth-p)
+
+Changes colored <font color="red">red</font> are breaking changes.
 
 ## Packaging
 

--- a/examples/inputs.rs
+++ b/examples/inputs.rs
@@ -9,9 +9,9 @@ fn main() {
         .line_numbers(true)
         .inputs(vec![
             Input::from_bytes(b"echo 'Hello World!'")
-                .name("embedded.sh")
-                .title("An embedded shell script.")
-                .kind("Embedded"),
+                .name("embedded.sh") // Dummy name provided to detect the syntax.
+                .kind("Embedded")
+                .title("An embedded shell script."),
             Input::from_stdin().title("Standard Input").kind("FD"),
         ])
         .print()

--- a/examples/inputs.rs
+++ b/examples/inputs.rs
@@ -1,0 +1,19 @@
+/// A small demonstration of the Input API.
+/// This prints embedded bytes with a custom header and then reads from STDIN.
+use bat::{Input, PrettyPrinter};
+
+fn main() {
+    PrettyPrinter::new()
+        .header(true)
+        .grid(true)
+        .line_numbers(true)
+        .inputs(vec![
+            Input::from_bytes(b"echo 'Hello World!'")
+                .name("embedded.sh")
+                .title("An embedded shell script.")
+                .kind("Embedded"),
+            Input::from_stdin().title("Standard Input").kind("FD"),
+        ])
+        .print()
+        .unwrap();
+}

--- a/examples/yaml.rs
+++ b/examples/yaml.rs
@@ -1,5 +1,5 @@
 /// A program that serializes a Rust structure to YAML and pretty-prints the result
-use bat::PrettyPrinter;
+use bat::{Input, PrettyPrinter};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -29,7 +29,7 @@ fn main() {
         .line_numbers(true)
         .grid(true)
         .header(true)
-        .input_from_bytes_with_name(&bytes, "person.yaml")
+        .input(Input::from_bytes(&bytes).name("person.yaml").kind("File"))
         .print()
         .unwrap();
 }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -193,11 +193,7 @@ impl HighlightingAssets {
         input: &mut OpenedInput,
         mapping: &SyntaxMapping,
     ) -> Result<&SyntaxReference> {
-        if input.kind.is_theme_preview_file() {
-            self.syntax_set
-                .find_syntax_by_name("Rust")
-                .ok_or_else(|| ErrorKind::UnknownSyntax("Rust".to_owned()).into())
-        } else if let Some(language) = language {
+        if let Some(language) = language {
             self.syntax_set
                 .find_syntax_by_token(language)
                 .ok_or_else(|| ErrorKind::UnknownSyntax(language.to_owned()).into())

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -257,7 +257,7 @@ impl App {
         let files: Option<Vec<&OsStr>> = self.matches.values_of_os("FILE").map(|vs| vs.collect());
 
         if files.is_none() {
-            let input = Input::stdin().as_file(filenames_or_none.next().unwrap_or(None));
+            let input = Input::stdin_as_file(filenames_or_none.next().unwrap_or(None));
             return Ok(vec![input]);
         }
         let files_or_none: Box<dyn Iterator<Item = _>> = match files {
@@ -269,9 +269,9 @@ impl App {
         for (filepath, provided_name) in files_or_none.zip(filenames_or_none) {
             if let Some(filepath) = filepath {
                 if filepath.to_str().unwrap_or_default() == "-" {
-                    file_input.push(Input::stdin().as_file(provided_name));
+                    file_input.push(Input::stdin_as_file(provided_name));
                 } else {
-                    file_input.push(Input::ordinary_file(filepath).as_file(provided_name));
+                    file_input.push(Input::ordinary_file(filepath).with_name(provided_name));
                 }
             }
         }

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -257,7 +257,7 @@ impl App {
         let files: Option<Vec<&OsStr>> = self.matches.values_of_os("FILE").map(|vs| vs.collect());
 
         if files.is_none() {
-            let input = Input::stdin().with_name(filenames_or_none.next().unwrap_or(None));
+            let input = Input::stdin().as_file(filenames_or_none.next().unwrap_or(None));
             return Ok(vec![input]);
         }
         let files_or_none: Box<dyn Iterator<Item = _>> = match files {
@@ -269,9 +269,9 @@ impl App {
         for (filepath, provided_name) in files_or_none.zip(filenames_or_none) {
             if let Some(filepath) = filepath {
                 if filepath.to_str().unwrap_or_default() == "-" {
-                    file_input.push(Input::stdin().with_name(provided_name));
+                    file_input.push(Input::stdin().as_file(provided_name));
                 } else {
-                    file_input.push(Input::ordinary_file(filepath).with_name(provided_name));
+                    file_input.push(Input::ordinary_file(filepath).as_file(provided_name));
                 }
             }
         }

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -13,6 +13,7 @@ use clap::ArgMatches;
 
 use console::Term;
 
+use crate::input::{new_file_input, new_stdin_input};
 use bat::{
     assets::HighlightingAssets,
     config::{Config, VisibleLines},
@@ -257,8 +258,9 @@ impl App {
         let files: Option<Vec<&OsStr>> = self.matches.values_of_os("FILE").map(|vs| vs.collect());
 
         if files.is_none() {
-            let input = Input::stdin_as_file(filenames_or_none.next().unwrap_or(None));
-            return Ok(vec![input]);
+            return Ok(vec![new_stdin_input(
+                filenames_or_none.next().unwrap_or(None),
+            )]);
         }
         let files_or_none: Box<dyn Iterator<Item = _>> = match files {
             Some(ref files) => Box::new(files.iter().map(|name| Some(*name))),
@@ -269,9 +271,9 @@ impl App {
         for (filepath, provided_name) in files_or_none.zip(filenames_or_none) {
             if let Some(filepath) = filepath {
                 if filepath.to_str().unwrap_or_default() == "-" {
-                    file_input.push(Input::stdin_as_file(provided_name));
+                    file_input.push(new_stdin_input(provided_name));
                 } else {
-                    file_input.push(Input::ordinary_file(filepath).with_name(provided_name));
+                    file_input.push(new_file_input(filepath, provided_name));
                 }
             }
         }

--- a/src/bin/bat/input.rs
+++ b/src/bin/bat/input.rs
@@ -1,0 +1,20 @@
+use bat::input::Input;
+use std::ffi::OsStr;
+
+pub fn new_file_input<'a>(file: &'a OsStr, name: Option<&'a OsStr>) -> Input<'a> {
+    named(Input::ordinary_file(file), name.or_else(|| Some(file)))
+}
+
+pub fn new_stdin_input(name: Option<&OsStr>) -> Input {
+    named(Input::stdin(), name)
+}
+
+fn named<'a>(input: Input<'a>, name: Option<&OsStr>) -> Input<'a> {
+    if let Some(provided_name) = name {
+        let mut input = input.with_name(Some(provided_name));
+        input.description_mut().set_kind(Some("File".to_owned()));
+        input
+    } else {
+        input
+    }
+}

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -10,7 +10,7 @@ mod directories;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::io;
-use std::io::Write;
+use std::io::{BufReader, Write};
 use std::path::Path;
 use std::process;
 
@@ -25,6 +25,7 @@ use assets::{assets_from_cache_or_binary, cache_dir, clear_assets, config_dir};
 use clap::crate_version;
 use directories::PROJECT_DIRS;
 
+use bat::input::InputDescription;
 use bat::{
     assets::HighlightingAssets,
     config::Config,
@@ -33,6 +34,8 @@ use bat::{
     input::Input,
     style::{StyleComponent, StyleComponents},
 };
+
+const THEME_PREVIEW_DATA: &[u8] = include_bytes!("../../../assets/theme_preview.rs");
 
 fn run_cache_subcommand(matches: &clap::ArgMatches) -> Result<()> {
     if matches.is_present("build") {
@@ -118,6 +121,12 @@ pub fn list_languages(config: &Config) -> Result<()> {
     Ok(())
 }
 
+fn theme_preview_file<'a>() -> Input<'a> {
+    Input::from_reader(Box::new(BufReader::new(THEME_PREVIEW_DATA)))
+        .with_name(Some("theme.rs".as_ref()))
+        .with_description(Some(InputDescription::new("")))
+}
+
 pub fn list_themes(cfg: &Config) -> Result<()> {
     let assets = assets_from_cache_or_binary()?;
     let mut config = cfg.clone();
@@ -137,7 +146,7 @@ pub fn list_themes(cfg: &Config) -> Result<()> {
             )?;
             config.theme = theme.to_string();
             Controller::new(&config, &assets)
-                .run(vec![Input::theme_preview_file()])
+                .run(vec![theme_preview_file()])
                 .ok();
             writeln!(stdout)?;
         }

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -130,6 +130,7 @@ pub fn list_themes(cfg: &Config) -> Result<()> {
     let mut config = cfg.clone();
     let mut style = HashSet::new();
     style.insert(StyleComponent::Plain);
+    config.language = Some("Rust");
     config.style_components = StyleComponents(style);
 
     let stdout = io::stdout();

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -122,7 +122,6 @@ pub fn list_languages(config: &Config) -> Result<()> {
 
 fn theme_preview_file<'a>() -> Input<'a> {
     Input::from_reader(Box::new(BufReader::new(THEME_PREVIEW_DATA)))
-        .with_name(Some("theme.rs".as_ref()))
 }
 
 pub fn list_themes(cfg: &Config) -> Result<()> {

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -6,6 +6,7 @@ mod assets;
 mod clap_app;
 mod config;
 mod directories;
+mod input;
 
 use std::collections::HashSet;
 use std::ffi::OsStr;

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -25,7 +25,6 @@ use assets::{assets_from_cache_or_binary, cache_dir, clear_assets, config_dir};
 use clap::crate_version;
 use directories::PROJECT_DIRS;
 
-use bat::input::InputDescription;
 use bat::{
     assets::HighlightingAssets,
     config::Config,
@@ -124,7 +123,6 @@ pub fn list_languages(config: &Config) -> Result<()> {
 fn theme_preview_file<'a>() -> Input<'a> {
     Input::from_reader(Box::new(BufReader::new(THEME_PREVIEW_DATA)))
         .with_name(Some("theme.rs".as_ref()))
-        .with_description(Some(InputDescription::new("")))
 }
 
 pub fn list_themes(cfg: &Config) -> Result<()> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -125,17 +125,6 @@ impl<'a> Input<'a> {
         }
     }
 
-    pub fn stdin_as_file(name: Option<impl AsRef<OsStr>>) -> Self {
-        match name {
-            None => Input::stdin(),
-            Some(name) => {
-                let mut input = Input::stdin().with_name(Some(name.as_ref()));
-                input.description.kind = Some("File".to_owned());
-                input
-            }
-        }
-    }
-
     pub fn from_reader(reader: Box<dyn Read + 'a>) -> Self {
         let kind = InputKind::CustomReader(reader);
         Input {

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,7 +18,7 @@ pub struct InputDescription {
 impl InputDescription {
     /// Creates a description for an input.
     ///
-    /// The name should uniquely describes where the input came from (e.g. "README.md")
+    /// The name should describe where the input came from (e.g. "README.md")
     pub fn new(name: impl Into<String>) -> Self {
         InputDescription {
             name: name.into(),

--- a/src/input.rs
+++ b/src/input.rs
@@ -125,6 +125,17 @@ impl<'a> Input<'a> {
         }
     }
 
+    pub fn stdin_as_file(name: Option<impl AsRef<OsStr>>) -> Self {
+        match name {
+            None => Input::stdin(),
+            Some(name) => {
+                let mut input = Input::stdin().with_name(Some(name.as_ref()));
+                input.description.kind = Some("File".to_owned());
+                input
+            }
+        }
+    }
+
     pub fn from_reader(reader: Box<dyn Read + 'a>) -> Self {
         let kind = InputKind::CustomReader(reader);
         Input {
@@ -150,11 +161,6 @@ impl<'a> Input<'a> {
 
         self.metadata.user_provided_name = provided_name.map(|n| n.to_owned());
         self
-    }
-
-    pub fn as_file(mut self, provided_name: Option<&OsStr>) -> Self {
-        self.description.kind = Some("File".to_owned());
-        self.with_name(provided_name)
     }
 
     pub fn description(&self) -> &InputDescription {

--- a/src/input.rs
+++ b/src/input.rs
@@ -35,15 +35,15 @@ impl InputDescription {
         }
     }
 
-    pub fn set_kind(&mut self, kind: Option<String>) -> () {
+    pub fn set_kind(&mut self, kind: Option<String>) {
         self.kind = kind;
     }
 
-    pub fn set_summary(&mut self, summary: Option<String>) -> () {
+    pub fn set_summary(&mut self, summary: Option<String>) {
         self.summary = summary;
     }
 
-    pub fn set_title(&mut self, title: Option<String>) -> () {
+    pub fn set_title(&mut self, title: Option<String>) {
         self.title = title;
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,10 +8,17 @@ use crate::error::*;
 
 const THEME_PREVIEW_FILE: &[u8] = include_bytes!("../assets/theme_preview.rs");
 
+/// A description for an Input source.
+/// This tells bat how to refer to the input.
 #[derive(Debug, Clone)]
 pub(crate) struct InputDescription {
+    /// The name of the input used when printing warnings.
     pub full: String,
+
+    /// The prefix string for the input when displaying it in the header.
     pub prefix: String,
+
+    /// The name of the input.
     pub name: String,
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,8 +6,6 @@ use content_inspector::{self, ContentType};
 
 use crate::error::*;
 
-const THEME_PREVIEW_FILE: &[u8] = include_bytes!("../assets/theme_preview.rs");
-
 /// A description of an Input source.
 /// This tells bat how to refer to the input.
 #[derive(Clone)]
@@ -62,7 +60,6 @@ impl InputDescription {
 pub(crate) enum InputKind<'a> {
     OrdinaryFile(OsString),
     StdIn,
-    ThemePreviewFile,
     CustomReader(Box<dyn Read + 'a>),
 }
 
@@ -73,7 +70,6 @@ impl<'a> InputKind<'a> {
                 InputDescription::new(path.to_string_lossy()).with_kind(Some("File"))
             }
             InputKind::StdIn => InputDescription::new("STDIN"),
-            InputKind::ThemePreviewFile => InputDescription::new(""),
             InputKind::CustomReader(_) => InputDescription::new("READER"),
         }
     }
@@ -93,17 +89,7 @@ pub struct Input<'a> {
 pub(crate) enum OpenedInputKind {
     OrdinaryFile(OsString),
     StdIn,
-    ThemePreviewFile,
     CustomReader,
-}
-
-impl OpenedInputKind {
-    pub(crate) fn is_theme_preview_file(&self) -> bool {
-        match self {
-            OpenedInputKind::ThemePreviewFile => true,
-            _ => false,
-        }
-    }
 }
 
 pub(crate) struct OpenedInput<'a> {
@@ -125,14 +111,6 @@ impl<'a> Input<'a> {
     pub fn stdin() -> Self {
         Input {
             kind: InputKind::StdIn,
-            metadata: InputMetadata::default(),
-            description: None,
-        }
-    }
-
-    pub fn theme_preview_file() -> Self {
-        Input {
-            kind: InputKind::ThemePreviewFile,
             metadata: InputMetadata::default(),
             description: None,
         }
@@ -195,12 +173,6 @@ impl<'a> Input<'a> {
                     }
                     InputReader::new(BufReader::new(file))
                 },
-            }),
-            InputKind::ThemePreviewFile => Ok(OpenedInput {
-                kind: OpenedInputKind::ThemePreviewFile,
-                description,
-                metadata: self.metadata,
-                reader: InputReader::new(THEME_PREVIEW_FILE),
             }),
             InputKind::CustomReader(reader) => Ok(OpenedInput {
                 description,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub(crate) mod syntax_mapping;
 mod terminal;
 pub(crate) mod wrapping;
 
-pub use pretty_printer::PrettyPrinter;
+pub use pretty_printer::{Input, PrettyPrinter};
 pub use syntax_mapping::{MappingTarget, SyntaxMapping};
 pub use wrapping::WrappingMode;
 

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -55,6 +55,12 @@ impl<'a> PrettyPrinter<'a> {
         }
     }
 
+    /// Add an input which should be pretty-printed
+    pub fn input(&mut self, input: Input<'a>) -> &mut Self {
+        self.inputs.push(input);
+        self
+    }
+
     /// Add a file which should be pretty-printed
     pub fn input_file(&mut self, path: impl AsRef<OsStr>) -> &mut Self {
         self.inputs.push(Input::ordinary_file(path.as_ref()));

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -310,6 +310,7 @@ impl<'a> PrettyPrinter<'a> {
     }
 }
 
+/// An input source for the pretty printer.
 pub struct Input<'a> {
     input: BatInput<'a>,
 }
@@ -343,7 +344,6 @@ impl<'a> Input<'a> {
     }
 
     /// The description for the type of input (e.g. "File")
-    /// This defaults to "File" for files, and nothing for other inputs.
     pub fn kind(mut self, kind: impl Into<String>) -> Self {
         let kind = kind.into();
         self.input

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{Config, VisibleLines},
     controller::Controller,
     error::Result,
-    input::Input as BatInput,
+    input,
     line_range::{HighlightedLineRanges, LineRange, LineRanges},
     style::{StyleComponent, StyleComponents},
     SyntaxMapping, WrappingMode,
@@ -312,18 +312,18 @@ impl<'a> PrettyPrinter<'a> {
 
 /// An input source for the pretty printer.
 pub struct Input<'a> {
-    input: BatInput<'a>,
+    input: input::Input<'a>,
 }
 
 impl<'a> Input<'a> {
     /// A new input from a reader.
     pub fn from_reader<R: Read + 'a>(reader: R) -> Self {
-        BatInput::from_reader(Box::new(reader)).into()
+        input::Input::from_reader(Box::new(reader)).into()
     }
 
     /// A new input from a file.
     pub fn from_file(path: impl AsRef<OsStr>) -> Self {
-        BatInput::ordinary_file(path.as_ref()).into()
+        input::Input::ordinary_file(path.as_ref()).into()
     }
 
     /// A new input from bytes.
@@ -333,7 +333,7 @@ impl<'a> Input<'a> {
 
     /// A new input from STDIN.
     pub fn from_stdin() -> Self {
-        BatInput::stdin().into()
+        input::Input::stdin().into()
     }
 
     /// The filename of the input.
@@ -360,14 +360,14 @@ impl<'a> Input<'a> {
     }
 }
 
-impl<'a> Into<Input<'a>> for BatInput<'a> {
+impl<'a> Into<Input<'a>> for input::Input<'a> {
     fn into(self) -> Input<'a> {
         Input { input: self }
     }
 }
 
-impl<'a> Into<BatInput<'a>> for Input<'a> {
-    fn into(self) -> BatInput<'a> {
+impl<'a> Into<input::Input<'a>> for Input<'a> {
+    fn into(self) -> input::Input<'a> {
         self.input
     }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -249,7 +249,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
                      (but will be present if the output of 'bat' is piped). You can use 'bat -A' \
                      to show the binary file contents.",
                     Yellow.paint("[bat warning]"),
-                    input.description().full,
+                    input.description.summary(),
                 )?;
             } else if self.config.style_components.grid() {
                 self.print_horizontal_line(handle, '┬')?;
@@ -283,13 +283,16 @@ impl<'a> Printer for InteractivePrinter<'a> {
             _ => "",
         };
 
-        let description = input.description();
+        let description = &input.description;
 
         writeln!(
             handle,
             "{}{}{}",
-            description.prefix,
-            self.colors.filename.paint(&description.name),
+            description
+                .kind()
+                .map(|kind| format!("{}: ", kind))
+                .unwrap_or("".into()),
+            self.colors.filename.paint(description.name()),
             mode
         )?;
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -292,7 +292,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
                 .kind()
                 .map(|kind| format!("{}: ", kind))
                 .unwrap_or("".into()),
-            self.colors.filename.paint(description.name()),
+            self.colors.filename.paint(description.title()),
             mode
         )?;
 


### PR DESCRIPTION
This pull request refactors the `InputDescription` struct into something consumable in a public API, and removes all special handling for the themes preview file.

## Example

```rust
PrettyPrinter::new()
    .grid(true)
    .header(true)
    .input(
        Input::from_reader(Box::new(BufReader::new("Hello world!\n".as_bytes())))
            .with_description(Some(
                InputDescription::new("String")
                    .with_kind(Some("built-in")),
            )),
    )
    .print()
    .unwrap();
```

![image](https://user-images.githubusercontent.com/32112321/82104666-9aa1a100-96cc-11ea-8ae4-ad9039322dd8.png)

## Breaking Changes
- `InputKind::ThemePreviewFile` no longer exists.