### PR TITLE
Update README.md using cargo install --path

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,11 +621,11 @@ cargo build --bins
 cargo test
 
 # Install (release version)
-cargo install --locked
+cargo install --path . --locked
 
 # Build a bat binary with modified syntaxes and themes
 bash assets/create.sh
-cargo install --locked --force
+cargo install --path . --locked --force
 ```
 
 ## Maintainers


### PR DESCRIPTION
When i follow the `Development` part in readme to set up project, the `cargo install --locked` is deprecated with error
`error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.`

My setup:
```
cargo --version                                                                                                                                         
cargo 1.45.1 (f242df6ed 2020-07-22)
```