### PR TITLE
Add extra themes help to output

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -205,6 +205,14 @@ pub fn list_themes(cfg: &Config) -> Result<()> {
             writeln!(stdout, "{}", theme)?;
         }
     }
+    writeln!(
+        stdout,
+        "Further themes can be installed to '{}/themes', \
+        and are added to the cache with `bat cache --build`. \
+        For more information, see:\n\n  \
+        https://github.com/sharkdp/bat#adding-new-themes",
+        config_file().to_string_lossy()
+    )?;
 
     Ok(())
 }

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -207,11 +207,11 @@ pub fn list_themes(cfg: &Config) -> Result<()> {
     }
     writeln!(
         stdout,
-        "Further themes can be installed to '{}/themes', \
+        "Further themes can be installed to '{}', \
         and are added to the cache with `bat cache --build`. \
         For more information, see:\n\n  \
         https://github.com/sharkdp/bat#adding-new-themes",
-        config_file().to_string_lossy()
+        config_file().join("themes").to_string_lossy()
     )?;
 
     Ok(())


### PR DESCRIPTION
This outputs some help text regarding adding extra themes when --list-themes is run. Initially thought it would go under help for --list-themes or --help but believe this is the best place for it. However happy to move it to a more appropriate location.


Closes #1162
