### PR TITLE
Fix #1443 macOS: regression_test.sh: mktemp: illegal option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## Bugfixes
 
+- Make ./tests/syntax-tests/regression_test.sh work on recent versions of macOS, see #1443 (@Enselic)
+
 ## Other
 
 ## Syntaxes

--- a/tests/syntax-tests/regression_test.sh
+++ b/tests/syntax-tests/regression_test.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 
 script_directory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-output_directory=$(mktemp -d --suffix=.bat-syntax-regression-test)
+output_directory=$(mktemp -d)
 
 "$script_directory"/create_highlighted_versions.py --output="$output_directory"
 


### PR DESCRIPTION
The macOS version of mktemp does not recognize the --suffix option.
Using pure -d should work since, it seems [1], macOS 10.11 however.

So to make the script work on macOS, stop using the --suffix option.

The downside is of course that the temporary dir will have an anonymous
name, but I see no risk of confusion given how short-lived the usage of
the dir is, and given the context it is used.

I will not be offended if you disagree, but it is nice to keep things simple.

[1] https://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x