### PR TITLE
Refactor HighlightingAssets::get_syntax to return Result type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - `--map-syntax` doesn't work with names provided through `--file-name` (@eth-p) 
 
 ## Other
+
+- bat now prints an error if an invalid syntax is specified (@sharkdp)
+
 ## New syntaxes
 ## New themes
 ## `bat` as a library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@
 ## Bugfixes
 
 - bat mishighlights Users that start with digits in SSH config, see #984
-- `--map-syntax` doesn't work with names provided through `--file-name` (@eth-p) 
+- `--map-syntax` doesn't work with names provided through `--file-name` (@eth-p)
 
 ## Other
 
-- bat now prints an error if an invalid syntax is specified (@sharkdp)
+- bat now prints an error if an invalid syntax is specified via `-l` or `--map-syntax`, see #1004 (@eth-p)
 
 ## New syntaxes
 ## New themes

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -121,7 +121,7 @@ impl<'b> Controller<'b> {
                             &mut opened_input,
                             #[cfg(feature = "git")]
                             &line_changes,
-                        ))
+                        )?)
                     };
 
                     let result = self.print_file(

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,17 @@ error_chain! {
         GlobParsingError(::globset::Error);
         SerdeYamlError(::serde_yaml::Error);
     }
+
+    errors {
+        UndetectedSyntax(input: String) {
+            description("unable to detect syntax"),
+            display("unable to detect syntax for {}", input)
+        }
+        UnknownSyntax(name: String) {
+            description("unknown syntax"),
+            display("unknown syntax: '{}'", name)
+        }
+    }
 }
 
 pub fn default_error_handler(error: &Error, output: &mut dyn Write) {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -164,7 +164,10 @@ impl<'a> InteractivePrinter<'a> {
             None
         } else {
             // Determine the type of syntax for highlighting
-            let syntax = assets.get_syntax(config.language, input, &config.syntax_mapping);
+            let syntax = assets
+                .get_syntax(config.language, input, &config.syntax_mapping)
+                .unwrap_or_else(|_| assets.syntax_set.find_syntax_plain_text());
+
             Some(HighlightLines::new(syntax, theme))
         };
 


### PR DESCRIPTION
That's one less TODO :)

I split it into two different `ErrorKind`s, in case we ever want to differentiate between a user providing an invalid syntax name, or `bat` not being able to determine the correct syntax.