### PR TITLE
CICD: Use 'cargo get' to extract crate metadata

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -105,6 +105,7 @@ jobs:
       with:
         crate: cargo-get
         version: latest
+        use-tool-cache: true
     - name: Extract crate information
       shell: bash
       run: |

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,11 +1,6 @@
 name: CICD
 
 env:
-  PROJECT_NAME: bat
-  PROJECT_VERSION: "0.17.1"
-  PROJECT_DESC: "A `cat` clone with wings"
-  PROJECT_MAINTAINER: "David Peter <mail@david-peter.de>"
-  PROJECT_HOMEPAGE: "https://github.com/sharkdp/bat"
   MIN_SUPPORTED_RUST_VERSION: "1.42.0"
 
 on: [push, pull_request]
@@ -105,6 +100,18 @@ jobs:
           arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
           aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
         esac
+    - name: Install 'cargo get'
+      uses: actions-rs/install@v0.1
+      with:
+        crate: cargo-get
+        version: latest
+    - name: Extract crate information
+      shell: bash
+      run: |
+        echo "PROJECT_NAME=$(cargo get --name)" >> $GITHUB_ENV
+        echo "PROJECT_VERSION=$(cargo get version --full)" >> $GITHUB_ENV
+        echo "PROJECT_MAINTAINER=$(cargo get --authors)" >> $GITHUB_ENV
+        echo "PROJECT_HOMEPAGE=$(cargo get --homepage)" >> $GITHUB_ENV
     - name: Initialize workflow variables
       id: vars
       shell: bash

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -100,19 +100,13 @@ jobs:
           arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
           aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
         esac
-    - name: Install 'cargo get'
-      uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-get
-        version: latest
-        use-tool-cache: true
     - name: Extract crate information
       shell: bash
       run: |
-        echo "PROJECT_NAME=$(cargo get --name)" >> $GITHUB_ENV
-        echo "PROJECT_VERSION=$(cargo get version --full)" >> $GITHUB_ENV
-        echo "PROJECT_MAINTAINER=$(cargo get --authors)" >> $GITHUB_ENV
-        echo "PROJECT_HOMEPAGE=$(cargo get --homepage)" >> $GITHUB_ENV
+        echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml)" >> $GITHUB_ENV
+        echo "PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+        echo "PROJECT_MAINTAINER=$(sed -n 's/^authors = \["\(.*\)"\]/\1/p' Cargo.toml)" >> $GITHUB_ENV
+        echo "PROJECT_HOMEPAGE=$(sed -n 's/^homepage = "\(.*\)"/\1/p' Cargo.toml)" >> $GITHUB_ENV
     - name: Initialize workflow variables
       id: vars
       shell: bash


### PR DESCRIPTION
As discussed in #1501: try to use `cargo get` to extract the crate metadata from `Cargo.toml` automatically.

GitHub Actions documentation on setting env variables dynamically: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

Ref: #1474 

Edit: Looks like this works as expected. This is how the environment looks like *after* the "Extract crate information" step:
```yaml
  env:
    MIN_SUPPORTED_RUST_VERSION: 1.42.0
    PROJECT_NAME: bat
    PROJECT_VERSION: 0.17.1
    PROJECT_MAINTAINER: David Peter <mail@david-peter.de>
    PROJECT_HOMEPAGE: https://github.com/sharkdp/bat
```