### PR TITLE
Clarified which pager is used in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ characters:
 
 ### Automatic paging
 
-`bat` can pipe its own output to `less` if the output is too large for one screen.
+`bat` can pipe its own output to the defult pager (e.g `less`) if the output is too large for one screen.
 
 ### File concatenation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ characters:
 
 ### Automatic paging
 
-`bat` can pipe its own output to the defult pager (e.g `less`) if the output is too large for one screen.
+`bat` can pipe its own output to a pager (e.g `less`) if the output is too large for one screen.
 
 ### File concatenation
 


### PR DESCRIPTION
For me the default pager is `most` and as the result the text will be pushed to `most` instead of `less`. This change also shows to the user that they can configure the pager according to their preference.