### PR TITLE
Highlight ebuild/eclass files with shell syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Bugfixes
 
 - Throws an error when `bat` is being used as `pager`, see #1343 (@adrian-rivera)
+- Bash syntax highlighting not selected for `*.ebuild` and `*.eclass` files, see #1292 (@sharkdp)
 
 ## Other
 

--- a/assets/patches/ShellScript.sublime-syntax.patch
+++ b/assets/patches/ShellScript.sublime-syntax.patch
@@ -1,0 +1,15 @@
+diff --git syntaxes/01_Packages/ShellScript/Bash.sublime-syntax syntaxes/01_Packages/ShellScript/Bash.sublime-syntax
+index e973e319..a703cef8 100644
+--- syntaxes/01_Packages/ShellScript/Bash.sublime-syntax
++++ syntaxes/01_Packages/ShellScript/Bash.sublime-syntax
+@@ -30,8 +30,8 @@ file_extensions:
+   - .zshenv
+   - .zshrc
+   - PKGBUILD  # https://jlk.fjfi.cvut.cz/arch/manpages/man/PKGBUILD.5
+-  - .ebuild
+-  - .eclass
++  - ebuild
++  - eclass
+ 
+ first_line_match: |
+   (?x)


### PR DESCRIPTION
Upstream patch: https://github.com/sublimehq/Packages/pull/2541

closes #1292