### PR TITLE
Allow env vars to override config variables, but not flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,7 @@
 
 ## Other
 
+- Allow environment variables to override configuration file, but not command-line flags, see #1152 and #1281 (@jacobmischka)
 - Switched to "·" (U+00B7) Middle Dot from "•" (U+2022) Bullet for non-printing spaces, see #1056 and #1100 (@LordFlashmeow)
 - Added zsh shell completion script, see #1136 (@Kienyew)
 - Improved `--help` text (@sharkdp)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,8 @@ dependencies = [
  "atty",
  "bincode",
  "bugreport",
- "clap",
+ "clap 2.34.0",
+ "clap 3.0.0",
  "clircle",
  "console",
  "content_inspector",
@@ -203,11 +204,27 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "term_size",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+dependencies = [
+ "atty",
+ "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "terminal_size",
+ "textwrap 0.14.2",
 ]
 
 [[package]]
@@ -735,6 +752,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,16 +1167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,8 +1191,16 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "term_size",
  "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,10 @@ default-features = false
 features = ["parsing"]
 
 [dependencies.clap]
-version = "2.34"
+version = "3.0"
 optional = true
 default-features = false
-features = ["suggestions", "color", "wrap_help"]
+features = ["suggestions", "color", "wrap_help", "cargo", "std", "env"]
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -188,7 +188,6 @@ impl App {
                 .matches
                 .value_of("tabs")
                 .map(String::from)
-                .or_else(|| env::var("BAT_TABS").ok())
                 .and_then(|t| t.parse().ok())
                 .unwrap_or(
                     if style_components.plain() && paging_mode == PagingMode::Never {
@@ -201,7 +200,6 @@ impl App {
                 .matches
                 .value_of("theme")
                 .map(String::from)
-                .or_else(|| env::var("BAT_THEME").ok())
                 .map(|s| {
                     if s == "default" {
                         String::from(HighlightingAssets::default_theme())
@@ -302,16 +300,6 @@ impl App {
             } else if matches.is_present("plain") {
                 [StyleComponent::Plain].iter().cloned().collect()
             } else {
-                let env_style_components: Option<Vec<StyleComponent>> = env::var("BAT_STYLE")
-                    .ok()
-                    .map(|style_str| {
-                        style_str
-                            .split(',')
-                            .map(StyleComponent::from_str)
-                            .collect::<Result<Vec<StyleComponent>>>()
-                    })
-                    .transpose()?;
-
                 matches
                     .value_of("style")
                     .map(|styles| {
@@ -321,7 +309,6 @@ impl App {
                             .filter_map(|style| style.ok())
                             .collect::<Vec<_>>()
                     })
-                    .or(env_style_components)
                     .unwrap_or_else(|| vec![StyleComponent::Full])
                     .into_iter()
                     .map(|style| style.components(self.interactive_output))

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -1,4 +1,4 @@
-use clap::{crate_name, crate_version, App as ClapApp, AppSettings, Arg, ArgGroup, SubCommand};
+use clap::{crate_name, crate_version, App as ClapApp, AppSettings, Arg, ArgGroup};
 use once_cell::sync::Lazy;
 use std::env;
 use std::path::Path;
@@ -16,7 +16,7 @@ static VERSION: Lazy<String> = Lazy::new(|| {
     }
 });
 
-pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
+pub fn build_app(interactive_output: bool) -> ClapApp<'static> {
     let clap_color_setting = if interactive_output && env::var_os("NO_COLOR").is_none() {
         AppSettings::ColoredHelp
     } else {
@@ -27,12 +27,10 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .version(VERSION.as_str())
         .global_setting(clap_color_setting)
         .global_setting(AppSettings::DeriveDisplayOrder)
-        .global_setting(AppSettings::UnifiedHelpMessage)
-        .global_setting(AppSettings::HidePossibleValuesInHelp)
+        .global_setting(AppSettings::HidePossibleValues)
         .setting(AppSettings::ArgsNegateSubcommands)
         .setting(AppSettings::AllowExternalSubcommands)
         .setting(AppSettings::DisableHelpSubcommand)
-        .setting(AppSettings::VersionlessSubcommands)
         .max_term_width(100)
         .about(
             "A cat(1) clone with wings.\n\n\
@@ -44,20 +42,20 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         )
         .long_about("A cat(1) clone with syntax highlighting and Git integration.")
         .arg(
-            Arg::with_name("FILE")
+            Arg::new("FILE")
                 .help("File(s) to print / concatenate. Use '-' for standard input.")
                 .long_help(
                     "File(s) to print / concatenate. Use a dash ('-') or no argument at all \
                      to read from standard input.",
                 )
-                .multiple(true)
-                .empty_values(false),
+                .multiple_occurrences(true)
+                .forbid_empty_values(true),
         )
         .arg(
-            Arg::with_name("show-all")
+            Arg::new("show-all")
                 .long("show-all")
                 .alias("show-nonprintable")
-                .short("A")
+                .short('A')
                 .conflicts_with("language")
                 .help("Show non-printable characters (space, tab, newline, ..).")
                 .long_help(
@@ -67,12 +65,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("plain")
+            Arg::new("plain")
                 .overrides_with("plain")
                 .overrides_with("number")
-                .short("p")
+                .short('p')
                 .long("plain")
-                .multiple(true)
+                .multiple_occurrences(true)
                 .help("Show plain style (alias for '--style=plain').")
                 .long_help(
                     "Only show plain style, no decorations. This is an alias for \
@@ -81,8 +79,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("language")
-                .short("l")
+            Arg::new("language")
+                .short('l')
                 .long("language")
                 .overrides_with("language")
                 .help("Set the language for syntax highlighting.")
@@ -95,12 +93,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("highlight-line")
+            Arg::new("highlight-line")
                 .long("highlight-line")
-                .short("H")
+                .short('H')
                 .takes_value(true)
                 .number_of_values(1)
-                .multiple(true)
+                .multiple_occurrences(true)
                 .value_name("N:M")
                 .help("Highlight lines N through M.")
                 .long_help(
@@ -114,11 +112,11 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("file-name")
+            Arg::new("file-name")
                 .long("file-name")
                 .takes_value(true)
                 .number_of_values(1)
-                .multiple(true)
+                .multiple_occurrences(true)
                 .value_name("name")
                 .help("Specify the name to display for a file.")
                 .long_help(
@@ -133,9 +131,9 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
     {
         app = app
                 .arg(
-                    Arg::with_name("diff")
+                    Arg::new("diff")
                         .long("diff")
-                        .short("d")
+                        .short('d')
                         .help("Only show lines that have been added/removed/modified.")
                         .long_help(
                             "Only show lines that have been added/removed/modified with respect \
@@ -143,7 +141,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                         ),
                 )
                 .arg(
-                    Arg::with_name("diff-context")
+                    Arg::new("diff-context")
                         .long("diff-context")
                         .overrides_with("diff-context")
                         .takes_value(true)
@@ -156,7 +154,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                                     .map_err(|e| e.to_string())
                             }, // Convert to Result<(), String>
                         )
-                        .hidden_short_help(true)
+                        .hide_short_help(true)
                         .long_help(
                             "Include N lines of context around added/removed/modified lines when using '--diff'.",
                         ),
@@ -164,7 +162,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
     }
 
     app = app.arg(
-        Arg::with_name("tabs")
+        Arg::new("tabs")
             .long("tabs")
             .env("BAT_TABS")
             .overrides_with("tabs")
@@ -183,10 +181,10 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 "Set the tab width to T spaces. Use a width of 0 to pass tabs through \
                      directly",
             )
-			.hide_env_values(true)
+			.hide_env(true)
     )
         .arg(
-            Arg::with_name("wrap")
+            Arg::new("wrap")
                 .long("wrap")
                 .overrides_with("wrap")
                 .takes_value(true)
@@ -200,11 +198,11 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                            control the output width."),
         )
         .arg(
-            Arg::with_name("terminal-width")
+            Arg::new("terminal-width")
                 .long("terminal-width")
                 .takes_value(true)
                 .value_name("width")
-                .hidden_short_help(true)
+                .hide_short_help(true)
                 .allow_hyphen_values(true)
                 .validator(
                     |t| {
@@ -225,10 +223,10 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("number")
+            Arg::new("number")
                 .long("number")
                 .overrides_with("number")
-                .short("n")
+                .short('n')
                 .help("Show line numbers (alias for '--style=numbers').")
                 .long_help(
                     "Only show line numbers, no other decorations. This is an alias for \
@@ -236,7 +234,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("color")
+            Arg::new("color")
                 .long("color")
                 .overrides_with("color")
                 .takes_value(true)
@@ -253,7 +251,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("italic-text")
+            Arg::new("italic-text")
                 .long("italic-text")
                 .takes_value(true)
                 .value_name("when")
@@ -264,7 +262,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long_help("Specify when to use ANSI sequences for italic text in the output. Possible values: always, *never*."),
         )
         .arg(
-            Arg::with_name("decorations")
+            Arg::new("decorations")
                 .long("decorations")
                 .overrides_with("decorations")
                 .takes_value(true)
@@ -280,19 +278,19 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("force-colorization")
+            Arg::new("force-colorization")
                 .long("force-colorization")
-                .short("f")
+                .short('f')
                 .conflicts_with("color")
                 .conflicts_with("decorations")
                 .overrides_with("force-colorization")
-                .hidden_short_help(true)
+                .hide_short_help(true)
                 .long_help("Alias for '--decorations=always --color=always'. This is useful \
                         if the output of bat is piped to another program, but you want \
                         to keep the colorization/decorations.")
         )
         .arg(
-            Arg::with_name("paging")
+            Arg::new("paging")
                 .long("paging")
                 .overrides_with("paging")
                 .takes_value(true)
@@ -309,23 +307,23 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("no-paging")
-                .short("P")
+            Arg::new("no-paging")
+                .short('P')
                 .long("no-paging")
                 .alias("no-pager")
                 .overrides_with("no-paging")
-                .hidden(true)
-                .hidden_short_help(true)
+                .hide(true)
+                .hide_short_help(true)
                 .help("Alias for '--paging=never'")
             )
         .arg(
-            Arg::with_name("pager")
+            Arg::new("pager")
                 .long("pager")
                 .env("BAT_PAGER")
                 .overrides_with("pager")
                 .takes_value(true)
                 .value_name("command")
-                .hidden_short_help(true)
+                .hide_short_help(true)
                 .help("Determine which pager to use.")
                 .long_help(
                     "Determine which pager is used. This option will override the \
@@ -333,13 +331,13 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                     To control when the pager is used, see the '--paging' option. \
                     Example: '--pager \"less -RF\"'."
                 )
-				.hide_env_values(true)
+				.hide_env(true)
         )
         .arg(
-            Arg::with_name("map-syntax")
-                .short("m")
+            Arg::new("map-syntax")
+                .short('m')
                 .long("map-syntax")
-                .multiple(true)
+                .multiple_occurrences(true)
                 .takes_value(true)
                 .number_of_values(1)
                 .value_name("glob:syntax")
@@ -354,7 +352,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("theme")
+            Arg::new("theme")
                 .long("theme")
                 .env("BAT_THEME")
                 .overrides_with("theme")
@@ -367,16 +365,16 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      BAT_THEME environment variable (e.g.: export \
                      BAT_THEME=\"...\").",
                 )
-				.hide_env_values(true)
+				.hide_env(true)
         )
         .arg(
-            Arg::with_name("list-themes")
+            Arg::new("list-themes")
                 .long("list-themes")
                 .help("Display all supported highlighting themes.")
                 .long_help("Display a list of supported themes for syntax highlighting."),
         )
         .arg(
-            Arg::with_name("style")
+            Arg::new("style")
                 .long("style")
                 .value_name("components")
                 .env("BAT_STYLE")
@@ -428,13 +426,13 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      * numbers: show line numbers in the side bar.\n  \
                      * snip: draw separation lines between distinct line ranges.",
                 )
-				.hide_env_values(true)
+				.hide_env(true)
         )
         .arg(
-            Arg::with_name("line-range")
+            Arg::new("line-range")
                 .long("line-range")
-                .short("r")
-                .multiple(true)
+                .short('r')
+                .multiple_occurrences(true)
                 .takes_value(true)
                 .number_of_values(1)
                 .value_name("N:M")
@@ -451,18 +449,18 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("list-languages")
+            Arg::new("list-languages")
                 .long("list-languages")
-                .short("L")
+                .short('L')
                 .conflicts_with("list-themes")
                 .help("Display all supported languages.")
                 .long_help("Display a list of supported languages for syntax highlighting."),
         )
         .arg(
-            Arg::with_name("unbuffered")
-                .short("u")
+            Arg::new("unbuffered")
+                .short('u')
                 .long("unbuffered")
-                .hidden_short_help(true)
+                .hide_short_help(true)
                 .long_help(
                     "This option exists for POSIX-compliance reasons ('u' is for \
                      'unbuffered'). The output is always unbuffered - this option \
@@ -470,72 +468,74 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
         .arg(
-            Arg::with_name("no-config")
+            Arg::new("no-config")
                 .long("no-config")
-                .hidden(true)
+                .hide(true)
                 .help("Do not use the configuration file"),
         )
         .arg(
-            Arg::with_name("no-custom-assets")
+            Arg::new("no-custom-assets")
                 .long("no-custom-assets")
-                .hidden(true)
+                .hide(true)
                 .help("Do not load custom assets"),
         )
         .arg(
-            Arg::with_name("config-file")
+            Arg::new("config-file")
                 .long("config-file")
                 .conflicts_with("list-languages")
                 .conflicts_with("list-themes")
-                .hidden(true)
+                .hide(true)
                 .help("Show path to the configuration file."),
         )
         .arg(
-            Arg::with_name("generate-config-file")
+            Arg::new("generate-config-file")
                 .long("generate-config-file")
                 .conflicts_with("list-languages")
                 .conflicts_with("list-themes")
-                .hidden(true)
+                .hide(true)
                 .help("Generates a default configuration file."),
         )
         .arg(
-            Arg::with_name("config-dir")
+            Arg::new("config-dir")
                 .long("config-dir")
-                .hidden(true)
+                .hide(true)
                 .help("Show bat's configuration directory."),
         )
         .arg(
-            Arg::with_name("cache-dir")
+            Arg::new("cache-dir")
                 .long("cache-dir")
-                .hidden(true)
+                .hide(true)
                 .help("Show bat's cache directory."),
         )
         .arg(
-            Arg::with_name("diagnostic")
+            Arg::new("diagnostic")
                 .long("diagnostic")
                 .alias("diagnostics")
-                .hidden_short_help(true)
+                .hide_short_help(true)
                 .help("Show diagnostic information for bug reports.")
         )
         .arg(
-            Arg::with_name("acknowledgements")
+            Arg::new("acknowledgements")
                 .long("acknowledgements")
-                .hidden_short_help(true)
+                .hide_short_help(true)
                 .help("Show acknowledgements."),
         )
         .arg(
-            Arg::with_name("ignored-suffix")
+            Arg::new("ignored-suffix")
                 .number_of_values(1)
-                .multiple(true)
+                .multiple_occurrences(true)
                 .takes_value(true)
                 .long("ignored-suffix")
-                .hidden_short_help(true)
+                .hide_short_help(true)
                 .help(
                     "Ignore extension. For example:\n  \
                     'bat --ignored-suffix \".dev\" my_file.json.dev' will use JSON syntax, and ignore '.dev'"
                 )
-        )
-        .help_message("Print this help message.")
-        .version_message("Show version information.");
+        );
+
+    let app = app
+        .mut_arg("help", |a| a.help("Print this help message."))
+        .mut_arg("version", |a| a.help("Show version information."));
 
     // Check if the current directory contains a file name cache. Otherwise,
     // enable the 'bat cache' subcommand.
@@ -543,12 +543,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         app
     } else {
         app.subcommand(
-            SubCommand::with_name("cache")
+            ClapApp::new("cache")
                 .about("Modify the syntax-definition and theme cache")
                 .arg(
-                    Arg::with_name("build")
+                    Arg::new("build")
                         .long("build")
-                        .short("b")
+                        .short('b')
                         .help("Initialize (or update) the syntax/theme cache.")
                         .long_help(
                             "Initialize (or update) the syntax/theme cache by loading from \
@@ -556,18 +556,18 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                         ),
                 )
                 .arg(
-                    Arg::with_name("clear")
+                    Arg::new("clear")
                         .long("clear")
-                        .short("c")
+                        .short('c')
                         .help("Remove the cached syntax definitions and themes."),
                 )
                 .group(
-                    ArgGroup::with_name("cache-actions")
+                    ArgGroup::new("cache-actions")
                         .args(&["build", "clear"])
                         .required(true),
                 )
                 .arg(
-                    Arg::with_name("source")
+                    Arg::new("source")
                         .long("source")
                         .requires("build")
                         .takes_value(true)
@@ -575,7 +575,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                         .help("Use a different directory to load syntaxes and themes from."),
                 )
                 .arg(
-                    Arg::with_name("target")
+                    Arg::new("target")
                         .long("target")
                         .requires("build")
                         .takes_value(true)
@@ -584,17 +584,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                             "Use a different directory to store the cached syntax and theme set.",
                         ),
                 )
-                .arg(
-                    Arg::with_name("blank")
-                        .long("blank")
-                        .requires("build")
-                        .help(
-                            "Create completely new syntax and theme sets \
+                .arg(Arg::new("blank").long("blank").requires("build").help(
+                    "Create completely new syntax and theme sets \
                              (instead of appending to the default sets).",
-                        ),
-                )
+                ))
                 .arg(
-                    Arg::with_name("acknowledgements")
+                    Arg::new("acknowledgements")
                         .long("acknowledgements")
                         .requires("build")
                         .help("Build acknowledgements.bin."),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -166,6 +166,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
     app = app.arg(
         Arg::with_name("tabs")
             .long("tabs")
+			.env("BAT_TABS")
             .overrides_with("tabs")
             .takes_value(true)
             .value_name("T")
@@ -319,6 +320,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("pager")
                 .long("pager")
+				.env("BAT_PAGER")
                 .overrides_with("pager")
                 .takes_value(true)
                 .value_name("command")
@@ -352,6 +354,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("theme")
                 .long("theme")
+				.env("BAT_THEME")
                 .overrides_with("theme")
                 .takes_value(true)
                 .help("Set the color theme for syntax highlighting.")
@@ -373,6 +376,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             Arg::with_name("style")
                 .long("style")
                 .value_name("components")
+				.env("BAT_STYLE")
                 // Need to turn this off for overrides_with to work as we want. See the bottom most
                 // example at https://docs.rs/clap/2.32.0/clap/struct.Arg.html#method.overrides_with
                 .use_delimiter(false)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -166,7 +166,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
     app = app.arg(
         Arg::with_name("tabs")
             .long("tabs")
-			.env("BAT_TABS")
+            .env("BAT_TABS")
             .overrides_with("tabs")
             .takes_value(true)
             .value_name("T")
@@ -321,7 +321,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("pager")
                 .long("pager")
-				.env("BAT_PAGER")
+                .env("BAT_PAGER")
                 .overrides_with("pager")
                 .takes_value(true)
                 .value_name("command")
@@ -356,7 +356,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("theme")
                 .long("theme")
-				.env("BAT_THEME")
+                .env("BAT_THEME")
                 .overrides_with("theme")
                 .takes_value(true)
                 .help("Set the color theme for syntax highlighting.")
@@ -379,7 +379,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             Arg::with_name("style")
                 .long("style")
                 .value_name("components")
-				.env("BAT_STYLE")
+                .env("BAT_STYLE")
                 // Need to turn this off for overrides_with to work as we want. See the bottom most
                 // example at https://docs.rs/clap/2.32.0/clap/struct.Arg.html#method.overrides_with
                 .use_delimiter(false)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -182,7 +182,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             .long_help(
                 "Set the tab width to T spaces. Use a width of 0 to pass tabs through \
                      directly",
-            ),
+            )
+			.hide_env_values(true)
     )
         .arg(
             Arg::with_name("wrap")
@@ -331,7 +332,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                     PAGER and BAT_PAGER environment variables. The default pager is 'less'. \
                     To control when the pager is used, see the '--paging' option. \
                     Example: '--pager \"less -RF\"'."
-                ),
+                )
+				.hide_env_values(true)
         )
         .arg(
             Arg::with_name("map-syntax")
@@ -364,7 +366,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      '--theme=\"...\"' option to the configuration file or export the \
                      BAT_THEME environment variable (e.g.: export \
                      BAT_THEME=\"...\").",
-                ),
+                )
+				.hide_env_values(true)
         )
         .arg(
             Arg::with_name("list-themes")
@@ -424,7 +427,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      * rule: horizontal lines to delimit files.\n  \
                      * numbers: show line numbers in the side bar.\n  \
                      * snip: draw separation lines between distinct line ranges.",
-                ),
+                )
+				.hide_env_values(true)
         )
         .arg(
             Arg::with_name("line-range")

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -286,11 +286,11 @@ fn run() -> Result<bool> {
     }
 
     match app.matches.subcommand() {
-        ("cache", Some(cache_matches)) => {
+        Some(("cache", cache_matches)) => {
             // If there is a file named 'cache' in the current working directory,
             // arguments for subcommand 'cache' are not mandatory.
             // If there are non-zero arguments, execute the subcommand cache, else, open the file cache.
-            if !cache_matches.args.is_empty() {
+            if cache_matches.is_present("build") || cache_matches.is_present("clear") {
                 run_cache_subcommand(cache_matches)?;
                 Ok(true)
             } else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -561,6 +561,18 @@ fn pager_overwrite() {
 }
 
 #[test]
+fn pager_env_overwrite_config() {
+    bat_with_config()
+        .env("BAT_CONFIG_PATH", "bat.conf")
+        .env("BAT_PAGER", "echo pager-output")
+        .arg("--paging=always")
+        .arg("test.txt")
+        .assert()
+        .success()
+        .stdout(predicate::eq("pager-output\n").normalize());
+}
+
+#[test]
 fn pager_overwrite_overwrite() {
     bat()
         .env("PAGER", "echo other-pager")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -538,10 +538,34 @@ fn pager_basic() {
 }
 
 #[test]
+fn pager_config() {
+    bat()
+        .arg("--pager=echo pager-output")
+        .arg("--paging=always")
+        .arg("test.txt")
+        .assert()
+        .success()
+        .stdout(predicate::eq("pager-output\n").normalize());
+}
+
+#[test]
 fn pager_overwrite() {
     bat()
         .env("PAGER", "echo other-pager")
         .env("BAT_PAGER", "echo pager-output")
+        .arg("--paging=always")
+        .arg("test.txt")
+        .assert()
+        .success()
+        .stdout(predicate::eq("pager-output\n").normalize());
+}
+
+#[test]
+fn pager_overwrite_overwrite() {
+    bat()
+        .env("PAGER", "echo other-pager")
+        .env("BAT_PAGER", "echo another-pager")
+        .arg("--pager=echo pager-output")
         .arg("--paging=always")
         .arg("test.txt")
         .assert()


### PR DESCRIPTION
Parses env configurations into matches (for those that can be configured
via matches) instead of relying on dedicated env checks everywhere.

Fixes #1152