### PR TITLE
Add Splunk Query Language highlighting

### DIFF
--- a/assets/syntaxes/02_Extra/splunk.sublime-syntax
+++ b/assets/syntaxes/02_Extra/splunk.sublime-syntax
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Splunk Query Language
+file_extensions:
+  - splunk
+  - spl
+scope: source.splunk
+contexts:
+  main:
+    - match: \b(abstract|accum|addcoltotals|addinfo|addtotals|analyzefields|anomalies|anomalousvalue|append|appendcols|appendpipe|arules|associate|audit|autoregress|bucket|bucketdir|chart|cluster|collect|concurrency|contingency|convert|correlate|crawl|datamodel|dbinspect|dedup|delete|delta|diff|dispatch|erex|eval|eventcount|eventstats|extract|fieldformat|fields|fieldsummary|file|filldown|fillnull|findtypes|folderize|foreach|format|gauge|gentimes|geostats|head|highlight|history|input|inputcsv|inputlookup|iplocation|join|kmeans|kvform|loadjob|localize|localop|lookup|makecontinuous|makemv|map|metadata|metasearch|multikv|multisearch|mvcombine|mvexpand|nomv|outlier|outputcsv|outputlookup|outputtext|overlap|pivot|predict|rangemap|rare|regex|relevancy|reltime|rename|replace|rest|return|reverse|rex|rtorder|run|savedsearch|script|scrub|search|searchtxn|selfjoin|sendemail|set|setfields|sichart|sirare|sistats|sitimechart|sitop|sort|spath|stats|strcat|streamstats|table|tags|tail|timechart|top|transaction|transpose|trendline|tscollect|tstats|typeahead|typelearner|typer|uniq|untable|where|x11|xmlkv|xmlunescape|xpath|xyseries)\b
+      comment: Splunk Built-in function
+      scope: support.class.splunk
+    - match: '([A-Za-z0-9]+) *\('
+      comment: Function calls
+      captures:
+        1: support.class.splunk
+    - match: \b(\d+)\b
+      comment: Digits
+      scope: constant.numeric.splunk
+    - match: \|
+      comment: Splunk Pipe
+      scope: constant.language.splunk
+    - match: \b(AND|OR|as|AS|by|BY)\b
+      comment: Splunk Operators
+      scope: keyword.operator.splunk
+    - match: "="
+      comment: Comparison or assignment
+      scope: keyword.operator.splunk
+    - match: (?<!\\)"
+      push:
+        - meta_scope: string.quoted.double.splunk
+        - match: (?<!\\)"
+          pop: true
+    - match: (?<!\\)'
+      push:
+        - meta_scope: string.quoted.single.splunk
+        - match: (?<!\\)'
+          pop: true


### PR DESCRIPTION
This PR adds support for Splunk Query Language highlighting for `.spl` and `.splunk` files

Example:
![image](https://user-images.githubusercontent.com/8982584/95257513-b8f76d00-0824-11eb-9289-af1add8831da.png)

It's still missing the test files, but I'm not sure whether that's required.