### PR TITLE
Fix clippy::if_same_then_else warning in --paging=auto logic

### DIFF
--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -82,10 +82,9 @@ impl App {
             Some("always") => PagingMode::Always,
             Some("never") => PagingMode::Never,
             Some("auto") | None => {
-                if self.matches.occurrences_of("plain") > 1 {
-                    // If we have -pp as an option when in auto mode, the pager should be disabled.
-                    PagingMode::Never
-                } else if self.matches.is_present("no-paging") {
+                // If we have -pp as an option when in auto mode, the pager should be disabled.
+                let extra_plain = self.matches.occurrences_of("plain") > 1;
+                if extra_plain || self.matches.is_present("no-paging") {
                     PagingMode::Never
                 } else if inputs.iter().any(Input::is_stdin) {
                     // If we are reading from stdin, only enable paging if we write to an


### PR DESCRIPTION
This PR fixes the last **correctness** category of clippy lints, to make the discussions in #1410 simpler to have.

I manually verified that the `-pp` and `-P` flags still work.

(It is worth noting that we have no automated tests that cover the changed code. Probably because it is a bit tricky to test e.g. `PagingMode::QuitIfOneScreen` with `assert_cmd`.)