### PR TITLE
Add support for comments after section headers (closes #1259)

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -33,7 +33,7 @@ The following files have been manually modified after converting from a `.tmLang
 
 * `Apache.sublime_syntax`=> removed `.conf` and `.CONF` file types.
 * `Dart.sublime-syntax` => removed `#regex.dart` include.
-* `INI.sublime-syntax` => added `.hgrc`, `hgrc`, and `desktop` file types.
+* `INI.sublime-syntax` => added `.hgrc`, `hgrc`, and `desktop` file types and support for comments after section headers
 * `Org mode.sublime-syntax` => removed `task` file type.
 * `SML.sublime_syntax` => removed `ml` file type.
 

--- a/assets/syntaxes/02_Extra/INI.sublime-syntax
+++ b/assets/syntaxes/02_Extra/INI.sublime-syntax
@@ -25,12 +25,13 @@ contexts:
       scope: comment.line.semicolon.ini
       captures:
         1: punctuation.definition.comment.ini
-    - match: '^\s*(\[)(.*?)(\])'
+    - match: '^\s*(\[)(.*?)(\])\s*(;.*)?$\n?'
       scope: meta.tag.section.ini
       captures:
         1: punctuation.definition.section.ini
         2: entity.section.ini
         3: punctuation.definition.section.ini
+        4: comment.definition.section.ini
     - match: '^(\s*(["'']?)(.+?)(\2)\s*(=))?\s*((["'']?)(.*?)(\7))\s*(;.*)?$\n?'
       scope: meta.declaration.ini
       captures:


### PR DESCRIPTION
There's no canonical definition of what's the INI syntax, but Python's `ConfigParser` supports comments after section headers:

```ini
[section] ; comment
```

I also put a PR in upstream (https://github.com/clintberry/sublime-text-2-ini/pull/29), but there have been no merges for a few years.
Also, we already have a modified version here, so a change upstream doesn't take effect.