### PR TITLE
Add support for opening file starting at a given line number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-- Add support for opening file starting at a given line number. As per #1185 (@Lidenburg)
+- Add support for opening file starting at a given line number. see #1185 (@Lidenburg)
 - Add Note to refer to see detailed help with --help (and vice versa with -h). see #1215 (@henil)
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+- Add support for opening file starting at a given line number. As per #1185 (@Lidenburg)
 - Add Note to refer to see detailed help with --help (and vice versa with -h). see #1215 (@henil)
 
 ## Features

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -238,6 +238,10 @@ impl App {
                 .map(LineRanges::from)
                 .map(|lr| HighlightedLineRanges(lr))
                 .unwrap_or_default(),
+            offset: match self.matches.value_of("offset") {
+                Some(v) => v.parse::<usize>().unwrap_or(0),
+                _ => 0,
+            }
         })
     }
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -223,6 +223,12 @@ impl App {
                         .unwrap_or_default(),
                 ),
             },
+            offset: self.matches.value_of("offset").map_or(0, |v|
+                        v.parse::<usize>().unwrap()
+                        + if style_components.header() {1} else {0} // the header is 1 row
+                        + if style_components.grid() {2} else {0}   // the grid is 2 rows
+                        + 1    // add 1 for this to be an _offset_ and not just what row to show
+            ),
             style_components,
             syntax_mapping,
             pager: self.matches.value_of("pager"),
@@ -237,11 +243,7 @@ impl App {
                 .transpose()?
                 .map(LineRanges::from)
                 .map(|lr| HighlightedLineRanges(lr))
-                .unwrap_or_default(),
-            offset: match self.matches.value_of("offset") {
-                Some(v) => v.parse::<usize>().unwrap_or(0),
-                _ => 0,
-            }
+                .unwrap_or_default()
         })
     }
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -120,6 +120,14 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             .number_of_values(1)
             .value_name("N")
             .multiple(false)
+            .validator(
+                |n| {
+                    n.parse::<usize>()
+                        .map_err(|_| "must be a number")
+                        .map(|_| ()) // Convert to Result<(), &str>
+                        .map_err(|e| e.to_string())
+                }, // Convert to Result<(), String>
+                )
             .help("Start showing file at line N"),
         );
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -112,24 +112,32 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      the filename. Note that the provided file name is also \
                      used for syntax detection.",
                 ),
-        )
-        .arg(
-            Arg::with_name("offset")
-            .long("offset")
-            .takes_value(true)
-            .number_of_values(1)
-            .value_name("N")
-            .multiple(false)
-            .validator(
-                |n| {
-                    n.parse::<usize>()
-                        .map_err(|_| "must be a number")
-                        .map(|_| ()) // Convert to Result<(), &str>
-                        .map_err(|e| e.to_string())
-                }, // Convert to Result<(), String>
-                )
-            .help("Start showing file at line N"),
         );
+
+    {
+        app = if let true = env::var("BAT_PAGER").unwrap_or_else(
+                    |_| env::var("PAGER").unwrap_or("less".to_string())) != "less" {
+            app
+        } else {
+            app.arg(
+                Arg::with_name("offset")
+                    .long("offset")
+                    .takes_value(true)
+                    .number_of_values(1)
+                    .value_name("N")
+                    .multiple(false)
+                    .validator(
+                        |n| {
+                            n.parse::<usize>()
+                                .map_err(|_| "must be a number")
+                                .map(|_| ()) // Convert to Result<(), &str>
+                                .map_err(|e| e.to_string())
+                        }, // Convert to Result<(), String>
+                    )
+                    .help("Start showing file at line N (only compatible with less as pager)")
+            )
+        };
+    }
 
     #[cfg(feature = "git")]
     {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -112,6 +112,15 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      the filename. Note that the provided file name is also \
                      used for syntax detection.",
                 ),
+        )
+        .arg(
+            Arg::with_name("offset")
+            .long("offset")
+            .takes_value(true)
+            .number_of_values(1)
+            .value_name("N")
+            .multiple(false)
+            .help("Start showing file at line N"),
         );
 
     #[cfg(feature = "git")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,9 @@ pub struct Config<'a> {
 
     /// Ranges of lines which should be highlighted with a special background color
     pub highlighted_lines: HighlightedLineRanges,
+
+    /// Offset to start displaying file from
+    pub offset: usize,
 }
 
 #[test]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -54,7 +54,7 @@ impl<'b> Controller<'b> {
                     paging_mode = PagingMode::Never;
                 }
             }
-            output_type = OutputType::from_mode(paging_mode, self.config.pager)?;
+            output_type = OutputType::from_mode(paging_mode, self.config.pager, self.config.offset)?;
         }
 
         #[cfg(not(feature = "paging"))]

--- a/src/output.rs
+++ b/src/output.rs
@@ -17,18 +17,18 @@ pub enum OutputType {
 
 impl OutputType {
     #[cfg(feature = "paging")]
-    pub fn from_mode(mode: PagingMode, pager: Option<&str>) -> Result<Self> {
+    pub fn from_mode(mode: PagingMode, pager: Option<&str>, offset: usize) -> Result<Self> {
         use self::PagingMode::*;
         Ok(match mode {
-            Always => OutputType::try_pager(false, pager)?,
-            QuitIfOneScreen => OutputType::try_pager(true, pager)?,
+            Always => OutputType::try_pager(false, pager, offset)?,
+            QuitIfOneScreen => OutputType::try_pager(true, pager, offset)?,
             _ => OutputType::stdout(),
         })
     }
 
     /// Try to launch the pager. Fall back to stdout in case of errors.
     #[cfg(feature = "paging")]
-    fn try_pager(quit_if_one_screen: bool, pager_from_config: Option<&str>) -> Result<Self> {
+    fn try_pager(quit_if_one_screen: bool, pager_from_config: Option<&str>, offset_from_config: usize) -> Result<Self> {
         use std::env;
         use std::ffi::OsString;
         use std::path::PathBuf;
@@ -103,6 +103,12 @@ impl OutputType {
                     } else {
                         p.args(args);
                     }
+                    
+                    if offset_from_config > 0 {
+                        // +3 for the `File: filename` header bat prepends
+                        p.arg(format!("+{}", offset_from_config + 3));
+                    }
+
                     p.env("LESSCHARSET", "UTF-8");
                     p
                 } else {

--- a/src/output.rs
+++ b/src/output.rs
@@ -104,9 +104,8 @@ impl OutputType {
                         p.args(args);
                     }
                     
-                    if offset_from_config > 0 {
-                        // +3 for the `File: filename` header bat prepends
-                        p.arg(format!("+{}", offset_from_config + 3));
+                    if offset_from_config > 1 {
+                        p.arg(format!("+{}", offset_from_config));
                     }
 
                     p.env("LESSCHARSET", "UTF-8");


### PR DESCRIPTION
Add support for opening file starting at a given line number.

From #1185 

Some things to note: 
- Only works with less as pager. Does nothing if piped to a file.
- Files that would normally quit because of `--quit-if-one-screen` don't if an offset is provided (because of less behavior)
- If an offset that is greater than the file is long is supplied, an ugly `Cannot seek to line number N  (press RETURN)` is shown (because of less behavior)