### PR TITLE
Set line endings for batch files to LF for syntax-tests

### DIFF
--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -4,10 +4,6 @@ snapshots/** text=auto eol=lf
 syntax-tests/source/** text=auto eol=lf
 syntax-tests/highlighted/** text=auto eol=lf
 
-# BAT/CMD files always need CRLF EOLs
-*.[Bb][Aa][Tt] text eol=crlf
-*.[Cc][Mm][Dd] text eol=crlf
-
 examples/* linguist-vendored
 snapshots/* linguist-vendored
 benchmarks/* linguist-vendored


### PR DESCRIPTION
I tried to fix the outgoing change in `highlighted/Batch/build.bat` after running `update.sh`, and as you mentioned in https://github.com/sharkdp/bat/pull/1289#issuecomment-705490210, the source file has CRLF line endings too.

But it looks like this is a git thing, git always commits .bat files with CRLF (because it looks like they don't run correctly with LF line endings, and while we don't want to run these syntax-test files, git doesn't know that). And whatever I tried to make git ignore this and just commit these files with only LF, it ignored all of my tries and just converts the file back to CRLF (`warning: LF will be replaced by CRLF in tests/syntax-tests/highlighted/Batch/build.bat`).

So I started comparing the generated files on a binary level and saw that the difference is only the last newline. The commited file has CRLF as every newline, but after running the `update.sh` the last newline was only a LF. So I changed the `create_highlighted_versions.py` script to replace that last newline with a CRLF which is what git would do too. That way the script always already generates the file git already knows, so it doesn't show an outgoing change after running `update.sh`.

This maybe isn't the best solution, but as said, everything else I tried didn't work. If somebody has a better solution, I'm open for feedback. The alternative would be to just ignore this, because when trying to commit the outgoing change it just disappears, but I still think it's confusing because it's showing an outgoing change I wouldn't expect when running `update.sh`. :shrug: 

Relates to #1213 