### PR TITLE
CICD: Code Coverage: Disable for now

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -380,7 +380,7 @@ jobs:
 
   coverage:
     name: Code Coverage
-    if: "false"
+    if: "false" # Temporarily disabled until made functional again, see https://github.com/sharkdp/bat/pull/1484
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -380,6 +380,7 @@ jobs:
 
   coverage:
     name: Code Coverage
+    if: "false"
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: true


### PR DESCRIPTION
Accoding to #1474:
> We are currently not using the code coverage part.

Since the Code Coverage job usually is the last to finish, I propose we disable it until someone makes it useful to run again. That will reduce the time it takes to complete the CICD pipeline and thus increase productivity for everyone! 
