### PR TITLE
Add mapping for Cake (.cake) files

### DIFF
--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -24,6 +24,7 @@ impl<'a> SyntaxMapping<'a> {
         let mut mapping = Self::empty();
         mapping.insert("*.h", MappingTarget::MapTo("C++")).unwrap();
         mapping.insert("*.fs", MappingTarget::MapTo("F#")).unwrap();
+        mapping.insert("*.cake", MappingTarget::MapTo("C#")).unwrap();
         mapping
             .insert("build", MappingTarget::MapToUnknown)
             .unwrap();


### PR DESCRIPTION
This PR adds syntax mappings for [Cake (C# Make)](https://github.com/cake-build/cake) build script definitions.

I couldn't find a CONTRIBUTING.md so not sure if you accept pull requests for things like this, but it would be super convenient to have support for this out of the box.