### PR TITLE
Handle file extension conflicts in --list-languages (#1076)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # unreleased
+- Handle file extension conflicts in --list-languages, see #1076 and #1135 (@Kienyew)
 
 ## Features
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -170,6 +170,21 @@ impl HighlightingAssets {
         self.theme_set.themes.keys().map(|s| s.as_ref())
     }
 
+    pub fn syntax_for_file_name(
+        &self,
+        file_name: impl AsRef<Path>,
+        mapping: &SyntaxMapping,
+    ) -> Option<&SyntaxReference> {
+        let file_name = file_name.as_ref();
+        match mapping.get_syntax_for(file_name) {
+            Some(MappingTarget::MapToUnknown) => None,
+            Some(MappingTarget::MapTo(syntax_name)) => {
+                self.syntax_set.find_syntax_by_name(syntax_name)
+            }
+            None => self.get_extension_syntax(file_name.as_os_str()),
+        }
+    }
+
     pub(crate) fn get_theme(&self, theme: &str) -> &Theme {
         match self.theme_set.themes.get(theme) {
             Some(theme) => theme,

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -100,11 +100,8 @@ pub fn list_languages(config: &Config) -> Result<()> {
                 true
             } else {
                 let test_file = Path::new("test").with_extension(extension);
-                if let Some(syntax) = assets.syntax_for_file_name(test_file, &config.syntax_mapping) {
-                    syntax.name == lang_name
-                } else {
-                    false
-                }
+                let syntax = assets.syntax_for_file_name(test_file, &config.syntax_mapping).unwrap();
+                syntax.name == lang_name
             }
         });
     }

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -86,19 +86,6 @@ pub fn list_languages(config: &Config) -> Result<()> {
         .filter(|syntax| !syntax.hidden && !syntax.file_extensions.is_empty())
         .cloned()
         .collect::<Vec<_>>();
-
-    for lang in languages.iter_mut() {
-        let lang_name = lang.name.clone();
-        lang.file_extensions.retain(|extension| {
-            let test_file = Path::new("test").with_extension(extension);
-            match config.syntax_mapping.get_syntax_for(test_file) {
-                Some(MappingTarget::MapTo(primary_lang)) => lang_name == primary_lang,
-                Some(MappingTarget::MapToUnknown) => false,
-                None => true,
-            }
-        });
-    }
-
     languages.sort_by_key(|lang| lang.name.to_uppercase());
 
     let configured_languages = get_syntax_mapping_to_paths(config.syntax_mapping.mappings());

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -93,7 +93,7 @@ pub fn list_languages(config: &Config) -> Result<()> {
             let test_file = Path::new("test").with_extension(extension);
             match config.syntax_mapping.get_syntax_for(test_file) {
                 Some(MappingTarget::MapTo(primary_lang)) => lang_name == primary_lang,
-                Some(MappingTarget::MapToUnknown) => true,
+                Some(MappingTarget::MapToUnknown) => false,
                 None => true,
             }
         });

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -86,6 +86,19 @@ pub fn list_languages(config: &Config) -> Result<()> {
         .filter(|syntax| !syntax.hidden && !syntax.file_extensions.is_empty())
         .cloned()
         .collect::<Vec<_>>();
+
+    for lang in languages.iter_mut() {
+        let lang_name = lang.name.clone();
+        lang.file_extensions.retain(|extension| {
+            let test_file = Path::new("test").with_extension(extension);
+            match config.syntax_mapping.get_syntax_for(test_file) {
+                Some(MappingTarget::MapTo(primary_lang)) => lang_name == primary_lang,
+                Some(MappingTarget::MapToUnknown) => true,
+                None => true,
+            }
+        });
+    }
+
     languages.sort_by_key(|lang| lang.name.to_uppercase());
 
     let configured_languages = get_syntax_mapping_to_paths(config.syntax_mapping.mappings());

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -25,12 +25,6 @@ impl<'a> SyntaxMapping<'a> {
         mapping.insert("*.h", MappingTarget::MapTo("C++")).unwrap();
         mapping.insert("*.fs", MappingTarget::MapTo("F#")).unwrap();
         mapping
-            .insert("*.js", MappingTarget::MapTo("JavaScript (Babel)"))
-            .unwrap();
-        mapping
-            .insert("*.sass", MappingTarget::MapTo("Sass"))
-            .unwrap();
-        mapping
             .insert("build", MappingTarget::MapToUnknown)
             .unwrap();
         mapping
@@ -73,16 +67,14 @@ impl<'a> SyntaxMapping<'a> {
             "*.swap",
             "*.target",
             "*.timer",
-        ]
-        .iter()
-        {
-            mapping.insert(glob, MappingTarget::MapTo("INI")).unwrap();
+        ].iter() {
+            mapping
+                .insert(glob, MappingTarget::MapTo("INI"))
+                .unwrap();
         }
 
         // pacman hooks
-        mapping
-            .insert("*.hook", MappingTarget::MapTo("INI"))
-            .unwrap();
+        mapping.insert("*.hook", MappingTarget::MapTo("INI")).unwrap();
 
         mapping
     }
@@ -100,7 +92,7 @@ impl<'a> SyntaxMapping<'a> {
         &self.mappings
     }
 
-    pub fn get_syntax_for(&self, path: impl AsRef<Path>) -> Option<MappingTarget<'a>> {
+    pub(crate) fn get_syntax_for(&self, path: impl AsRef<Path>) -> Option<MappingTarget<'a>> {
         let candidate = Candidate::new(path.as_ref());
         let canddidate_filename = path.as_ref().file_name().map(Candidate::new);
         for (ref glob, ref syntax) in self.mappings.iter().rev() {

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -25,6 +25,12 @@ impl<'a> SyntaxMapping<'a> {
         mapping.insert("*.h", MappingTarget::MapTo("C++")).unwrap();
         mapping.insert("*.fs", MappingTarget::MapTo("F#")).unwrap();
         mapping
+            .insert("*.js", MappingTarget::MapTo("JavaScript (Babel)"))
+            .unwrap();
+        mapping
+            .insert("*.sass", MappingTarget::MapTo("Sass"))
+            .unwrap();
+        mapping
             .insert("build", MappingTarget::MapToUnknown)
             .unwrap();
         mapping
@@ -67,14 +73,16 @@ impl<'a> SyntaxMapping<'a> {
             "*.swap",
             "*.target",
             "*.timer",
-        ].iter() {
-            mapping
-                .insert(glob, MappingTarget::MapTo("INI"))
-                .unwrap();
+        ]
+        .iter()
+        {
+            mapping.insert(glob, MappingTarget::MapTo("INI")).unwrap();
         }
 
         // pacman hooks
-        mapping.insert("*.hook", MappingTarget::MapTo("INI")).unwrap();
+        mapping
+            .insert("*.hook", MappingTarget::MapTo("INI"))
+            .unwrap();
 
         mapping
     }
@@ -92,7 +100,7 @@ impl<'a> SyntaxMapping<'a> {
         &self.mappings
     }
 
-    pub(crate) fn get_syntax_for(&self, path: impl AsRef<Path>) -> Option<MappingTarget<'a>> {
+    pub fn get_syntax_for(&self, path: impl AsRef<Path>) -> Option<MappingTarget<'a>> {
         let candidate = Candidate::new(path.as_ref());
         let canddidate_filename = path.as_ref().file_name().map(Candidate::new);
         for (ref glob, ref syntax) in self.mappings.iter().rev() {


### PR DESCRIPTION
Now the each outputted extension should be unique to only one language. Below is the diff output of the old `bat --list-languages` and new `bat --list-languages`.
```diff
13c13
< C:c,h
---
> C:c
49c49
< GLSL:vs,fs,gs,vsh,fsh,gsh,vshader,fshader,gshader,vert,frag,geom,tesc,tese,comp,glsl
---
> GLSL:vs,gs,vsh,fsh,gsh,vshader,fshader,gshader,vert,frag,geom,tesc,tese,comp,glsl
70,71c70,71
< JavaScript:js,htc
< JavaScript (Babel):js,mjs,jsx,babel,es6,cjs
---
> JavaScript:htc
> JavaScript (Babel):js,mjs,jsx,babel,es6,cjs,*.js
92,93c92,93
< Objective-C:m,h
< Objective-C++:mm,M,h
---
> Objective-C:m
> Objective-C++:mm,M
119c119
< Ruby Haml:haml,sass
---
> Ruby Haml:haml
123c123
< Sass:sass
---
> Sass:sass,*.sass

```

But since #1035, some of the output is appearing in the form `Lang ext, *.ext`.
For instance in the C++ entry of `bat --list-languages`, containing both `h` and `*.h`:

```
...
C++                                 cpp, cc, cp, cxx, c++, C, h, hh, hpp, hxx, h++, inl, ipp, *.h
...
```
and likewise 

```
...
Sass                                 sass, *.sass
...
F#                                   fs, fsi, fsx, *.fs
...
JavaScript (Babel)                   js, mjs, jsx, babel, es6, cjs, *.js
...
```

Should this be the desired behavior? @sharkdp 