### PR TITLE
Make 'vcs_modification_markers' change non-breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,8 @@
 - SML, see #1005 (@kopecs)
 
 ## New themes
-## `bat` as a library
 
-- `PrettyPrinter::vcs_modification_markers` is no longer available without the `git` feature, see #997 (@eth-p)
+## `bat` as a library
 
 ## Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ## `bat` as a library
 
+- `PrettyPrinter::vcs_modification_markers` has been marked deprecated when building without the `git` feature, see #997 and #1020 (@eth-p, @sharkdp)
+
 ## Packaging
 
 - Compilation problems with `onig_sys` on various platforms have been resolved by upgrading to `syntect 4.2`, which includes a new `onig` version that allows to build `onig_sys` without the `bindgen` dependency. This removes the need for `libclang(-dev)` to be installed to compile `bat`. Package maintainers might want to remove `clang` as a build dependency. See #650 for more details.

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -167,6 +167,14 @@ impl<'a> PrettyPrinter<'a> {
 
     /// Whether to show modification markers for VCS changes. This has no effect if
     /// the `git` feature is not activated.
+    #[cfg_attr(
+        not(feature = "git"),
+        deprecated(
+            note = "Using vcs_modification_markers without the 'git' feature has no effect. \
+                    The function will be removed (for non-'git' use cases) in the future."
+        )
+    )]
+    #[allow(unused_variables)]
     pub fn vcs_modification_markers(&mut self, yes: bool) -> &mut Self {
         #[cfg(feature = "git")]
         {

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -165,10 +165,13 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
-    /// Whether to show modification markers for VCS changes
-    #[cfg(feature = "git")]
+    /// Whether to show modification markers for VCS changes. This has no effect if
+    /// the `git` feature is not activated.
     pub fn vcs_modification_markers(&mut self, yes: bool) -> &mut Self {
-        self.active_style_components.vcs_modification_markers = yes;
+        #[cfg(feature = "git")]
+        {
+            self.active_style_components.vcs_modification_markers = yes;
+        }
         self
     }
 


### PR DESCRIPTION
I'd like to release a new version of `bat` without breaking changes in the library. @eth-p what do you think?

We could still remove it later when introducing other breaking changes as well.