### PR TITLE
Add Clippy linter step to CICD

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets --all-features -- --deny warnings --allow clippy::new-without-default --allow clippy::match-bool --allow clippy::if_same_then_else
+        args: --all-targets --all-features
     - name: Test
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -22,6 +22,12 @@ jobs:
         toolchain: ${{ env.MIN_SUPPORTED_RUST_VERSION }}
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
+        components: clippy
+    - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all-targets --all-features -- --deny warnings --allow clippy::new-without-default --allow clippy::match-bool --allow clippy::if_same_then_else
     - name: Test
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Run the linter on the minimum supported rust version; otherwise we will
get lint warnings for things that require a too high Rust toolchain
version to fix.

Allow the following warnings, since we already have them our code:
- clippy::new-without-default
- clippy::match-bool
- clippy::if_same_then_else

Eventually we should fix these lint issues and then disallow them to
prevent them from coming back in other places.

The clippy args used is recommended here:
https://github.com/rust-lang/rust-clippy#travis-ci

I noticed that my PR #1402 passed CICD checks despite having some lint issues, so I thought it would be a good idea to add a linter step to CICD.

I tested the new step in GitHub Actions over at my fork, and it seems to work. You can check here if you want: https://github.com/Enselic/bat/runs/1467487513?check_suite_focus=true (Please ignore my temp changes to CICD.yml to be able to make the test).

But of course it would be a good idea for you to make sure the new step works when triggered from this repo as well. I think you have to trigger it manually since I don't have permission to trigger new CI/CD steps in this repo (which makes sense for security reasons of course).

(I didn't add anything about this to CHANGELOG.md since the change does not affect the behavior of bat, as touched upon in CONTRIBUTING.md)
