### PR TITLE
CICD: Build: Enable target x86_64-pc-windows-gnu again

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -92,9 +92,9 @@ jobs:
           - { os: ubuntu-18.04   , target: x86_64-unknown-linux-musl   , use-cross: use-cross }
           - { os: ubuntu-16.04   , target: x86_64-unknown-linux-gnu    }
           - { os: macos-latest   , target: x86_64-apple-darwin         }
-          # - { os: windows-latest , target: i686-pc-windows-gnu         }  ## disabled; linker errors (missing '_imp____acrt_iob_func')
+          # - { os: windows-latest , target: i686-pc-windows-gnu         }  ## disabled; error: linker `i686-w64-mingw32-gcc` not found
           - { os: windows-latest , target: i686-pc-windows-msvc        }
-          # - { os: windows-latest , target: x86_64-pc-windows-gnu       }  ## disabled; linker errors (missing '_imp____acrt_iob_func')
+          - { os: windows-latest , target: x86_64-pc-windows-gnu       }
           - { os: windows-latest , target: x86_64-pc-windows-msvc      }
     steps:
     - name: Git checkout
@@ -112,8 +112,6 @@ jobs:
       run: |
         # toolchain
         TOOLCHAIN="stable" ## default to "stable" toolchain
-        # * specify alternate TOOLCHAIN for *-pc-windows-gnu targets; gnu targets on Windows are broken for the standard *-pc-windows-msvc toolchain (refs: <https://github.com/rust-lang/rust/issues/47048>, <https://github.com/rust-lang/rust/issues/53454>, <https://github.com/rust-lang/cargo/issues/6754>)
-        case ${{ matrix.job.target }} in *-pc-windows-gnu) TOOLCHAIN="stable-${{ matrix.job.target }}" ;; esac;
         # * use requested TOOLCHAIN if specified
         if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
         echo ::set-output name=TOOLCHAIN::${TOOLCHAIN}

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          # { os, target, cargo-options, features, use-cross, toolchain }
+          # { os, target, cargo-options, features, use-cross }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: use-cross }
           - { os: ubuntu-18.04   , target: aarch64-unknown-linux-gnu   , use-cross: use-cross }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-gnu      , use-cross: use-cross }
@@ -110,11 +110,6 @@ jobs:
       id: vars
       shell: bash
       run: |
-        # toolchain
-        TOOLCHAIN="stable" ## default to "stable" toolchain
-        # * use requested TOOLCHAIN if specified
-        if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
-        echo ::set-output name=TOOLCHAIN::${TOOLCHAIN}
         # staging directory
         STAGING='_staging'
         echo ::set-output name=STAGING::${STAGING}
@@ -194,7 +189,7 @@ jobs:
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
+        toolchain: stable
         target: ${{ matrix.job.target }}
         override: true
         profile: minimal # minimal component installation (ie, no documentation)


### PR DESCRIPTION
Make `x86_64-pc-windows-gnu` build again with TOOLCHAIN stable. The referenced issues that are removed have all been closed. There is still some problem with i686-pc-windows-gnu that I haven't managed to figure out how to solve yet, but that's something for later.

I also added an extra commit to remove the unnecessary TOOLCHAIN logic, like I did for Code Coverage.

I did a test-deploy of this change, and got a [green job](https://github.com/Enselic/bat/actions/runs/467135535) and a [release with downloads](https://github.com/Enselic/bat/releases/tag/v0.0.2). Note that `bat-v0.0.2-x86_64-pc-windows-gnu.zip` is a new download due to this PR (🎉 )

This PR is part of the series of PRs for https://github.com/sharkdp/bat/issues/1474.