### PR TITLE
Fix remaining clippy suggestions

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets --all-features -- --allow clippy::style
+        args: --all-targets --all-features
     - name: Test
       uses: actions-rs/cargo@v1
       with:

--- a/src/bin/bat/input.rs
+++ b/src/bin/bat/input.rs
@@ -2,7 +2,7 @@ use bat::input::Input;
 use std::ffi::OsStr;
 
 pub fn new_file_input<'a>(file: &'a OsStr, name: Option<&'a OsStr>) -> Input<'a> {
-    named(Input::ordinary_file(file), name.or_else(|| Some(file)))
+    named(Input::ordinary_file(file), name.or(Some(file)))
 }
 
 pub fn new_stdin_input(name: Option<&OsStr>) -> Input {

--- a/src/input.rs
+++ b/src/input.rs
@@ -137,11 +137,7 @@ impl<'a> Input<'a> {
     }
 
     pub fn is_stdin(&self) -> bool {
-        if let InputKind::StdIn = self.kind {
-            true
-        } else {
-            false
-        }
+        matches!(self.kind, InputKind::StdIn)
     }
 
     pub fn with_name(mut self, provided_name: Option<&OsStr>) -> Self {

--- a/src/output.rs
+++ b/src/output.rs
@@ -150,11 +150,7 @@ impl OutputType {
 
     #[cfg(feature = "paging")]
     pub(crate) fn is_pager(&self) -> bool {
-        if let OutputType::Pager(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, OutputType::Pager(_))
     }
 
     #[cfg(not(feature = "paging"))]

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -320,6 +320,12 @@ impl<'a> PrettyPrinter<'a> {
     }
 }
 
+impl Default for PrettyPrinter<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// An input source for the pretty printer.
 pub struct Input<'a> {
     input: input::Input<'a>,

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -8,7 +8,7 @@ fn all_themes_are_present() {
     let assets = HighlightingAssets::from_binary();
 
     let mut themes: Vec<_> = assets.themes().collect();
-    themes.sort();
+    themes.sort_unstable();
 
     assert_eq!(
         themes,

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -7,7 +7,7 @@ macro_rules! snapshot_tests {
         $(
             #[test]
             fn $test_name() {
-                let bat_tester = BatTester::new();
+                let bat_tester = BatTester::default();
                 bat_tester.test_snapshot(stringify!($test_name), $style);
             }
         )*

--- a/tests/tester.rs
+++ b/tests/tester.rs
@@ -19,23 +19,6 @@ pub struct BatTester {
 }
 
 impl BatTester {
-    pub fn new() -> Self {
-        let temp_dir = create_sample_directory().expect("sample directory");
-
-        let root = env::current_exe()
-            .expect("tests executable")
-            .parent()
-            .expect("tests executable directory")
-            .parent()
-            .expect("bat executable directory")
-            .to_path_buf();
-
-        let exe_name = if cfg!(windows) { "bat.exe" } else { "bat" };
-        let exe = root.join(exe_name);
-
-        BatTester { temp_dir, exe }
-    }
-
     pub fn test_snapshot(&self, name: &str, style: &str) {
         let output = Command::new(&self.exe)
             .current_dir(self.temp_dir.path())
@@ -63,6 +46,25 @@ impl BatTester {
             .expect("could not read snapshot file");
 
         assert_eq!(expected, actual);
+    }
+}
+
+impl Default for BatTester {
+    fn default() -> Self {
+        let temp_dir = create_sample_directory().expect("sample directory");
+
+        let root = env::current_exe()
+            .expect("tests executable")
+            .parent()
+            .expect("tests executable directory")
+            .parent()
+            .expect("bat executable directory")
+            .to_path_buf();
+
+        let exe_name = if cfg!(windows) { "bat.exe" } else { "bat" };
+        let exe = root.join(exe_name);
+
+        BatTester { temp_dir, exe }
     }
 }
 


### PR DESCRIPTION
Now that we decided to move to Rust 1.42 as the min. required version, we can fix the remaining clippy "style" suggestions.