### PR TITLE
Clarify stdin syntax highlighting in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Display multiple files at once
 > bat src/*.rs
 ```
 
-Read from stdin, determine the syntax automatically
+Read from stdin, determine the syntax automatically (note, this will only work
+if the syntax can be determined from the initial line of the file, usually
+through a shebang such as `#!/bin/sh`)
 
 ```bash
 > curl -s https://sh.rustup.rs | bat

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Display multiple files at once
 > bat src/*.rs
 ```
 
-Read from stdin, determine the syntax automatically (note, this will only work
-if the syntax can be determined from the initial line of the file, usually
-through a shebang such as `#!/bin/sh`)
+Read from stdin, determine the syntax automatically (note, highlighting will
+only work if the syntax can be determined from the first line of the file,
+usually through a shebang such as `#!/bin/sh`)
 
 ```bash
 > curl -s https://sh.rustup.rs | bat


### PR DESCRIPTION
Clarify the requirements for automatic syntax highlighting when reading
input from stdin. Fixes #1028.