### PR TITLE
Use more conservative circle detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "git2",
  "globset",
  "lazy_static",
+ "nix",
  "path_abs",
  "predicates",
  "semver",
@@ -213,12 +214,12 @@ dependencies = [
 
 [[package]]
 name = "clircle"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27a01e782190a8314e65cc94274d9bbcd52e05a9d15b437fe2b31259b854b0d"
+checksum = "e68bbd985a63de680ab4d1ad77b6306611a8f961b282c8b5ab513e6de934e396"
 dependencies = [
  "cfg-if",
- "nix",
+ "libc",
  "serde",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 semver = "0.11"
 path_abs = { version = "0.5", default-features = false }
-clircle = "0.2.0"
+clircle = "0.3"
 bugreport = "0.3"
 dirs-next = { version = "2.0.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,9 @@ predicates = "1.0.7"
 wait-timeout = "0.2.0"
 tempfile = "3.2.0"
 
+[target.'cfg(unix)'.dev-dependencies]
+nix = "0.19.1"
+
 [build-dependencies]
 clap = { version = "2.33", optional = true }
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -329,7 +329,7 @@ mod tests {
 
             let input = Input::ordinary_file(file_path.as_os_str());
             let dummy_stdin: &[u8] = &[];
-            let mut opened_input = input.open(dummy_stdin).unwrap();
+            let mut opened_input = input.open(dummy_stdin, None).unwrap();
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
@@ -343,7 +343,7 @@ mod tests {
             let input = Input::from_reader(Box::new(BufReader::new(first_line.as_bytes())))
                 .with_name(Some(file_path.as_os_str()));
             let dummy_stdin: &[u8] = &[];
-            let mut opened_input = input.open(dummy_stdin).unwrap();
+            let mut opened_input = input.open(dummy_stdin, None).unwrap();
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
@@ -367,7 +367,7 @@ mod tests {
 
         fn syntax_for_stdin_with_content(&self, file_name: &str, content: &[u8]) -> String {
             let input = Input::stdin().with_name(Some(OsStr::new(file_name)));
-            let mut opened_input = input.open(content).unwrap();
+            let mut opened_input = input.open(content, None).unwrap();
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
@@ -523,7 +523,7 @@ mod tests {
 
         let input = Input::ordinary_file(file_path_symlink.as_os_str());
         let dummy_stdin: &[u8] = &[];
-        let mut opened_input = input.open(dummy_stdin).unwrap();
+        let mut opened_input = input.open(dummy_stdin, None).unwrap();
 
         assert_eq!(
             test.assets


### PR DESCRIPTION
Fixes #1503

This implements the exact logic for circle detection from `cat` for `bat`. To test this out yourself, you will have to get the newest version from the [pull request](https://github.com/niklasmohrin/clircle/pull/6) on the `clircle` repository and replace the `clircle` dependency in the `Cargo.toml` with the path to your local copy.

I will still have to fix the tests and see what to do with windows. Now that the posix approach (only error if program will provably fail later on) is taken here, we will have to investigate the situation on windows more closely.

I might still change things, there are breaking changes in `clircle` already, so there's no reason to hold back on changes over there.

Let me know, what you think and if you know anything about this on windows!
