### PR TITLE
Add Syntax Highlighting for Lean

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -207,3 +207,6 @@
 	path = assets/themes/gruvbox
 	url = https://github.com/subnut/gruvbox-tmTheme.git
 	branch = bat-source
+[submodule "assets/syntaxes/02_Extra/Lean"]
+	path = assets/syntaxes/02_Extra/Lean
+	url = https://github.com/leanprover/vscode-lean.git

--- a/assets/syntaxes/02_Extra/Lean.sublime-syntax
+++ b/assets/syntaxes/02_Extra/Lean.sublime-syntax
@@ -1,0 +1,125 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Lean
+file_extensions:
+  - lean
+scope: source.lean
+contexts:
+  main:
+    - include: comments
+    - match: '\b(?<!\.)(inductive|coinductive|structure|theorem|axiom|axioms|abbreviation|lemma|definition|def|instance|class|constant)\b\s+(\{[^}]*\})?'
+      captures:
+        1: keyword.other.definitioncommand.lean
+      push:
+        - meta_scope: meta.definitioncommand.lean
+        - match: '(?=\bwith\b|\bextends\b|[:\|\(\[\{⦃<>])'
+          pop: true
+        - include: comments
+        - include: definitionName
+        - match: ","
+    - match: \b(Prop|Type|Sort)\b
+      scope: storage.type.lean
+    - match: '\battribute\b\s*\[[^\]]*\]'
+      scope: storage.modifier.lean
+    - match: '@\[[^\]]*\]'
+      scope: storage.modifier.lean
+    - match: \b(?<!\.)(private|meta|mutual|protected|noncomputable)\b
+      scope: keyword.control.definition.modifier.lean
+    - match: \b(sorry)\b
+      scope: invalid.illegal.lean
+    - match: '#print\s+(def|definition|inductive|instance|structure|axiom|axioms|class)\b'
+      scope: keyword.other.command.lean
+    - match: '#(print|eval|reduce|check|help|exit|find|where)\b'
+      scope: keyword.other.command.lean
+    - match: \b(?<!\.)(import|export|prelude|theory|definition|def|abbreviation|instance|renaming|hiding|exposing|parameter|parameters|begin|constant|constants|lemma|variable|variables|theorem|example|open|axiom|inductive|coinductive|with|structure|universe|universes|alias|precedence|reserve|postfix|prefix|infix|infixl|infixr|notation|end|using|namespace|section|local|set_option|extends|include|omit|class|classes|instances|raw|run_cmd|restate_axiom)(?!\.)\b
+      scope: keyword.other.lean
+    - match: \b(?<!\.)(calc|have|this|match|do|suffices|show|by|in|at|let|forall|fun|exists|assume|from|obtain|haveI|λ)(?!\.)\b
+      scope: keyword.other.lean
+    - match: «
+      push:
+        - meta_content_scope: entity.name.lean
+        - match: »
+          pop: true
+    - match: \b(?<!\.)(if|then|else)\b
+      scope: keyword.control.lean
+    - match: '"'
+      captures:
+        0: punctuation.definition.string.begin.lean
+      push:
+        - meta_scope: string.quoted.double.lean
+        - match: '"'
+          captures:
+            0: punctuation.definition.string.end.lean
+          pop: true
+        - match: '\\[\\"nt'']'
+          scope: constant.character.escape.lean
+        - match: '\\x[0-9A-Fa-f][0-9A-Fa-f]'
+          scope: constant.character.escape.lean
+        - match: '\\u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]'
+          scope: constant.character.escape.lean
+    - match: '''[^\\'']'''
+      scope: string.quoted.single.lean
+    - match: '''(\\(x..|u....|.))'''
+      scope: string.quoted.single.lean
+      captures:
+        1: constant.character.escape.lean
+    - match: '`+[^\[(]\S+'
+      scope: entity.name.lean
+    - match: '\b([0-9]+|0([xX][0-9a-fA-F]+))\b'
+      scope: constant.numeric.lean
+  blockComment:
+    - match: /-
+      push:
+        - meta_scope: comment.block.lean
+        - match: "-/"
+          pop: true
+        - include: scope:source.lean.markdown
+        - include: blockComment
+  comments:
+    - include: dashComment
+    - include: docComment
+    - include: stringBlock
+    - include: modDocComment
+    - include: blockComment
+  dashComment:
+    - match: (--)
+      captures:
+        0: punctuation.definition.comment.lean
+      push:
+        - meta_scope: comment.line.double-dash.lean
+        - match: $
+          pop: true
+        - include: scope:source.lean.markdown
+  definitionName:
+    - match: '\b[^:«»\(\)\{\}[:space:]=→λ∀?][^:«»\(\)\{\}[:space:]]*'
+      scope: entity.name.function.lean
+    - match: «
+      push:
+        - meta_content_scope: entity.name.function.lean
+        - match: »
+          pop: true
+  docComment:
+    - match: /--
+      push:
+        - meta_scope: comment.block.documentation.lean
+        - match: "-/"
+          pop: true
+        - include: scope:source.lean.markdown
+        - include: blockComment
+  modDocComment:
+    - match: /-!
+      push:
+        - meta_scope: comment.block.documentation.lean
+        - match: "-/"
+          pop: true
+        - include: scope:source.lean.markdown
+        - include: blockComment
+  stringBlock:
+    - match: /-"
+      push:
+        - meta_scope: comment.block.string.lean
+        - match: '"-/'
+          pop: true
+        - include: scope:source.lean.markdown
+        - include: blockComment

