### PR TITLE
README.md: Warn about buggy snap packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,6 @@
    - `input_from_reader_with_name`
    - `vcs_modification_markers` (if the `git` feature is not enabled)
 
-## Packaging
-
-- `bat` is now available on snapstore with package name called `batcat`, see #1401 (@purveshpatel511)
-
 
 # v0.17.1
 

--- a/README.md
+++ b/README.md
@@ -297,8 +297,8 @@ zypper install bat
 
 ### Via snap package
 
-There is currently no recommended snap package available. Be aware that existing ones might be [buggy](https://github.com/sharkdp/bat/issues/1519).
-
+There is currently no recommended snap package available.
+Existing packages may be available, but are not officially supported and may contain [issues](https://github.com/sharkdp/bat/issues/1519).
 
 ### On macOS (or Linux) via Homebrew
 

--- a/README.md
+++ b/README.md
@@ -297,11 +297,7 @@ zypper install bat
 
 ### Via snap package
 
-```
-sudo snap install batcat
-```
-
-[Get it from the Snap Store](https://snapcraft.io/batcat)
+There is currently no recommended snap package available. Be aware that existing ones might be [buggy](https://github.com/sharkdp/bat/issues/1519).
 
 
 ### On macOS (or Linux) via Homebrew


### PR DESCRIPTION
As discussed in #1519, the batcat snap package is too problematic for
official endorsement, so withdraw recommendation from README.me (and
remove section from CHANGELOG.md since a release with it has not been
made yet).

For now this MR should just be seen as a sketch of how we could go about doing it, in case we end up choosing this path.
