### PR TITLE
Mention Homebrew on Linux 🍺🐧

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ You can install `bat` with zypper:
 zypper install bat
 ```
 
+### On Linux
+
+You can install `bat` with [Homebrew](https://formulae.brew.sh/formula-linux/bat)::
+
+```bash
+brew install bat
+```
+
 ### On macOS
 
 You can install `bat` with [Homebrew](http://braumeister.org/formula/bat):

--- a/README.md
+++ b/README.md
@@ -276,21 +276,15 @@ You can install `bat` with zypper:
 zypper install bat
 ```
 
-### On Linux
+### On macOS (or Linux) via Homebrew
 
-You can install `bat` with [Homebrew](https://formulae.brew.sh/formula-linux/bat)::
-
-```bash
-brew install bat
-```
-
-### On macOS
-
-You can install `bat` with [Homebrew](http://braumeister.org/formula/bat):
+You can install `bat` with [Homebrew on MacOS](https://formulae.brew.sh/formula/bat) or [Homebrew on Linux](https://formulae.brew.sh/formula-linux/bat):
 
 ```bash
 brew install bat
 ```
+
+### On macOS via MacPorts
 
 Or install `bat` with [MacPorts](https://ports.macports.org/port/bat/summary):
 


### PR DESCRIPTION
Was already published on `Homebrew on Linux` by someone else, 
not sure why this isn't already mentioned inside the README 🤔🙂

btw the following link to the `Homebrew on MacOS` formula seems to be wrong 🧐

```
You can install `bat` with [Homebrew](http://braumeister.org/formula/bat):
```