### PR TITLE
Allow clippy::style lints

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets --all-features
+        args: --all-targets --all-features -- --allow clippy::style
     - name: Test
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Turns out GitHub is clever enough to pick up clippy warnings from us
just running it, and showing them in PRs under a "Unchanged files with
check annotations (beta)" header.

The only warnings currently shown are style warnings, and we agreed we
don't want to risk putting off contributors over style issues. So
explicitly allow (don't warn in the logs for) this category of clippy
lints.

This means that the only clippy categories left that prints warnings
(Warn) are:

    clippy::complexity
    clippy::perf

And the only category of lints that fails the CI build (Deny) remains to
be:

    clippy::correctness

See https://rust-lang.github.io/rust-clippy/master/index.html for a
catalog of all lints.