### PR TITLE
Introduce bat_warning! helper macro

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -11,6 +11,7 @@ use syntect::parsing::{SyntaxReference, SyntaxSet, SyntaxSetBuilder};
 use path_abs::PathAbs;
 
 use crate::assets_metadata::AssetsMetadata;
+use crate::bat_warning;
 use crate::error::*;
 use crate::input::{InputReader, OpenedInput, OpenedInputKind};
 use crate::syntax_mapping::{MappingTarget, SyntaxMapping};
@@ -190,21 +191,11 @@ impl HighlightingAssets {
             Some(theme) => theme,
             None => {
                 if theme == "ansi-light" || theme == "ansi-dark" {
-                    use ansi_term::Colour::Yellow;
-                    eprintln!(
-                        "{}: Theme '{}' is deprecated, using 'ansi' instead.",
-                        Yellow.paint("[bat warning]"),
-                        theme
-                    );
+                    bat_warning!("Theme '{}' is deprecated, using 'ansi' instead.", theme);
                     return self.get_theme("ansi");
                 }
                 if theme != "" {
-                    use ansi_term::Colour::Yellow;
-                    eprintln!(
-                        "{}: Unknown theme '{}', using default.",
-                        Yellow.paint("[bat warning]"),
-                        theme
-                    );
+                    bat_warning!("Unknown theme '{}', using default.", theme)
                 }
                 &self.theme_set.themes[self.fallback_theme.unwrap_or_else(|| Self::default_theme())]
             }

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -16,6 +16,7 @@ use console::Term;
 use crate::input::{new_file_input, new_stdin_input};
 use bat::{
     assets::HighlightingAssets,
+    bat_warning,
     config::{Config, VisibleLines},
     error::*,
     input::Input,
@@ -323,11 +324,7 @@ impl App {
 
         // If `grid` is set, remove `rule` as it is a subset of `grid`, and print a warning.
         if styled_components.grid() && styled_components.0.remove(&StyleComponent::Rule) {
-            use ansi_term::Colour::Yellow;
-            eprintln!(
-                "{}: Style 'rule' is a subset of style 'grid', 'rule' will not be visible.",
-                Yellow.paint("[bat warning]"),
-            );
+            bat_warning!("Style 'rule' is a subset of style 'grid', 'rule' will not be visible.");
         }
 
         Ok(styled_components)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 //!     .unwrap();
 //! ```
 
+mod macros;
+
 pub mod assets;
 pub mod assets_metadata;
 pub mod config;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,7 @@
+#[macro_export]
+macro_rules! bat_warning {
+    ($($arg:tt)*) => ({
+        use ansi_term::Colour::Yellow;
+        eprintln!("{}: {}", Yellow.paint("[bat warning]"), format!($($arg)*));
+    })
+}


### PR DESCRIPTION
This macro is intended to be package-internal and is not to be
considered part of the public lib API.

Use it in three places to reduce code duplication. However, main reason
for this refactoring is to allow us to fix #1063 without duplicating the
code yet another time.

The macro can also be used for the "Binary content from {} will not be
printed to the terminal" message if that message starts to use eprintln!
instead (if ever).

To trigger/verify the changed code, the following commands can be used:

    cargo run -- --theme=ansi-light tests/examples/single-line.txt
    cargo run -- --theme=does-not-exist tests/examples/single-line.txt
    cargo run -- --style=grid,rule tests/examples/single-line.txt