### PR TITLE
Explicitly allow clippy::match_bool until we bump MSRV

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -23,7 +23,9 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets --all-features
+        # clippy::match_bool is allowed by default from Rust 1.45.0, see
+        # https://github.com/rust-lang/rust-clippy/commit/e1d13c34b0beaea9a5fbf13687672ef85e779d9f
+        args: --all-targets --all-features -- --allow clippy::match_bool
     - name: Test
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Since we run clippy on Rust 1.42.0 we still get warnings about the
presence of clippy::match_bool lints. That lint has been moved from
'Style' to 'Pedantic' in Rust 1.45.0 and onwards however, so let's
silent it in our clippy runs too.

See discussion in https://github.com/sharkdp/bat/pull/1494