### PR TITLE
Add integration test for unparsable pager

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -439,6 +439,17 @@ fn alias_pager_disable_long_overrides_short() {
 }
 
 #[test]
+fn pager_failed_to_parse() {
+    bat()
+        .env("BAT_PAGER", "mismatched-quotes 'a")
+        .arg("--paging=always")
+        .arg("test.txt")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Could not parse pager command"));
+}
+
+#[test]
 fn config_location_test() {
     bat_with_config()
         .env("BAT_CONFIG_PATH", "bat.conf")


### PR DESCRIPTION
Right now all tests pass even if we e.g. return

    Ok(OutputType::stdout())

instead of doing

    .chain_err(|| "Could not parse pager command.")?

so add a test to make sure this functionality don't break.

This is mainly to harden against regressions in #1402, but is self-contained and can be merged right away. As a side-note, we already have a test for `BAT_PAGER=""` so there is no need to add another one.