### PR TITLE
Also build Debian packages in PR CI workflow

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -124,7 +124,7 @@ jobs:
         echo ::set-output name=PKG_BASENAME::${PKG_BASENAME}
         echo ::set-output name=PKG_NAME::${PKG_NAME}
         # deployable tag? (ie, leading "vM" or "M"; M == version number)
-        unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
+        unset DEPLOY ; if [[ $REF_TAG =~ ^v[0-9].* ]]; then DEPLOY='true' ; fi
         echo ::set-output name=DEPLOY::${DEPLOY}
         # DPKG architecture?
         unset DPKG_ARCH

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -135,8 +135,7 @@ jobs:
           x86_64-*-linux-*) DPKG_ARCH=amd64 ;;
         esac;
         echo ::set-output name=DPKG_ARCH::${DPKG_ARCH}
-        # DPKG version?
-        unset DPKG_VERSION ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DPKG_VERSION=${REF_TAG/#[vV]/} ; fi
+        DPKG_VERSION=${PROJECT_VERSION}
         echo ::set-output name=DPKG_VERSION::${DPKG_VERSION}
         # DPKG base name/conflicts?
         DPKG_BASENAME=${PROJECT_NAME}
@@ -339,11 +338,17 @@ jobs:
           # build dpkg
           fakeroot dpkg-deb --build "${DPKG_DIR}" "${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}"
         fi
-    - name: Upload build artifacts
+    - name: Upload package artifact
       uses: actions/upload-artifact@master
       with:
         name: ${{ steps.vars.outputs.PKG_NAME }}
         path: ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}
+    - name: Upload Debian package artifact
+      uses: actions/upload-artifact@master
+      if: steps.vars.outputs.DPKG_NAME
+      with:
+        name: ${{ steps.vars.outputs.DPKG_NAME }}
+        path: ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
       if: steps.vars.outputs.DEPLOY

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,6 +2,7 @@ name: CICD
 
 env:
   PROJECT_NAME: bat
+  PROJECT_VERSION: "0.17.1"
   PROJECT_DESC: "A `cat` clone with wings"
   PROJECT_MAINTAINER: "David Peter <mail@david-peter.de>"
   PROJECT_HOMEPAGE: "https://github.com/sharkdp/bat"
@@ -116,10 +117,9 @@ jobs:
         echo ::set-output name=EXE_suffix::${EXE_suffix}
         # parse commit reference info
         unset REF_TAG ; case ${GITHUB_REF} in refs/tags/*) REF_TAG=${GITHUB_REF#refs/tags/} ;; esac;
-        REF_SHAS=${GITHUB_SHA:0:8}
         # package name
         PKG_suffix=".tar.gz" ; case ${{ matrix.job.target }} in *-pc-windows-*) PKG_suffix=".zip" ;; esac;
-        PKG_BASENAME=${PROJECT_NAME}-${REF_TAG:-$REF_SHAS}-${{ matrix.job.target }}
+        PKG_BASENAME=${PROJECT_NAME}-v${PROJECT_VERSION}-${{ matrix.job.target }}
         PKG_NAME=${PKG_BASENAME}${PKG_suffix}
         echo ::set-output name=PKG_BASENAME::${PKG_BASENAME}
         echo ::set-output name=PKG_NAME::${PKG_NAME}

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -115,17 +115,14 @@ jobs:
         # determine EXE suffix
         EXE_suffix="" ; case ${{ matrix.job.target }} in *-pc-windows-*) EXE_suffix=".exe" ;; esac;
         echo ::set-output name=EXE_suffix::${EXE_suffix}
-        # parse commit reference info
-        unset REF_TAG ; case ${GITHUB_REF} in refs/tags/*) REF_TAG=${GITHUB_REF#refs/tags/} ;; esac;
         # package name
         PKG_suffix=".tar.gz" ; case ${{ matrix.job.target }} in *-pc-windows-*) PKG_suffix=".zip" ;; esac;
         PKG_BASENAME=${PROJECT_NAME}-v${PROJECT_VERSION}-${{ matrix.job.target }}
         PKG_NAME=${PKG_BASENAME}${PKG_suffix}
         echo ::set-output name=PKG_BASENAME::${PKG_BASENAME}
         echo ::set-output name=PKG_NAME::${PKG_NAME}
-        # deployable tag? (ie, leading "vM" or "M"; M == version number)
-        unset DEPLOY ; if [[ $REF_TAG =~ ^v[0-9].* ]]; then DEPLOY='true' ; fi
-        echo ::set-output name=DEPLOY::${DEPLOY}
+        unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
+        echo ::set-output name=IS_RELEASE::${IS_RELEASE}
         # DPKG architecture?
         unset DPKG_ARCH
         case ${{ matrix.job.target }} in
@@ -351,7 +348,7 @@ jobs:
         path: ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1
-      if: steps.vars.outputs.DEPLOY
+      if: steps.vars.outputs.IS_RELEASE
       with:
         files: |
           ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}


### PR DESCRIPTION
This PR makes Debian packages be built and published as artifacts for regular PR workflows.

It consists of four steps (commits) that can be code review individually together with respective commit message if the full diff is too confusing.

I think the only controversial change is the addition of `PROJECT_VERSION: "0.17.1"`, but it is already duplicated a lot, and I could not figure out a way to parse it from Cargo.toml in the CI script that was less annoying than duplicating it another time. I am open for ideas though.

The reason we need to do it is that Debian packages can not be built without a version, and since a PR does not contain a version (unlike a tag) we need to use the Cargo.toml version. If we think it is too confusing to reuse the same version string for different builds, we could perhaps suffix the git SHA at the end, but personally I think that is not necessary at this stage.

This PR makes the following artifacts be built and uploaded for each PR:

```
bat-musl_0.17.1_amd64.deb
bat-musl_0.17.1_i686.deb
bat-v0.17.1-aarch64-unknown-linux-gnu.tar.gz
bat-v0.17.1-arm-unknown-linux-gnueabihf.tar.gz
bat-v0.17.1-i686-pc-windows-msvc.zip
bat-v0.17.1-i686-unknown-linux-gnu.tar.gz
bat-v0.17.1-i686-unknown-linux-musl.tar.gz
bat-v0.17.1-x86_64-apple-darwin.tar.gz
bat-v0.17.1-x86_64-pc-windows-gnu.zip
bat-v0.17.1-x86_64-pc-windows-msvc.zip
bat-v0.17.1-x86_64-unknown-linux-gnu.tar.gz
bat-v0.17.1-x86_64-unknown-linux-musl.tar.gz
bat_0.17.1_amd64.deb
bat_0.17.1_arm64.deb
bat_0.17.1_armhf.deb
bat_0.17.1_i686.deb
```

so now the only entries missing compared to a real release is:

```
Source code (zip)
Source code (tar.gz)
```

Test deploy looks good: https://github.com/Enselic/bat/releases/tag/v0.0.12