### PR TITLE
Add after_help NOTE to refer to detailed help (and vice versa)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # unreleased
 
+- Add Note to refer to see detailed help with --help (and vice versa with -h). see #1215 (@henil)
+
 ## Features
 
 ## Bugfixes

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -24,6 +24,10 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             "A cat(1) clone with wings.\n\n\
              Use '--help' instead of '-h' to see a more detailed version of the help text.",
         )
+        .after_help(
+            "Note: `bat -h` prints a short and concise overview while `bat --help` gives all \
+                 details.",
+        )
         .long_about("A cat(1) clone with syntax highlighting and Git integration.")
         .arg(
             Arg::with_name("FILE")


### PR DESCRIPTION
From a TODO in #1211. Kept wording the same as in `fd` for consistency.