### PR TITLE
CICD: Code Coverage: Use matrix.job.toolchain directly

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -417,14 +417,6 @@ jobs:
       id: vars
       shell: bash
       run: |
-        # toolchain
-        TOOLCHAIN="nightly" ## default to "nightly" toolchain
-        # * use requested TOOLCHAIN if specified
-        if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
-        # * use requested TOOLCHAIN if specified
-        if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
-        echo set-output name=TOOLCHAIN::${TOOLCHAIN}
-        echo ::set-output name=TOOLCHAIN::${TOOLCHAIN}
         # target-specific options
         # * CODECOV_FLAGS
         CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
@@ -433,7 +425,7 @@ jobs:
     - name: rust toolchain ~ install
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
+        toolchain: ${{ matrix.job.toolchain }}
         override: true
         profile: minimal # minimal component installation (ie, no documentation)
     - name: Test


### PR DESCRIPTION
No need for complicated var and set-output logic when we can simply use
matrix.job.toolchain directly.

This is a small and self-contained PR to simplify CICD as requested in #1474.

(Disclaimer: I am new to GitHub Actions myself, but I am comfortable with CI/CD in general.)
