### PR TITLE
bat cache --build: Print syntect error message for themes if any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Only print themes hint in interactive mode (`bat --list-themes`), see #1439 (@rsteube)
 - Make ./tests/syntax-tests/regression_test.sh work on recent versions of macOS, see #1443 (@Enselic)
 - VimL syntax highlighting fix, see #1450 (@esensar)
+- Print an 'Invalid syntax theme settings' error message if a custom theme is broken, see #614 (@Enselic)
 
 ## Other
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -38,9 +38,16 @@ impl HighlightingAssets {
         };
 
         let theme_dir = source_dir.join("themes");
-
-        let res = theme_set.add_from_folder(&theme_dir);
-        if res.is_err() {
+        if theme_dir.exists() {
+            let res = theme_set.add_from_folder(&theme_dir);
+            if let Err(err) = res {
+                println!(
+                    "Failed to load one or more themes from '{}' (reason: '{}')",
+                    theme_dir.to_string_lossy(),
+                    err,
+                );
+            }
+        } else {
             println!(
                 "No themes were found in '{}', using the default set",
                 theme_dir.to_string_lossy()


### PR DESCRIPTION
This will fix #614 by making it clear what is wrong by showing the
following error message:

    Failed to load one or more themes from
    '/Users/me/.config/bat/themes' (reason: 'Invalid syntax theme
    settings')

We also need to add a check if theme_dir.exists(), otherwise an absent
dir will seem like an error:

    Failed to load one or more themes from
    '/Users/me/.config/bat/themes' (reason: 'IO error for
    operation on /Users/me/.config/bat/themes: No such file or
    directory (os error 2)')

(This is the same check we already have for syntax_dir.)