### PR TITLE
Improve readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Other
 
+- `Input::ordinary_file` and `Input::with_name` now accept `Path` rather than `OsStr` see #1571 (@matklad)
+
 ## Syntaxes
 
 ## New themes

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -327,7 +327,7 @@ mod tests {
                 writeln!(temp_file, "{}", first_line).unwrap();
             }
 
-            let input = Input::ordinary_file(file_path.as_os_str());
+            let input = Input::ordinary_file(&file_path);
             let dummy_stdin: &[u8] = &[];
             let mut opened_input = input.open(dummy_stdin, None).unwrap();
 
@@ -341,7 +341,7 @@ mod tests {
         fn syntax_for_file_with_content_os(&self, file_name: &OsStr, first_line: &str) -> String {
             let file_path = self.temp_dir.path().join(file_name);
             let input = Input::from_reader(Box::new(BufReader::new(first_line.as_bytes())))
-                .with_name(Some(file_path.as_os_str()));
+                .with_name(Some(&file_path));
             let dummy_stdin: &[u8] = &[];
             let mut opened_input = input.open(dummy_stdin, None).unwrap();
 
@@ -366,7 +366,7 @@ mod tests {
         }
 
         fn syntax_for_stdin_with_content(&self, file_name: &str, content: &[u8]) -> String {
-            let input = Input::stdin().with_name(Some(OsStr::new(file_name)));
+            let input = Input::stdin().with_name(Some(file_name));
             let mut opened_input = input.open(content, None).unwrap();
 
             self.assets
@@ -521,7 +521,7 @@ mod tests {
             .expect("creation of directory succeeds");
         symlink(&file_path, &file_path_symlink).expect("creation of symbolic link succeeds");
 
-        let input = Input::ordinary_file(file_path_symlink.as_os_str());
+        let input = Input::ordinary_file(&file_path_symlink);
         let dummy_stdin: &[u8] = &[];
         let mut opened_input = input.open(dummy_stdin, None).unwrap();
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::env;
-use std::ffi::OsStr;
+use std::path::Path;
 use std::str::FromStr;
 
 use atty::{self, Stream};
@@ -248,16 +248,19 @@ impl App {
             }
             _ => {}
         }
-        let filenames: Option<Vec<&str>> = self
+        let filenames: Option<Vec<&Path>> = self
             .matches
-            .values_of("file-name")
-            .map(|values| values.collect());
+            .values_of_os("file-name")
+            .map(|values| values.map(Path::new).collect());
 
-        let mut filenames_or_none: Box<dyn Iterator<Item = _>> = match filenames {
-            Some(ref filenames) => Box::new(filenames.iter().map(|name| Some(OsStr::new(*name)))),
+        let mut filenames_or_none: Box<dyn Iterator<Item = Option<&Path>>> = match filenames {
+            Some(filenames) => Box::new(filenames.into_iter().map(Some)),
             None => Box::new(std::iter::repeat(None)),
         };
-        let files: Option<Vec<&OsStr>> = self.matches.values_of_os("FILE").map(|vs| vs.collect());
+        let files: Option<Vec<&Path>> = self
+            .matches
+            .values_of_os("FILE")
+            .map(|vs| vs.map(Path::new).collect());
 
         if files.is_none() {
             return Ok(vec![new_stdin_input(

--- a/src/bin/bat/input.rs
+++ b/src/bin/bat/input.rs
@@ -1,15 +1,15 @@
 use bat::input::Input;
-use std::ffi::OsStr;
+use std::path::Path;
 
-pub fn new_file_input<'a>(file: &'a OsStr, name: Option<&'a OsStr>) -> Input<'a> {
+pub fn new_file_input<'a>(file: &'a Path, name: Option<&'a Path>) -> Input<'a> {
     named(Input::ordinary_file(file), name.or(Some(file)))
 }
 
-pub fn new_stdin_input(name: Option<&OsStr>) -> Input {
+pub fn new_stdin_input(name: Option<&Path>) -> Input {
     named(Input::stdin(), name)
 }
 
-fn named<'a>(input: Input<'a>, name: Option<&OsStr>) -> Input<'a> {
+fn named<'a>(input: Input<'a>, name: Option<&Path>) -> Input<'a> {
     if let Some(provided_name) = name {
         let mut input = input.with_name(Some(provided_name));
         input.description_mut().set_kind(Some("File".to_owned()));

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -9,7 +9,6 @@ mod directories;
 mod input;
 
 use std::collections::{HashMap, HashSet};
-use std::ffi::OsStr;
 use std::io;
 use std::io::{BufReader, Write};
 use std::path::Path;
@@ -269,7 +268,7 @@ fn run() -> Result<bool> {
                 run_cache_subcommand(cache_matches)?;
                 Ok(true)
             } else {
-                let inputs = vec![Input::ordinary_file(OsStr::new("cache"))];
+                let inputs = vec![Input::ordinary_file("cache")];
                 let config = app.config(&inputs)?;
 
                 run_controller(inputs, &config)

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "git")]
 
 use std::collections::HashMap;
-use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
 
@@ -17,7 +16,7 @@ pub enum LineChange {
 
 pub type LineChanges = HashMap<u32, LineChange>;
 
-pub fn get_git_diff(filename: &OsStr) -> Option<LineChanges> {
+pub fn get_git_diff(filename: &Path) -> Option<LineChanges> {
     let repo = Repository::discover(&filename).ok()?;
 
     let repo_path_absolute = fs::canonicalize(repo.workdir()?).ok()?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -112,6 +112,7 @@ impl<'a> Input<'a> {
     pub fn ordinary_file(path: impl AsRef<Path>) -> Self {
         Self::_ordinary_file(path.as_ref())
     }
+
     fn _ordinary_file(path: &Path) -> Self {
         let kind = InputKind::OrdinaryFile(path.to_path_buf());
         Input {
@@ -143,10 +144,11 @@ impl<'a> Input<'a> {
         matches!(self.kind, InputKind::StdIn)
     }
 
-    pub fn with_name(mut self, provided_name: Option<impl AsRef<Path>>) -> Self {
+    pub fn with_name(self, provided_name: Option<impl AsRef<Path>>) -> Self {
         self._with_name(provided_name.as_ref().map(|it| it.as_ref()))
     }
-    pub fn _with_name(mut self, provided_name: Option<&Path>) -> Self {
+
+    fn _with_name(mut self, provided_name: Option<&Path>) -> Self {
         if let Some(name) = provided_name {
             self.description.name = name.to_string_lossy().to_string()
         }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -1,5 +1,5 @@
-use std::ffi::OsStr;
 use std::io::Read;
+use std::path::Path;
 
 use console::Term;
 use syntect::parsing::SyntaxReference;
@@ -71,7 +71,7 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     /// Add a file which should be pretty-printed
-    pub fn input_file(&mut self, path: impl AsRef<OsStr>) -> &mut Self {
+    pub fn input_file(&mut self, path: impl AsRef<Path>) -> &mut Self {
         self.input(Input::from_file(path).kind("File"))
     }
 
@@ -79,7 +79,7 @@ impl<'a> PrettyPrinter<'a> {
     pub fn input_files<I, P>(&mut self, paths: I) -> &mut Self
     where
         I: IntoIterator<Item = P>,
-        P: AsRef<OsStr>,
+        P: AsRef<Path>,
     {
         self.inputs(paths.into_iter().map(Input::from_file))
     }
@@ -297,8 +297,8 @@ impl<'a> Input<'a> {
     }
 
     /// A new input from a file.
-    pub fn from_file(path: impl AsRef<OsStr>) -> Self {
-        input::Input::ordinary_file(path.as_ref()).into()
+    pub fn from_file(path: impl AsRef<Path>) -> Self {
+        input::Input::ordinary_file(path).into()
     }
 
     /// A new input from bytes.
@@ -313,8 +313,8 @@ impl<'a> Input<'a> {
 
     /// The filename of the input.
     /// This affects syntax detection and changes the default header title.
-    pub fn name(mut self, name: impl AsRef<OsStr>) -> Self {
-        self.input = self.input.with_name(Some(name.as_ref()));
+    pub fn name(mut self, name: impl AsRef<Path>) -> Self {
+        self.input = self.input.with_name(Some(name));
         self
     }
 


### PR DESCRIPTION
Using `Path`s for paths expresses intent more clearly.

Drive by change mostly, I just accidentally fell into non-utf8 arguments pit :) 