### PR TITLE
Fix zsh completion

### DIFF
--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -3,8 +3,8 @@
 local context state state_descr line
 typeset -A opt_args
 
-(( $+functions[_cache_subcommand] )) ||
-_cache_subcommand() {
+(( $+functions[_{{PROJECT_EXECUTABLE}}_cache_subcommand] )) ||
+_{{PROJECT_EXECUTABLE}}_cache_subcommand() {
     local -a args
     args=(
         '(-b --build -c --clear)'{-b,--build}'[Initialize or update the syntax/theme cache]'
@@ -19,12 +19,12 @@ _cache_subcommand() {
     _arguments -S -s $args
 }
 
-(( $+functions[_main] )) ||
-_main() {
+(( $+functions[_{{PROJECT_EXECUTABLE}}_main] )) ||
+_{{PROJECT_EXECUTABLE}}_main() {
     local -a args
     args=(
         '(-A --show-all)'{-A,--show-all}'[Show non-printable characters (space, tab, newline, ..)]'
-        {-p,--plain}'[Show plain style (alias for `--style=plain`)]:When `-p` is used twice (`-pp`), it also disables automatic paging (alias for `--style=plain --paging=never`)'
+        '*'{-p,--plain}'[Show plain style (alias for `--style=plain`), repeat twice to disable disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[Set the language for syntax highlighting]:<language>:->language'
         '(-H --highlight-line)'{-H,--highlight-line}'[Highlight lines N through M]:<N\:M>...'
         '(--file-name)'--file-name'[Specify the name to display for a file]:<name>...:_files'
@@ -51,13 +51,13 @@ _main() {
 
     _arguments -S -s $args
 
-    case "$state" in 
+    case "$state" in
         language)
             local IFS=$'\n'
             local -a languages
             languages=( $({{PROJECT_EXECUTABLE}} --list-languages | awk -F':|,' '{ for (i = 1; i <= NF; ++i) printf("%s:%s\n", $i, $1) }') )
 
-            _describe 'language' languages 
+            _describe 'language' languages
         ;;
 
         theme)
@@ -79,15 +79,15 @@ if (( ${#words} == 2 )); then
     local -a subcommands
     subcommands=('cache:Modify the syntax-definition and theme cache')
     _describe subcommand subcommands
-    _main
+    _{{PROJECT_EXECUTABLE}}_main
 else
     case $words[2] in
         cache)
-            _cache_subcommand
+            _{{PROJECT_EXECUTABLE}}_cache_subcommand
         ;;
 
         *)
-            _main
+            _{{PROJECT_EXECUTABLE}}_main
         ;;
     esac
 fi


### PR DESCRIPTION
* Fix completion for `-p` option (closes #1320). The issue was in the `-p/--plain` option (it was expecting an argument), other flags are fine.

* Use prefixed function names to avoid a name clash. Functions in zsh are global, so having a function with the name `_main` isn't good.