### PR TITLE
CICD: Build: Stop building on Ubuntu 16.04

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -87,9 +87,8 @@ jobs:
           - { os: ubuntu-18.04   , target: aarch64-unknown-linux-gnu   , use-cross: true }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-gnu      , use-cross: true }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-musl     , use-cross: true }
-          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu                      , disable-deploy: true }  ## deployed from ubuntu-16.04
+          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu    }
           - { os: ubuntu-18.04   , target: x86_64-unknown-linux-musl   , use-cross: true }
-          - { os: ubuntu-16.04   , target: x86_64-unknown-linux-gnu    }
           - { os: macos-latest   , target: x86_64-apple-darwin         }
           # - { os: windows-latest , target: i686-pc-windows-gnu         }  ## disabled; error: linker `i686-w64-mingw32-gcc` not found
           - { os: windows-latest , target: i686-pc-windows-msvc        }
@@ -357,7 +356,7 @@ jobs:
         fi
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
-      if: steps.vars.outputs.DEPLOY && !matrix.job.disable-deploy
+      if: steps.vars.outputs.DEPLOY
       with:
         files: |
           ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -83,12 +83,11 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          # { os, target, cargo-options, features, use-cross }
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: true }
           - { os: ubuntu-18.04   , target: aarch64-unknown-linux-gnu   , use-cross: true }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-gnu      , use-cross: true }
           - { os: ubuntu-18.04   , target: i686-unknown-linux-musl     , use-cross: true }
-          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu    }
+          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu                      , disable-deploy: true }  ## deployed from ubuntu-16.04
           - { os: ubuntu-18.04   , target: x86_64-unknown-linux-musl   , use-cross: true }
           - { os: ubuntu-16.04   , target: x86_64-unknown-linux-gnu    }
           - { os: macos-latest   , target: x86_64-apple-darwin         }
@@ -133,8 +132,6 @@ jobs:
         echo ::set-output name=PKG_NAME::${PKG_NAME}
         # deployable tag? (ie, leading "vM" or "M"; M == version number)
         unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
-        # unset deploy on ubuntu-18.04 x64 - we will deploy the tarball/deb built on ubuntu-16.04 x64
-        if [ "${{ matrix.job.os }}" = "ubuntu-18.04" ] && [ "${{ matrix.job.target }}" = "x86_64-unknown-linux-gnu" ]; then unset DEPLOY; fi
         echo ::set-output name=DEPLOY::${DEPLOY}
         # DPKG architecture?
         unset DPKG_ARCH
@@ -360,7 +357,7 @@ jobs:
         fi
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
-      if: steps.vars.outputs.DEPLOY
+      if: steps.vars.outputs.DEPLOY && !matrix.job.disable-deploy
       with:
         files: |
           ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}


### PR DESCRIPTION
This results in a nicer workflow file that is easier to follow.

Also remove the unneccesary doc row that repeats what is already in the
matrix and that is annoying to keep up to date.

For #1474

Successful deploy: https://github.com/Enselic/bat/releases/tag/v0.0.6

Btw, when deploy failed but build worked, what was wrong? Would be nice to be able to add some kind of deploy-dry-run so we don't have to manually push tags to verify deploy.