--- a/doc/assets.md
+++ b/doc/assets.md
@@ -59,3 +59,4 @@ The following files have been manually modified after converting from a `.tmLang
    https://github.com/seanjames777/SML-Language-Definition/blob/master/sml.tmLanguage
 * `Cabal.sublime_syntax` has been added manually from
   https://github.com/SublimeHaskell/SublimeHaskell/ - we don't want to include the whole submodule because it includes other syntaxes ("Haskell improved") as well.
+* `Lean.sublime-syntax` has been added manually from https://github.com/leanprover/vscode-lean/blob/master/syntaxes/lean.json via conversion.

--- a/tests/syntax-tests/highlighted/Lean/test.lean
+++ b/tests/syntax-tests/highlighted/Lean/test.lean
@@ -1,0 +1,68 @@
+[38;2;249;38;114mimport[0m[38;2;248;248;242m data.matrix.notation[0m
+[38;2;249;38;114mimport[0m[38;2;248;248;242m data.vector2[0m
+
+[38;2;117;113;94m/-![0m
+
+[38;2;117;113;94mHelpers that don't currently fit elsewhere...[0m
+
+[38;2;117;113;94m-/[0m
+
+[38;2;249;38;114mlemma[0m[38;2;248;248;242m [0m[38;2;166;226;46msplit_eq[0m[38;2;248;248;242m [0m[38;2;248;248;242m{m n : [0m[3;38;2;102;217;239mType[0m[38;2;248;248;242m*} (x : m × n) (p p' : m × n) :[0m
+[38;2;248;248;242m  p = x ∨ p' = x ∨ (x ≠ p ∧ x ≠ p') := [0m[38;2;249;38;114mby[0m[38;2;248;248;242m tauto[0m
+
+[38;2;117;113;94m--[0m[38;2;117;113;94m For `playfield`s, the piece type and/or piece index type.[0m
+[38;2;249;38;114mvariables[0m[38;2;248;248;242m (X : [0m[3;38;2;102;217;239mType[0m[38;2;248;248;242m*)[0m
+[38;2;249;38;114mvariables[0m[38;2;248;248;242m [has_repr X][0m
+
+[38;2;249;38;114mnamespace[0m[38;2;248;248;242m chess.utils[0m
+
+[38;2;249;38;114msection[0m[38;2;248;248;242m repr[0m
+
+[38;2;117;113;94m/--[0m
+[38;2;117;113;94mAn auxiliary wrapper for `option X` that allows for overriding the `has_repr` instance[0m
+[38;2;117;113;94mfor `option`, and rather, output just the value in the `some` and a custom provided[0m
+[38;2;117;113;94m`string` for `none`.[0m
+[38;2;117;113;94m-/[0m
+[38;2;249;38;114mstructure[0m[38;2;248;248;242m [0m[38;2;166;226;46moption_wrapper[0m[38;2;248;248;242m [0m[38;2;248;248;242m:=[0m
+[38;2;248;248;242m(val : option X)[0m
+[38;2;248;248;242m(none_s : string)[0m
+
+[38;2;249;38;114minstance[0m[38;2;248;248;242m [0m[38;2;166;226;46mwrapped_option_repr[0m[38;2;248;248;242m [0m[38;2;248;248;242m: has_repr (option_wrapper X) :=[0m
+[38;2;248;248;242m⟨[0m[38;2;249;38;114mλ[0m[38;2;248;248;242m ⟨val, s⟩, (option.map has_repr.repr val).get_or_else s⟩[0m
+
+[38;2;249;38;114mvariables[0m[38;2;248;248;242m {X}[0m
+[38;2;117;113;94m/--[0m
+[38;2;117;113;94mConstruct an `option_wrapper` term from a provided `option X` and the `string`[0m
+[38;2;117;113;94mthat will override the `has_repr.repr` for `none`.[0m
+[38;2;117;113;94m-/[0m
+[38;2;249;38;114mdef[0m[38;2;248;248;242m [0m[38;2;166;226;46moption_wrap[0m[38;2;248;248;242m [0m[38;2;248;248;242m(val : option X) (none_s : string) : option_wrapper X := ⟨val, none_s⟩[0m
+
+[38;2;117;113;94m--[0m[38;2;117;113;94m The size of the "vectors" for a `fin n' → X`, for `has_repr` definitions[0m
+[38;2;249;38;114mvariables[0m[38;2;248;248;242m {m' n' : ℕ}[0m
+
+[38;2;117;113;94m/--[0m
+[38;2;117;113;94mFor a "vector" `X^n'` represented by the type `Π n' : ℕ, fin n' → X`, where[0m
+[38;2;117;113;94mthe `X` has a `has_repr` instance itself, we can provide a `has_repr` for the "vector".[0m
+[38;2;117;113;94mThis definition is used for displaying rows of the playfield, when it is defined[0m
+[38;2;117;113;94mvia a `matrix`, likely through notation.[0m
+[38;2;117;113;94m-/[0m
+[38;2;249;38;114mdef[0m[38;2;248;248;242m [0m[38;2;166;226;46mvec_repr[0m[38;2;248;248;242m [0m[38;2;248;248;242m: Π {n' : ℕ}, (fin n' → X) → string :=[0m
+[38;2;249;38;114mλ[0m[38;2;248;248;242m _ v, string.intercalate [0m[38;2;230;219;116m"[0m[38;2;230;219;116m, [0m[38;2;230;219;116m"[0m[38;2;248;248;242m ((vector.of_fn v).to_list.map repr)[0m
+
+[38;2;249;38;114minstance[0m[38;2;248;248;242m [0m[38;2;166;226;46mvec_repr_instance[0m[38;2;248;248;242m [0m[38;2;248;248;242m: has_repr (fin n' → X) := ⟨vec_repr⟩[0m
+
+[38;2;117;113;94m/--[0m
+[38;2;117;113;94mFor a `matrix` `X^(m' × n')` where the `X` has a `has_repr` instance itself,[0m
+[38;2;117;113;94mwe can provide a `has_repr` for the matrix, using `vec_repr` for each of the rows of the matrix.[0m
+[38;2;117;113;94mThis definition is used for displaying the playfield, when it is defined[0m
+[38;2;117;113;94mvia a `matrix`, likely through notation.[0m
+[38;2;117;113;94m-/[0m
+[38;2;249;38;114mdef[0m[38;2;248;248;242m [0m[38;2;166;226;46mmatrix_repr[0m[38;2;248;248;242m [0m[38;2;248;248;242m: Π {m' n'}, matrix (fin m') (fin n') X → string :=[0m
+[38;2;249;38;114mλ[0m[38;2;248;248;242m _ _ M, string.intercalate [0m[38;2;230;219;116m"[0m[38;2;230;219;116m;[0m[38;2;190;132;255m\n[0m[38;2;230;219;116m"[0m[38;2;248;248;242m ((vector.of_fn M).to_list.map repr)[0m
+
+[38;2;249;38;114minstance[0m[38;2;248;248;242m [0m[38;2;166;226;46mmatrix_repr_instance[0m[38;2;248;248;242m [0m[38;2;248;248;242m:[0m
+[38;2;248;248;242m  has_repr (matrix (fin n') (fin m') X) := ⟨matrix_repr⟩[0m
+
+[38;2;249;38;114mend[0m[38;2;248;248;242m repr[0m
+
+[38;2;249;38;114mend[0m[38;2;248;248;242m chess.utils[0m

--- a/tests/syntax-tests/source/Lean/test.lean
+++ b/tests/syntax-tests/source/Lean/test.lean
@@ -1,0 +1,68 @@
+import data.matrix.notation
+import data.vector2
+
+/-!
+
+Helpers that don't currently fit elsewhere...
+
+-/
+
+lemma split_eq {m n : Type*} (x : m × n) (p p' : m × n) :
+  p = x ∨ p' = x ∨ (x ≠ p ∧ x ≠ p') := by tauto
+
+-- For `playfield`s, the piece type and/or piece index type.
+variables (X : Type*)
+variables [has_repr X]
+
+namespace chess.utils
+
+section repr
+
+/--
+An auxiliary wrapper for `option X` that allows for overriding the `has_repr` instance
+for `option`, and rather, output just the value in the `some` and a custom provided
+`string` for `none`.
+-/
+structure option_wrapper :=
+(val : option X)
+(none_s : string)
+
+instance wrapped_option_repr : has_repr (option_wrapper X) :=
+⟨λ ⟨val, s⟩, (option.map has_repr.repr val).get_or_else s⟩
+
+variables {X}
+/--
+Construct an `option_wrapper` term from a provided `option X` and the `string`
+that will override the `has_repr.repr` for `none`.
+-/
+def option_wrap (val : option X) (none_s : string) : option_wrapper X := ⟨val, none_s⟩
+
+-- The size of the "vectors" for a `fin n' → X`, for `has_repr` definitions
+variables {m' n' : ℕ}
+
+/--
+For a "vector" `X^n'` represented by the type `Π n' : ℕ, fin n' → X`, where
+the `X` has a `has_repr` instance itself, we can provide a `has_repr` for the "vector".
+This definition is used for displaying rows of the playfield, when it is defined
+via a `matrix`, likely through notation.
+-/
+def vec_repr : Π {n' : ℕ}, (fin n' → X) → string :=
+λ _ v, string.intercalate ", " ((vector.of_fn v).to_list.map repr)
+
+instance vec_repr_instance : has_repr (fin n' → X) := ⟨vec_repr⟩
+
+/--
+For a `matrix` `X^(m' × n')` where the `X` has a `has_repr` instance itself,
+we can provide a `has_repr` for the matrix, using `vec_repr` for each of the rows of the matrix.
+This definition is used for displaying the playfield, when it is defined
+via a `matrix`, likely through notation.
+-/
+def matrix_repr : Π {m' n'}, matrix (fin m') (fin n') X → string :=
+λ _ _ M, string.intercalate ";\n" ((vector.of_fn M).to_list.map repr)
+
+instance matrix_repr_instance :
+  has_repr (matrix (fin n') (fin m') X) := ⟨matrix_repr⟩
+
+end repr
+
+end chess.utils


### PR DESCRIPTION
Hello -- 

`Lean` is an [interactive theorem prover](https://leanprover-community.github.io/) with a decent sized user base (e.g. its Zulip has... around 3,000 folks idling in it). No users really use Sublime Text, the vast majority of its users use [VSCode](https://github.com/leanprover/vscode-lean), with a small subset using emacs (and an even smaller subset using other), so as I read it it likely doesn't meet the inclusion criteria, but just checking to be sure the above doesn't affect anything (it not really having any Sublime users). I'm sure you get a bunch of these, so certainly no hard feelings if you close it.

Thanks for `bat`!