### PR TITLE
CICD: Don't run jobs twice in PRs

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -4,7 +4,13 @@ env:
   MIN_SUPPORTED_RUST_VERSION: "1.42.0"
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
 
 jobs:
   min_version:


### PR DESCRIPTION
Without this change, creating a PR triggers all jobs to run twice. Once
due to a push event and once due to a pull_request event.

Change to only trigger jobs due to push when pushing a tag or to the
master branch, to avoid duplicate jobs for each PR.

Triggering for tags confirmed to still work: https://github.com/Enselic/bat/actions/runs/586250776