### PR TITLE
Fix #1413 Can't use `bat` at all! (Error: Use of bat as a pager is di…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Print an 'Invalid syntax theme settings' error message if a custom theme is broken, see #614 (@Enselic)
 - If plain mode is set and wrap is not explicitly opted in, long lines will no be truncated, see #1426
 - If `PAGER` (but not `BAT_PAGER` or `--pager`) is `more` or `most`, silently use `less` instead to ensure support for colors, see #1063 (@Enselic)
+- If `PAGER` is `bat`, silently use `less` to prevent recursion. For `BAT_PAGER` or `--pager`, exit with error, see #1413 (@Enselic)
 
 ## Other
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -500,13 +500,36 @@ fn pager_disable() {
 }
 
 #[test]
+fn env_var_pager_value_bat() {
+    bat()
+        .env("PAGER", "bat")
+        .arg("--paging=always")
+        .arg("test.txt")
+        .assert()
+        .success()
+        .stdout(predicate::eq("hello world\n").normalize());
+}
+
+#[test]
+fn env_var_bat_pager_value_bat() {
+    bat()
+        .env("BAT_PAGER", "bat")
+        .arg("--paging=always")
+        .arg("test.txt")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("bat as a pager is disallowed"));
+}
+
+#[test]
 fn pager_value_bat() {
     bat()
         .arg("--pager=bat")
         .arg("--paging=always")
         .arg("test.txt")
         .assert()
-        .failure();
+        .failure()
+        .stderr(predicate::str::contains("bat as a pager is disallowed"));
 }
 
 /// We shall use less instead of most if PAGER is used since PAGER


### PR DESCRIPTION
…sallowed...)

Fixed by implementing the proposal by sharkdp:

* Allow PAGER=bat, but ignore the setting in bat and simply default to
  less. Unless of course, BAT_PAGER or --pager is used to overwrite the
  value of PAGER.

* Disallow the usage of bat within BAT_PAGER and --pager.