### PR TITLE
Fixes to use the user-specified pager for less version check and diagnostic.

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -229,6 +229,8 @@ fn run() -> Result<bool> {
 
     if app.matches.is_present("diagnostic") {
         use bugreport::{bugreport, collector::*, format::Markdown};
+        let pager = bat::config::get_pager_executable(app.matches.value_of("pager"))
+            .unwrap_or("less".to_owned()); // FIXME: Avoid non-canonical path to "less".
 
         bugreport!()
             .info(SoftwareVersion::default())
@@ -252,7 +254,7 @@ fn run() -> Result<bool> {
             ]))
             .info(FileContent::new("Config file", config_file()))
             .info(CompileTimeInformation::default())
-            .info(CommandOutput::new("Less version", "less", &["--version"]))
+            .info(CommandOutput::new("Less version", pager, &["--version"]))
             .print::<Markdown>();
 
         return Ok(true);

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,15 @@ pub struct Config<'a> {
     pub highlighted_lines: HighlightedLineRanges,
 }
 
+#[cfg(all(feature = "application", feature = "paging"))]
+pub fn get_pager_executable(config_pager: Option<&str>) -> Option<String> {
+    if let Ok(Some(pager)) = crate::pager::get_pager(config_pager) {
+        Some(pager.bin)
+    } else {
+        None
+    }
+}
+
 #[test]
 fn default_config_should_include_all_lines() {
     use crate::line_range::RangeCheckResult;

--- a/src/less.rs
+++ b/src/less.rs
@@ -1,9 +1,10 @@
 #![cfg(feature = "paging")]
 
+use std::ffi::OsStr;
 use std::process::Command;
 
-pub fn retrieve_less_version() -> Option<usize> {
-    let cmd = Command::new("less").arg("--version").output().ok()?;
+pub fn retrieve_less_version(less_path: &dyn AsRef<OsStr>) -> Option<usize> {
+    let cmd = Command::new(less_path).arg("--version").output().ok()?;
     parse_less_version(&cmd.stdout)
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -63,7 +63,7 @@ impl OutputType {
             return Err(ErrorKind::InvalidPagerValueBat.into());
         }
 
-        let mut p = Command::new(pager.bin);
+        let mut p = Command::new(&pager.bin);
         let args = pager.args;
 
         if pager.kind == PagerKind::Less {
@@ -92,7 +92,7 @@ impl OutputType {
                 //
                 // For newer versions (530 or 558 on Windows), we omit '--no-init' as it
                 // is not needed anymore.
-                match retrieve_less_version() {
+                match retrieve_less_version(&pager.bin) {
                     None => {
                         p.arg("--no-init");
                     }


### PR DESCRIPTION
As we briefly mentioned in #1098, hardcoded paths to `less` were a bit of a pain point for both the version check and the `--diagnostic` option. This is a quick pull request that fixes both of them.