### PR TITLE
CICD: Remove explicit allow of clippy::match_bool since MSRV 1.45 bump

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -31,9 +31,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        # clippy::match_bool is allowed by default from Rust 1.45.0, see
-        # https://github.com/rust-lang/rust-clippy/commit/e1d13c34b0beaea9a5fbf13687672ef85e779d9f
-        args: --all-targets --all-features -- --allow clippy::match_bool
+        args: --all-targets --all-features
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Now that we are on MSRV 1.45, there is no need to "backport" the change
that reclassified clippy::match_bool as "pedantic".