### PR TITLE
Add a system wide configuration file #668

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Support a system wide configuration file on unix platforms `/etc/bat/config` (@akinnane)
+
 ## Bugfixes
 
 ## Other

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -7,7 +7,7 @@ use atty::{self, Stream};
 
 use crate::{
     clap_app,
-    config::{get_args_from_config_file, get_args_from_env_var},
+    config::{get_args_from_config_files, get_args_from_env_var},
 };
 use clap::ArgMatches;
 
@@ -61,7 +61,7 @@ impl App {
 
             // Read arguments from bats config file
             let mut args = get_args_from_env_var()
-                .unwrap_or_else(get_args_from_config_file)
+                .unwrap_or_else(get_args_from_config_files)
                 .chain_err(|| "Could not parse configuration file")?;
 
             // Put the zero-th CLI argument (program name) first

--- a/src/bin/bat/directories.rs
+++ b/src/bin/bat/directories.rs
@@ -9,6 +9,7 @@ use lazy_static::lazy_static;
 pub struct BatProjectDirs {
     cache_dir: PathBuf,
     config_dir: PathBuf,
+    system_config_dir: Option<PathBuf>,
 }
 
 impl BatProjectDirs {
@@ -26,9 +27,16 @@ impl BatProjectDirs {
 
         let config_dir = config_dir_op.map(|d| d.join("bat"))?;
 
+        #[cfg(target_family = "unix")]
+        let system_config_dir = Some(PathBuf::from("/etc/bat"));
+
+        #[cfg(target_family = "windows")]
+        let system_config_dir = None;
+
         Some(BatProjectDirs {
             cache_dir,
             config_dir,
+            system_config_dir,
         })
     }
 
@@ -57,6 +65,10 @@ impl BatProjectDirs {
 
     pub fn config_dir(&self) -> &Path {
         &self.config_dir
+    }
+
+    pub fn system_config_dir(&self) -> Option<&PathBuf> {
+        self.system_config_dir.as_ref()
     }
 }
 


### PR DESCRIPTION
This adds a system wide configuration file `/etc/bat/config` as requested in #668.

In the thread, there was discussion around the correct paths for this file on different platforms. For Unix I've used `/etc/bat/config`, however, I've not added a location for Windows as I'm not sure what the correct path would be. I'm happy to update this if someone can suggest locations for either platform.

There was also discussion about making the path configurable for package maintainers. I had a look in `build.rs` but it wasn't clear how to feed through into the binary. Can you provide guidance on how that would be done?
