### PR TITLE
bat --list-languages: remove unnecessary format!() call

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -162,7 +162,7 @@ pub fn get_languages(config: &Config) -> Result<String> {
                 num_chars += new_chars;
                 result += &format!("{}", style.paint(&word[..]));
                 if extension.peek().is_some() {
-                    result += &format!("{}", comma_separator);
+                    result += comma_separator;
                 }
             }
             result += "\n";


### PR DESCRIPTION
To trigger/verify the changed code, run

    bat --list-languages   # or -L

This is the last clippy warning in the code that you get if you run

    cargo clippy --all-targets --all-features -- --allow clippy::style

so by fixing it it becomes easier to spot when a new warning is
introduced (that does not belong to the clippy category clippy::style).
And by making it easy to spot new warnings, we increase chance of such
regressions not ending up in the code base.