### PR TITLE
Print error message if bat not found on path

### DIFF
--- a/tests/syntax-tests/create_highlighted_versions.py
+++ b/tests/syntax-tests/create_highlighted_versions.py
@@ -64,6 +64,9 @@ def create_highlighted_versions(output_basepath):
                 file=sys.stderr,
             )
             sys.exit(1)
+        except FileNotFoundError:
+            print("Error: Could not execute 'bat'. Please make sure that the executable is available on the PATH.")
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Referring to issue #1213, some users were seeing traceback when bat was not found on path.