### PR TITLE
Add --diagnostic option to bat

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -226,7 +226,13 @@ jobs:
       with:
         use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
         command: run
-        args: --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} -- --paging=never --color=always --theme=ansi-dark Cargo.toml src/config.rs
+        args: --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} -- --paging=never --color=always --theme=ansi Cargo.toml src/config.rs
+    - name: bat diagnostics output
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
+        command: run
+        args: --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} -- --paging=never --color=always --theme=ansi Cargo.toml src/config.rs --diagnostic
     - name: Check features regex-onig
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,8 +197,6 @@ dependencies = [
 [[package]]
 name = "bugreport"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824268bc0fcb3b94da597b81fa9dd52175cfde5522f4892a0cff3932802ff805"
 dependencies = [
  "snailquote",
  "sys-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,9 @@ dependencies = [
 
 [[package]]
 name = "bugreport"
-version = "0.1.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "116762017f173ea5d8103e75533f6bdb62cb6f2257c9c95672beb085a70daed8"
 dependencies = [
  "snailquote",
  "sys-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "assert_cmd",
  "atty",
+ "bugreport",
  "clap",
  "clircle",
  "console",
@@ -191,6 +192,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "bugreport"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824268bc0fcb3b94da597b81fa9dd52175cfde5522f4892a0cff3932802ff805"
+dependencies = [
+ "snailquote",
+ "sys-info",
 ]
 
 [[package]]
@@ -1071,6 +1082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
+name = "snailquote"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34b729d802f52194598858ac852c3fb3b33f6e026cd03195072ccb7bf3fc810"
+dependencies = [
+ "thiserror",
+ "unicode_categories",
+]
+
+[[package]]
 name = "std_prelude"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,9 +1105,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1114,6 +1135,16 @@ dependencies = [
  "serde_json",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5cfbd84f86389198ade41b439f72a5b1b3a8ba728e61cd589e1720d0df44c39"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1154,6 +1185,26 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "term_size",
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1218,6 +1269,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_yaml = "0.8"
 semver = "0.11"
 path_abs = { version = "0.5", default-features = false }
 clircle = "0.2.0"
-bugreport = "0.1"
+bugreport = "0.2"
 
 [dependencies.git2]
 version = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_yaml = "0.8"
 semver = "0.11"
 path_abs = { version = "0.5", default-features = false }
 clircle = "0.2.0"
-bugreport = "0.2.1"
+bugreport = "0.3"
 
 [dependencies.git2]
 version = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ serde_yaml = "0.8"
 semver = "0.11"
 path_abs = { version = "0.5", default-features = false }
 clircle = "0.2.0"
+bugreport = "0.1"
 
 [dependencies.git2]
 version = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_yaml = "0.8"
 semver = "0.11"
 path_abs = { version = "0.5", default-features = false }
 clircle = "0.2.0"
-bugreport = "0.2"
+bugreport = "0.2.1"
 
 [dependencies.git2]
 version = "0.13"

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -480,6 +480,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("diagnostic")
                 .long("diagnostic")
+                .alias("diagnostics")
                 .hidden_short_help(true)
                 .help("Show diagnostic information for bug reports.")
         )

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -477,6 +477,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .hidden(true)
                 .help("Show bat's cache directory."),
         )
+        .arg(
+            Arg::with_name("diagnostic")
+                .long("diagnostic")
+                .hidden_short_help(true)
+                .help("Show diagnostic information for bug reports.")
+        )
         .help_message("Print this help message.")
         .version_message("Show version information.");
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -237,11 +237,17 @@ fn run() -> Result<bool> {
             .info(EnvironmentVariables::list(&[
                 "SHELL",
                 "PAGER",
-                "BAT_PAGER",
+                "BAT_CACHE_PATH",
                 "BAT_CONFIG_PATH",
+                "BAT_OPTS",
+                "BAT_PAGER",
                 "BAT_STYLE",
-                "BAT_THEME",
                 "BAT_TABS",
+                "BAT_THEME",
+                "XDG_CONFIG_HOME",
+                "XDG_CACHE_HOME",
+                "COLORTERM",
+                "NO_COLOR",
             ]))
             .info(FileContent::new("Config file", config_file()))
             .info(CompileTimeInformation::default())

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -35,8 +35,7 @@ use bat::{
     error::*,
     input::Input,
     style::{StyleComponent, StyleComponents},
-    MappingTarget,
-    PagingMode,
+    MappingTarget, PagingMode,
 };
 
 const THEME_PREVIEW_DATA: &[u8] = include_bytes!("../../../assets/theme_preview.rs");
@@ -227,6 +226,27 @@ fn run_controller(inputs: Vec<Input>, config: &Config) -> Result<bool> {
 /// `Ok(false)` if any intermediate errors occurred (were printed).
 fn run() -> Result<bool> {
     let app = App::new()?;
+
+    if app.matches.is_present("diagnostic") {
+        use bugreport::{bugreport, collectors::*};
+
+        bugreport!()
+            .info(SoftwareVersion::default())
+            .info(OperatingSystem::default())
+            .info(CommandLine::default())
+            .info(EnvironmentVariables::list(&[
+                "SHELL",
+                "PAGER",
+                "BAT_PAGER",
+                "BAT_CONFIG_PATH",
+                "BAT_STYLE",
+                "BAT_THEME",
+                "BAT_TABS",
+            ]))
+            .print_markdown();
+
+        return Ok(true);
+    }
 
     match app.matches.subcommand() {
         ("cache", Some(cache_matches)) => {

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -243,6 +243,9 @@ fn run() -> Result<bool> {
                 "BAT_THEME",
                 "BAT_TABS",
             ]))
+            .info(FileContent::new("Config file", config_file()))
+            .info(CompileTimeInformation::default())
+            .info(CommandOutput::new("Less version", "less", &["--version"]))
             .print_markdown();
 
         return Ok(true);

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -228,7 +228,7 @@ fn run() -> Result<bool> {
     let app = App::new()?;
 
     if app.matches.is_present("diagnostic") {
-        use bugreport::{bugreport, collectors::*};
+        use bugreport::{bugreport, collector::*, format::Markdown};
 
         bugreport!()
             .info(SoftwareVersion::default())
@@ -252,7 +252,7 @@ fn run() -> Result<bool> {
             .info(FileContent::new("Config file", config_file()))
             .info(CompileTimeInformation::default())
             .info(CommandOutput::new("Less version", "less", &["--version"]))
-            .print_markdown();
+            .print::<Markdown>();
 
         return Ok(true);
     }


### PR DESCRIPTION
This is a draft with a new `--diagnostic` option for `bat` that could eventually replace the `diagnostics/info.sh` script for bug reports (closes #1405). The main part of the work in is in [a new crate called `bugreport`](https://github.com/sharkdp/bugreport), which is in a early stage as well.

I'd be glad for any kind of feedback!

### example output

*(see CI output for more examples)*

```
▶ alias bat="bat --style='numbers,grid,header'"     
▶ export BAT_STYLE=numbers,grid
▶ bat --pager="less -RF" src/macros.rs --diagnostic
```

#### Software version

bat 0.17.1

#### Operating system

Linux 5.9.14-arch1-1

#### Command-line

```bash
bat --style=numbers,grid,header '--pager=less -RF' src/macros.rs --diagnostic 
```

#### Environment variables

```bash
SHELL=/usr/bin/zsh
PAGER=less
BAT_PAGER=<not set>
BAT_CONFIG_PATH=<not set>
BAT_STYLE=numbers,grid
BAT_THEME=<not set>
BAT_TABS=<not set>
```

#### Config file

```
# Use italic text on the terminal (not supported on all terminals)
--italic-text=always

# Syntax mappings
--map-syntax .ignore:"Git Ignore"
--map-syntax .fdignore:"Git Ignore"
--map-syntax '*.ino':"C++"
```

#### Compile time information

- Profile: release
- Target triple: x86_64-unknown-linux-gnu
- Family: unix
- OS: linux
- Architecture: x86_64
- Pointer width: 64
- Endian: little
- CPU features: fxsr,sse,sse2
- Host: x86_64-unknown-linux-gnu

#### Less version

```
> less --version 
less 563 (PCRE regular expressions)
Copyright (C) 1984-2020  Mark Nudelman

less comes with NO WARRANTY, to the extent permitted by law.
For information about the terms of redistribution,
see the file named README in the less distribution.
Home page: http://www.greenwoodsoftware.com/less
```
