### PR TITLE
Do not ignore non-existent BAT_CONFIG_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - If `PAGER` (but not `BAT_PAGER` or `--pager`) is `more` or `most`, silently use `less` instead to ensure support for colors, see #1063 (@Enselic)
 - If `PAGER` is `bat`, silently use `less` to prevent recursion. For `BAT_PAGER` or `--pager`, exit with error, see #1413 (@Enselic)
 - Manpage highlighting fix, see #1511 (@keith-hall)
+- `BAT_CONFIG_PATH` ignored by `bat` if non-existent, see #1550 (@sharkdp)
 
 ## Other
 

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -10,13 +10,12 @@ pub fn config_file() -> PathBuf {
     env::var("BAT_CONFIG_PATH")
         .ok()
         .map(PathBuf::from)
-        .filter(|config_path| config_path.is_file())
         .unwrap_or_else(|| PROJECT_DIRS.config_dir().join("config"))
 }
 
 pub fn generate_config_file() -> bat::error::Result<()> {
     let config_file = config_file();
-    if config_file.exists() {
+    if config_file.is_file() {
         println!(
             "A config file already exists at: {}",
             config_file.to_string_lossy()
@@ -71,7 +70,14 @@ pub fn generate_config_file() -> bat::error::Result<()> {
 #--map-syntax ".ignore:Git Ignore"
 "#;
 
-    fs::write(&config_file, default_config)?;
+    fs::write(&config_file, default_config).map_err(|e| {
+        format!(
+            "Failed to create config file at '{}': {}",
+            config_file.to_string_lossy(),
+            e
+        )
+    })?;
+
     println!(
         "Success! Config file written to {}",
         config_file.to_string_lossy()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -652,6 +652,13 @@ fn config_location_test() {
         .assert()
         .success()
         .stdout("bat.conf\n");
+
+    bat_with_config()
+        .env("BAT_CONFIG_PATH", "not-existing.conf")
+        .arg("--config-file")
+        .assert()
+        .success()
+        .stdout("not-existing.conf\n");
 }
 
 #[test]


### PR DESCRIPTION
Do not ignore `BAT_CONFIG_PATH` if it doesn't exist. Both when
generating a new config file with `--generate-config-file` and
when attempting to read the config.

Also, provide a better error message in case the file can not
be created.

closes #1550