### PR TITLE
Add support for NO_COLOR env var (#1021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # unreleased
 
 ## Features
+
+- Added support for the `NO_COLOR` environment variable, see #1021 and #1031 (@eth-p)
+
 ## Bugfixes
 ## Other
 ## New syntaxes

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -165,7 +165,7 @@ impl App {
             colored_output: match self.matches.value_of("color") {
                 Some("always") => true,
                 Some("never") => false,
-                Some("auto") | _ => self.interactive_output,
+                Some("auto") | _ => env::var_os("NO_COLOR").is_none() && self.interactive_output,
             },
             paging_mode,
             term_width: maybe_term_width.unwrap_or(Term::stdout().size().1 as usize),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -1,8 +1,9 @@
 use clap::{crate_name, crate_version, App as ClapApp, AppSettings, Arg, ArgGroup, SubCommand};
+use std::env;
 use std::path::Path;
 
 pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
-    let clap_color_setting = if interactive_output {
+    let clap_color_setting = if interactive_output && env::var_os("NO_COLOR").is_none() {
         AppSettings::ColoredHelp
     } else {
         AppSettings::ColorNever


### PR DESCRIPTION
Adds support for the `NO_COLOR` environment variable.

When `NO_COLOR` is provided:
- The help text is not colored.
- Colors are disabled when using `--color=auto`. Note: `--color=always` overrides the environment variable.