### PR TITLE
Shell script improvements

### DIFF
--- a/assets/create.sh
+++ b/assets/create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 ASSET_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/tests/benchmarks/comparison.sh
+++ b/tests/benchmarks/comparison.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 if ! which hyperfine > /dev/null 2>&1; then
     echo "'hyperfine' does not seem to be installed."
     echo "You can get it here: https://github.com/sharkdp/hyperfine"

--- a/tests/benchmarks/comparison.sh
+++ b/tests/benchmarks/comparison.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! which hyperfine > /dev/null 2>&1; then
     echo "'hyperfine' does not seem to be installed."

--- a/tests/benchmarks/run-benchmarks.sh
+++ b/tests/benchmarks/run-benchmarks.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 if ! which hyperfine > /dev/null 2>&1; then
     echo "'hyperfine' does not seem to be installed."
     echo "You can get it here: https://github.com/sharkdp/hyperfine"

--- a/tests/benchmarks/run-benchmarks.sh
+++ b/tests/benchmarks/run-benchmarks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! which hyperfine > /dev/null 2>&1; then
     echo "'hyperfine' does not seem to be installed."

--- a/tests/syntax-tests/regression_test.sh
+++ b/tests/syntax-tests/regression_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/tests/syntax-tests/update.sh
+++ b/tests/syntax-tests/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 python="python3"
 if ! command -v python3 &>/dev/null; then python="python"; fi

--- a/tests/syntax-tests/update.sh
+++ b/tests/syntax-tests/update.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 python="python3"
 if ! command -v python3 &>/dev/null; then python="python"; fi
 "$python" create_highlighted_versions.py -O highlighted


### PR DESCRIPTION
This PR adds a few improvements to the shell scripts of this project:
* replacing `#!/bin/bash` with `#!/usr/bin/env bash` to improve compatibility with system where `/bin/bash` is absent (for instance NixOS)
* adding the execution flag
* adding `cd $(dirname $0)` to allow running the scripts from another directory (for instance form root `./tests/syntax-tests/regression_test.sh`). I tested every scripts, some of them were already working without.