### PR TITLE
Throws an error when `bat` is being user as pager.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Bugfixes
 
+- Throws an error when `bat` is being used as `pager`, see #1343 (@adrian-rivera)
+
 ## Other
 
 ## Syntaxes

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,10 @@ error_chain! {
             description("unknown syntax"),
             display("unknown syntax: '{}'", name)
         }
+        InvalidPagerValueBat {
+            description("invalid value `bat` for pager property"),
+            display("Use of bat as a pager is disallowed in order to avoid infinite recursion problems")
+        }
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -85,10 +85,10 @@ impl OutputType {
 
         match pagerflags.split_first() {
             Some((pager_name, args)) => {
-                let mut pager_path = PathBuf::from(pager_name);
+                let pager_path = PathBuf::from(pager_name);
 
                 if pager_path.file_stem() == Some(&OsString::from("bat")) {
-                    pager_path = PathBuf::from("less");
+                    return Err(ErrorKind::InvalidPagerValueBat.into());
                 }
 
                 let is_less = pager_path.file_stem() == Some(&OsString::from("less"));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -406,6 +406,16 @@ fn pager_disable() {
 }
 
 #[test]
+fn pager_value_bat() {
+    bat()
+        .arg("--pager=bat")
+        .arg("--paging=always")
+        .arg("test.txt")
+        .assert()
+        .failure();
+}
+
+#[test]
 fn alias_pager_disable() {
     bat()
         .env("PAGER", "echo other-pager")


### PR DESCRIPTION
As mentioned on #1334 `bat` should not be used as a value for `pager`,
this change checks both the balue of `bat` provided as a parameter or
as an environment variable.