### PR TITLE
ShellCheck

### DIFF
--- a/diagnostics/info.sh
+++ b/diagnostics/info.sh
@@ -58,7 +58,8 @@ _bat_:run() {
 	_out "$BAT" --version
 	_out env | grep '^BAT_\|^PAGER='
 
-	local cache_dir="$($BAT --cache-dir)"
+	local cache_dir
+	cache_dir="$($BAT --cache-dir)"
 	if [[ -f "${cache_dir}/syntaxes.bin" ]]; then
 		_print_command "$BAT" "--list-languages"
 		echo "Found custom syntax set."
@@ -79,8 +80,8 @@ _bat_config_:run() {
 _bat_wrapper_:run() {
 	_bat_wrapper_:detect_wrapper() {
 		local bat="$1"
-		if file "$(which "${bat}")" | grep "text executable" &> /dev/null; then
-			_out_fence cat "$(which "${bat}")"
+		if file "$(command -v "${bat}")" | grep "text executable" &> /dev/null; then
+			_out_fence cat "$(command -v "${bat}")"
 			return
 		fi
 
@@ -104,7 +105,8 @@ _bat_wrapper_function_:run() {
 				fi ;;
 
 			*bash* | *zsh*)
-				local type="$("$SHELL" --login -i -c "type ${command}" 2>&1)"
+				local type
+				type="$("$SHELL" --login -i -c "type ${command}" 2>&1)"
 				if grep 'function' <<< "$type" &> /dev/null; then
 					_out_fence "$SHELL" --login -i -c "declare -f ${command}"
 					return

--- a/tests/benchmarks/comparison.sh
+++ b/tests/benchmarks/comparison.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit
 
-if ! which hyperfine > /dev/null 2>&1; then
+if ! command -v hyperfine > /dev/null 2>&1; then
     echo "'hyperfine' does not seem to be installed."
     echo "You can get it here: https://github.com/sharkdp/hyperfine"
     exit 1

--- a/tests/benchmarks/run-benchmarks.sh
+++ b/tests/benchmarks/run-benchmarks.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit
 
-if ! which hyperfine > /dev/null 2>&1; then
+if ! command -v hyperfine > /dev/null 2>&1; then
     echo "'hyperfine' does not seem to be installed."
     echo "You can get it here: https://github.com/sharkdp/hyperfine"
     exit 1

--- a/tests/syntax-tests/update.sh
+++ b/tests/syntax-tests/update.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit
 
 python="python3"
 if ! command -v python3 &>/dev/null; then python="python"; fi


### PR DESCRIPTION
Fix the following warnings.

[SC2155](https://github.com/koalaman/shellcheck/wiki/SC2155): Declare and assign separately to avoid masking return values.
[SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164): Use cd ... || exit in case cd fails.
[SC2230](https://github.com/koalaman/shellcheck/wiki/SC2230): which is non-standard. Use builtin 'command -v' instead.