### PR TITLE
CICD: Add aarch64-apple-darwin

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -95,6 +95,7 @@ jobs:
           - { os: ubuntu-18.04 , target: x86_64-unknown-linux-gnu    }
           - { os: ubuntu-18.04 , target: x86_64-unknown-linux-musl   , use-cross: true }
           - { os: macos-10.15  , target: x86_64-apple-darwin         }
+          - { os: macos-10.15  , target: aarch64-apple-darwin        , use-cross: true }
           # - { os: windows-2019 , target: i686-pc-windows-gnu         }  ## disabled; error: linker `i686-w64-mingw32-gcc` not found
           - { os: windows-2019 , target: i686-pc-windows-msvc        }
           - { os: windows-2019 , target: x86_64-pc-windows-gnu       }


### PR DESCRIPTION
This is a Rust Tier 2 platform. We already build other Tier 2 targets,
for example arm-unknown-linux-gnueabihf.

The tracking issue for this target is here:
https://github.com/rust-lang/rust/issues/73908

closes #1551