### PR TITLE
CICD: Remove use-cross when host == target

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -88,9 +88,9 @@ jobs:
           - { os: ubuntu-18.04   , target: aarch64-unknown-linux-gnu   , use-cross: use-cross }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-gnu      , use-cross: use-cross }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-musl     , use-cross: use-cross }
-          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu    , use-cross: use-cross }
+          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu    }
           - { os: ubuntu-18.04   , target: x86_64-unknown-linux-musl   , use-cross: use-cross }
-          - { os: ubuntu-16.04   , target: x86_64-unknown-linux-gnu    , use-cross: use-cross }
+          - { os: ubuntu-16.04   , target: x86_64-unknown-linux-gnu    }
           - { os: macos-latest   , target: x86_64-apple-darwin         }
           # - { os: windows-latest , target: i686-pc-windows-gnu         }  ## disabled; linker errors (missing '_imp____acrt_iob_func')
           - { os: windows-latest , target: i686-pc-windows-msvc        }


### PR DESCRIPTION
I tried to remove all `use-cross` occurrences, but the two targets this PR were the only ones that builds without `use-cross`.

For reference, here is what happens if you try to remove `use-cross` for all builds: https://github.com/Enselic/bat/actions/runs/464151908

This PR is for #1474.
