### PR TITLE
only try to publish one set of archives/packages for linux x64

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -152,6 +152,8 @@ jobs:
         echo ::set-output name=PKG_NAME::${PKG_NAME}
         # deployable tag? (ie, leading "vM" or "M"; M == version number)
         unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
+        # unset deploy on ubuntu-18.04 x64 - we will deploy the tarball/deb built on ubuntu-16.04 x64
+        if [ "${{ matrix.job.os }}" = "ubuntu-18.04" ] && [ "${{ matrix.job.target }}" = "x86_64-unknown-linux-gnu" ]; then unset DEPLOY; fi
         echo set-output name=DEPLOY::${DEPLOY:-<empty>/false}
         echo ::set-output name=DEPLOY::${DEPLOY}
         # DPKG architecture?


### PR DESCRIPTION
This will resolve the race condition where both the ubuntu 16.04 x64 and ubuntu 18.04 x64 builds generate a `bat-VERSION-x86_64-unknown-linux-gnu.tar.gz` and `bat_VERSION_amd64.deb` and try to publish them. We favour the older release for compatibility.