### PR TITLE
Add test 'grid_for_file_without_newline' (for issue #299 fix)

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -827,3 +827,27 @@ fn plain_mode_does_not_add_nonexisting_newline() {
         .stdout("Single Line");
 }
 
+// Regression test for https://github.com/sharkdp/bat/issues/299
+#[test]
+fn grid_for_file_without_newline() {
+    bat()
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=full")
+        .arg("single-line.txt")
+        .assert()
+        .success()
+        .stdout(
+            "\
+───────┬────────────────────────────────────────────────────────────────────────
+       │ File: single-line.txt
+───────┼────────────────────────────────────────────────────────────────────────
+   1   │ Single Line
+───────┴────────────────────────────────────────────────────────────────────────
+",
+        )
+        .stderr("");
+}


### PR DESCRIPTION
This is a regression test for the fix for issue #299. If that fix is
reverted, currently only one test ('header_padding') fails. But that
test is for a different use case, so add a dedicated regression test for
the particular use case issue #299 is about.