### PR TITLE
WIP: Add Input::from_string and Input::from_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## `bat` as a library
 
 - `PrettyPrinter::vcs_modification_markers` is no longer available without the `git` feature, see #997 (@eth-p)
+- Add `Input::from_string` and `Input::from_bytes` functions (@eth-p)
 
 ## Packaging
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -83,6 +83,14 @@ impl<'a> Input<'a> {
         }
     }
 
+    pub fn from_string(string: impl Into<&'a str>) -> Self {
+        Input::from_reader(Box::new(BufReader::new(string.into().as_bytes())))
+    }
+
+    pub fn from_bytes(bytes: impl Into<&'a [u8]>) -> Self {
+        Input::from_reader(Box::new(BufReader::new(bytes.into())))
+    }
+
     pub fn is_stdin(&self) -> bool {
         if let InputKind::StdIn = self.kind {
             true


### PR DESCRIPTION
This pull request adds `Input::from_string` and `Input::from_bytes`. It won't have any practical use until #1002 is merged, and as such should be merged after.