### PR TITLE
Ignore 'more' on pager

### DIFF
--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -221,7 +221,10 @@ impl App {
             },
             style_components,
             syntax_mapping,
-            pager: self.matches.value_of("pager"),
+            pager: match self.matches.value_of("pager") {
+                Some(s) => if s == "more" { None } else { Some(s) },
+                _ => None,
+            },
             use_italic_text: match self.matches.value_of("italic-text") {
                 Some("always") => true,
                 _ => false,

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -221,10 +221,7 @@ impl App {
             },
             style_components,
             syntax_mapping,
-            pager: match self.matches.value_of("pager") {
-                Some(s) => if s == "more" { None } else { Some(s) },
-                _ => None,
-            },
+            pager: self.matches.value_of("pager"),
             use_italic_text: match self.matches.value_of("italic-text") {
                 Some("always") => true,
                 _ => false,

--- a/src/output.rs
+++ b/src/output.rs
@@ -59,6 +59,7 @@ impl OutputType {
 
         let pager = pager_from_config
             .or(pager_from_env)
+            .filter(|p| p != "most")
             .unwrap_or_else(|| String::from("less"));
 
         let pagerflags =


### PR DESCRIPTION
A couple things:
1. There's probably a terser syntax for this. I'd love to see it, I'm still learning Rust.
2. Depending on the desired behavior this may or may not be sufficient. When specifying "more" the fall-over to None means the default "less" will be used. This is in contrast to if you specify, say, "More" where bat will just disable paging. 

Resolves #1063