### PR TITLE
Add `-s`/`--squeeze` and `--squeeze-limit`.

### DIFF
--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -234,6 +234,11 @@ impl App {
                 .map(LineRanges::from)
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
+            squeeze_lines: if self.matches.is_present("squeeze") {
+                1
+            } else {
+                0
+            },
         })
     }
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -235,9 +235,14 @@ impl App {
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
             squeeze_lines: if self.matches.is_present("squeeze") {
-                1
+                Some(
+                    self.matches
+                        .value_of("squeeze-limit")
+                        .and_then(|s| s.parse::<usize>().ok())
+                        .unwrap_or(1),
+                )
             } else {
-                0
+                None
             },
         })
     }

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -353,6 +353,13 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long_help("Display a list of supported themes for syntax highlighting."),
         )
         .arg(
+            Arg::with_name("squeeze")
+                .long("squeeze")
+                .short("s")
+                .help("Squeeze consecutive empty lines.")
+                .long_help("Squeeze consecutive empty lines into a single empty line.")
+        )
+        .arg(
             Arg::with_name("style")
                 .long("style")
                 .value_name("components")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -360,6 +360,14 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long_help("Squeeze consecutive empty lines into a single empty line.")
         )
         .arg(
+            Arg::with_name("squeeze-limit")
+                .long("squeeze-limit")
+                .takes_value(true)
+                .validator(|s| s.parse::<usize>().map(|_| ()).map_err(|_| "Requires a non-negative number".to_owned()))
+                .help("The maximum number of consecutive empty lines.")
+                .long_help("Set the maximum number of consecutive empty lines to be printed.")
+        )
+        .arg(
             Arg::with_name("style")
                 .long("style")
                 .value_name("components")

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,7 +84,7 @@ pub struct Config<'a> {
     pub highlighted_lines: HighlightedLineRanges,
 
     /// The maximum number of consecutive empty lines to display
-    pub squeeze_lines: usize,
+    pub squeeze_lines: Option<usize>,
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,9 @@ pub struct Config<'a> {
 
     /// Ranges of lines which should be highlighted with a special background color
     pub highlighted_lines: HighlightedLineRanges,
+
+    /// The maximum number of consecutive empty lines to display
+    pub squeeze_lines: usize,
 }
 
 #[test]

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -259,8 +259,7 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     /// Specify the maximum number of consecutive empty lines to print.
-    /// If set to `0`, all empty lines will be shown.
-    pub fn squeeze_empty_lines(&mut self, maximum: usize) -> &mut Self {
+    pub fn squeeze_empty_lines(&mut self, maximum: Option<usize>) -> &mut Self {
         self.config.squeeze_lines = maximum;
         self
     }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -258,6 +258,13 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Specify the maximum number of consecutive empty lines to print.
+    /// If set to `0`, all empty lines will be shown.
+    pub fn squeeze_empty_lines(&mut self, maximum: usize) -> &mut Self {
+        self.config.squeeze_lines = maximum;
+        self
+    }
+
     /// Specify the highlighting theme
     pub fn theme(&mut self, theme: impl AsRef<str>) -> &mut Self {
         self.config.theme = theme.as_ref().to_owned();

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -398,10 +398,10 @@ impl<'a> Printer for InteractivePrinter<'a> {
         };
 
         // Skip squeezed lines.
-        if self.config.squeeze_lines > 0 {
+        if let Some(squeeze_limit) = self.config.squeeze_lines {
             if line.trim_end_matches(|c| c == '\r' || c == '\n').is_empty() {
                 self.consecutive_empty_lines += 1;
-                if self.consecutive_empty_lines > self.config.squeeze_lines {
+                if self.consecutive_empty_lines > squeeze_limit {
                     return Ok(());
                 }
             } else {


### PR DESCRIPTION
After some reconsideration towards #762, I decided to try adding support for `bat -s`.

While I personally think that having the option to squeeze empty lines goes against the Unix philosophy, `cat` itself has the feature on every distro. For the sake of maintaining drop-in replacement compatibility, I added support to bat.

Another benefit of including it rather than relying on sed would be to show the correct line numbers in the sidebar.

---

This pull request adds:

- `bat --squeeze`/`bat -s`
- `bat --squeeze-limit=<number>` -- to set the maximum number of consecutive empty lines when using `-s`
- `PrettyPrinter::squeeze_empty_lines`
