### PR TITLE
Add `-S` flag to less when `--wrap=never` (closes #1255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Features
 
+- Adjust pager configuration to comply with `--wrap=never`, see #1255 (@gahag)
+
 ## Bugfixes
 
 ## Other

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -54,7 +54,10 @@ impl<'b> Controller<'b> {
                     paging_mode = PagingMode::Never;
                 }
             }
-            output_type = OutputType::from_mode(paging_mode, self.config.pager)?;
+
+            let wrapping_mode = self.config.wrapping_mode;
+
+            output_type = OutputType::from_mode(paging_mode, wrapping_mode, self.config.pager)?;
         }
 
         #[cfg(not(feature = "paging"))]

--- a/src/output.rs
+++ b/src/output.rs
@@ -12,7 +12,7 @@ use crate::wrapping::WrappingMode;
 
 
 #[cfg(feature = "paging")]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum SingleScreenAction {
     Quit,
     Nothing,
@@ -93,11 +93,11 @@ impl OutputType {
                     let mut p = Command::new(&pager_path);
                     if args.is_empty() || replace_arguments_to_less {
                         p.arg("--RAW-CONTROL-CHARS");
-                        if let SingleScreenAction::Quit = single_screen_action {
+                        if single_screen_action == SingleScreenAction::Quit {
                             p.arg("--quit-if-one-screen");
                         }
 
-                        if let WrappingMode::NoWrapping = wrapping_mode {
+                        if wrapping_mode == WrappingMode::NoWrapping {
                             p.arg("--chop-long-lines");
                         }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,6 +7,8 @@ use crate::error::*;
 use crate::less::retrieve_less_version;
 #[cfg(feature = "paging")]
 use crate::paging::PagingMode;
+#[cfg(feature = "paging")]
+use crate::wrapping::WrappingMode;
 
 #[derive(Debug)]
 pub enum OutputType {
@@ -17,18 +19,23 @@ pub enum OutputType {
 
 impl OutputType {
     #[cfg(feature = "paging")]
-    pub fn from_mode(mode: PagingMode, pager: Option<&str>) -> Result<Self> {
+    pub fn from_mode(paging_mode: PagingMode, wrapping_mode: WrappingMode, pager: Option<&str>) -> Result<Self> {
         use self::PagingMode::*;
-        Ok(match mode {
-            Always => OutputType::try_pager(false, pager)?,
-            QuitIfOneScreen => OutputType::try_pager(true, pager)?,
+        use self::WrappingMode::*;
+        Ok(match paging_mode {
+            Always => OutputType::try_pager(false, wrapping_mode == Character, pager)?,
+            QuitIfOneScreen => OutputType::try_pager(true, wrapping_mode == Character, pager)?,
             _ => OutputType::stdout(),
         })
     }
 
     /// Try to launch the pager. Fall back to stdout in case of errors.
     #[cfg(feature = "paging")]
-    fn try_pager(quit_if_one_screen: bool, pager_from_config: Option<&str>) -> Result<Self> {
+    fn try_pager(
+        quit_if_one_screen: bool,
+        line_wrap: bool,
+        pager_from_config: Option<&str>
+    ) -> Result<Self> {
         use std::env;
         use std::ffi::OsString;
         use std::path::PathBuf;
@@ -80,6 +87,10 @@ impl OutputType {
                         p.arg("--RAW-CONTROL-CHARS");
                         if quit_if_one_screen {
                             p.arg("--quit-if-one-screen");
+                        }
+
+                        if !line_wrap {
+                            p.arg("-S");
                         }
 
                         // Passing '--no-init' fixes a bug with '--quit-if-one-screen' in older


### PR DESCRIPTION
Prevent less from wrapping lines by setting the proper flag when `--wrap=never`.
If the user set a custom value for `--pager`, no additional flag is set.

The implementation is done, I just have to finish testing with the many less versions.
I'm considering building a docker image with the relevant less versions to help testing.