### PR TITLE
CICD: Build: Remove unused REF_* outputs

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -117,14 +117,8 @@ jobs:
         EXE_suffix="" ; case ${{ matrix.job.target }} in *-pc-windows-*) EXE_suffix=".exe" ;; esac;
         echo ::set-output name=EXE_suffix::${EXE_suffix}
         # parse commit reference info
-        REF_NAME=${GITHUB_REF#refs/*/}
-        unset REF_BRANCH ; case ${GITHUB_REF} in refs/heads/*) REF_BRANCH=${GITHUB_REF#refs/heads/} ;; esac;
         unset REF_TAG ; case ${GITHUB_REF} in refs/tags/*) REF_TAG=${GITHUB_REF#refs/tags/} ;; esac;
         REF_SHAS=${GITHUB_SHA:0:8}
-        echo ::set-output name=REF_NAME::${REF_NAME}
-        echo ::set-output name=REF_BRANCH::${REF_BRANCH}
-        echo ::set-output name=REF_TAG::${REF_TAG}
-        echo ::set-output name=REF_SHAS::${REF_SHAS}
         # parse target
         unset TARGET_ARCH ; case ${{ matrix.job.target }} in arm-unknown-linux-gnueabihf) TARGET_ARCH=arm ;; i686-*) TARGET_ARCH=i686 ;; x86_64-*) TARGET_ARCH=x86_64 ;; esac;
         echo ::set-output name=TARGET_ARCH::${TARGET_ARCH}


### PR DESCRIPTION
There is no usage of `steps.vars.outputs.REF_*` so no need to setup such
things. Also remove setting up REF_NAME and REF_BRANCH env vars, since
they are never read.

For https://github.com/sharkdp/bat/issues/1474

Successful deploy: https://github.com/Enselic/bat/releases/tag/v0.0.4