### PR TITLE
make bat -L use pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## Features
+- make `bat -L` use built-in pager 
 
 ## Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## Features
-- make `bat -L` use built-in pager 
+- Use a pager when `bat --list-languages` is called, see #1394 (@stku1985)
 
 ## Bugfixes
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -36,6 +36,7 @@ use bat::{
     input::Input,
     style::{StyleComponent, StyleComponents},
     MappingTarget,
+    PagingMode,
 };
 
 const THEME_PREVIEW_DATA: &[u8] = include_bytes!("../../../assets/theme_preview.rs");
@@ -248,9 +249,13 @@ fn run() -> Result<bool> {
 
             if app.matches.is_present("list-languages") {
                 let languages: String = get_languages(&config)?;
-                let inputs: Vec<Input> = vec!(Input::from_reader(Box::new(languages.as_bytes())));
-                let config = app.config(&inputs)?;
-                run_controller(inputs, &config)
+                let inputs: Vec<Input> = vec![Input::from_reader(Box::new(languages.as_bytes()))];
+                let plain_config = Config {
+                    style_components: StyleComponents::new(StyleComponent::Plain.components(false)),
+                    paging_mode: PagingMode::QuitIfOneScreen,
+                    ..Default::default()
+                };
+                run_controller(inputs, &plain_config)
             } else if app.matches.is_present("list-themes") {
                 list_themes(&config)?;
                 Ok(true)


### PR DESCRIPTION
Hello dear `bat`-team,

I took a look at the issues page and implemented the following: https://github.com/sharkdp/bat/issues/1394;
i.e. this PR makes `bat -L` use its built-in pager.

Since I am new to this whole project I am thankful for any pointers.

One thing I want to discuss: `bat -L` is not the only command producing long output. Shall I implement the same paging logic for these as well?