### PR TITLE
CICD: Add workflow_dispatch to enable manual builds

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -5,6 +5,7 @@ env:
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Which is useful when you want to test a fix without creating a PR for
it.

Disclaimer: I put this in master in my fork, but it did not seem to work. I suspect it has to be in the mother project. From what I understand, this change should be enough to allow CICD piplines to be created manually, which is always useful.
Source: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

Maybe we can merge this and simply see if it works?