### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ description="A cat(1) clone with wings."
 homepage = "https://github.com/sharkdp/bat"
 license = "MIT/Apache-2.0"
 name = "bat"
-readme = "README.md"
 repository = "https://github.com/sharkdp/bat"
 version = "0.17.1"
 exclude = [


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).