### PR TITLE
Add support for env vars and manpage refs with dots to Manpage syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - If plain mode is set and wrap is not explicitly opted in, long lines will no be truncated, see #1426
 - If `PAGER` (but not `BAT_PAGER` or `--pager`) is `more` or `most`, silently use `less` instead to ensure support for colors, see #1063 (@Enselic)
 - If `PAGER` is `bat`, silently use `less` to prevent recursion. For `BAT_PAGER` or `--pager`, exit with error, see #1413 (@Enselic)
+- Manpage highlighting fix, see #1511 (@keith-hall)
 
 ## Other
 

--- a/assets/syntaxes/02_Extra/Manpage.sublime-syntax
+++ b/assets/syntaxes/02_Extra/Manpage.sublime-syntax
@@ -59,12 +59,19 @@ contexts:
       escape: '(?={{section_heading}})'
 
   function-call:
-    - match: '\b([A-Za-z0-9_\-]+)(\()([^)]*)(\))'
+    - match: '\b([A-Za-z0-9_\-]+\.)?([A-Za-z0-9_\-]+)(\()([^)]*)(\))'
       captures:
         1: entity.name.function.man
-        2: keyword.operator.man
-        3: constant.numeric.man
-        4: keyword.operator.man
+        2: entity.name.function.man
+        3: keyword.operator.man
+        4: constant.numeric.man
+        5: keyword.operator.man
+
+  env-var:
+    - match: '(\$)(?!\d)(\w+)\b'
+      captures:
+        1: punctuation.definition.variable.man
+        2: constant.other.man
 
   options:
     # command-line options like --option=value, --some-flag, or -x
@@ -86,6 +93,7 @@ contexts:
           pop: true
     - include: function-call
     - include: c-code
+    - include: env-var
 
   expect-command-line-option:
     - match: '[A-Za-z0-9-]+'

--- a/assets/syntaxes/02_Extra/syntax_test_man.man
+++ b/assets/syntaxes/02_Extra/syntax_test_man.man
@@ -149,3 +149,14 @@ EXAMPLE
            #define POLLIN_SET  (EPOLLRDNORM | EPOLLRDBAND | EPOLLIN |
                                 EPOLLHUP | EPOLLERR)
 #                                                  ^ source.c meta.preprocessor.macro meta.group punctuation.section.group.end
+
+ENVIRONMENT
+       $SYSTEMD_LOG_LEVEL
+#      ^ punctuation.definition.variable
+#       ^^^^^^^^^^^^^^^^^ constant.other
+           systemd reads the log level from this environment variable. This
+           can be overridden with --log-level=.
+
+SEE ALSO
+       The systemd Homepage[11], systemd-system.conf(5), locale.conf(5)
+#                                ^^^^^^^^^^^^^^^^^^^ entity.name.function


### PR DESCRIPTION
This PR updates the Manpage syntax to fix #1511 and also highlight environment variables, i.e. like those beginning with a `$` sign in `man systemd`

