### PR TITLE
Add support for LESSOPEN and LESSCLOSE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 - Add SystemVerilog file syntax, see #1580 (@SeanMcLoughlin)
+- Add `--preprocessor=lessopen` support, see #1597 (@eth-p) 
 
 ## Bugfixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "globset",
  "lazy_static",
  "nix",
+ "os_str_bytes",
  "path_abs",
  "predicates",
  "semver",
@@ -686,6 +687,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e293568965aea261bdf010db17df7030e3c9a275c415d51d6112f7cf9b7af012"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,12 @@ application = [
     "paging",
     "wild",
     "regex-onig",
+    "preprocessor-lessopen",
 ]
 git = ["git2"] # Support indicating git modifications
 paging = ["shell-words"] # Support applying a pager on the output
+preprocessor = []
+preprocessor-lessopen = ["preprocessor", "os_str_bytes"] # Support LESSOPEN and LESSCLOSE
 
 # You need to use one of these if you depend on bat as a library:
 regex-onig = ["syntect/regex-onig"] # Use the "oniguruma" regex engine
@@ -51,6 +54,7 @@ path_abs = { version = "0.5", default-features = false }
 clircle = "0.3"
 bugreport = "0.3"
 dirs-next = { version = "2.0.0", optional = true }
+os_str_bytes = { version = "3.0", optional = true }
 
 [dependencies.git2]
 version = "0.13"

--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ Also, note that this will [not work](https://github.com/sharkdp/bat/issues/1145)
 The [`prettybat`](https://github.com/eth-p/bat-extras/blob/master/doc/prettybat.md) script is a wrapper that will format code and print it with `bat`.
 
 
+#### `lesspipe.sh`
+
+Starting from version `0.19.0`, `bat` has opt-in support for file preprocessing using the `LESSOPEN` and `LESSCLOSE` environment variables.
+This can be used with [lesspipe.sh](https://github.com/wofr06/lesspipe) to enable viewing of compressed files, PDFs, and much more.
+
+To enable preprocessing, you need to either pass the `--preprocessor=lessopen` argument through the command line, or add it to bat's [configuration file](https://github.com/sharkdp/bat#configuration-file).
+
+For more information on how to use `LESSOPEN` and `LESSCLOSE`, please check the [Input Preprocessor section of `man less(1)`](https://linux.die.net/man/1/less#~#Input%20Preprocessor#:~:text=You%20may%20define%20an%20%22input%20preprocessor%22%20for%20less.).
+
+
 ## Installation
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg)](https://repology.org/project/bat-cat/versions)

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -299,7 +299,7 @@ mod tests {
     use std::io::Write;
     use tempfile::TempDir;
 
-    use crate::input::Input;
+    use crate::input::{Input, InputHandle};
 
     struct SyntaxDetectionTest<'a> {
         assets: HighlightingAssets,
@@ -328,8 +328,11 @@ mod tests {
             }
 
             let input = Input::ordinary_file(&file_path);
-            let dummy_stdin: &[u8] = &[];
-            let mut opened_input = input.open(dummy_stdin, None).unwrap();
+            let input_handle = InputHandle {
+                stdout_identifier: None,
+            };
+
+            let mut opened_input = input.open(&input_handle).unwrap();
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
@@ -342,8 +345,10 @@ mod tests {
             let file_path = self.temp_dir.path().join(file_name);
             let input = Input::from_reader(Box::new(BufReader::new(first_line.as_bytes())))
                 .with_name(Some(&file_path));
-            let dummy_stdin: &[u8] = &[];
-            let mut opened_input = input.open(dummy_stdin, None).unwrap();
+            let input_handle = InputHandle {
+                stdout_identifier: None,
+            };
+            let mut opened_input = input.open(&input_handle).unwrap();
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
@@ -366,8 +371,11 @@ mod tests {
         }
 
         fn syntax_for_stdin_with_content(&self, file_name: &str, content: &[u8]) -> String {
-            let input = Input::stdin().with_name(Some(file_name));
-            let mut opened_input = input.open(content, None).unwrap();
+            let input = Input::stdin_with_contents(content).with_name(Some(file_name));
+            let input_handle = InputHandle {
+                stdout_identifier: None,
+            };
+            let mut opened_input = input.open(&input_handle).unwrap();
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
@@ -523,8 +531,10 @@ mod tests {
         symlink(&file_path, &file_path_symlink).expect("creation of symbolic link succeeds");
 
         let input = Input::ordinary_file(&file_path_symlink);
-        let dummy_stdin: &[u8] = &[];
-        let mut opened_input = input.open(dummy_stdin, None).unwrap();
+        let input_handle = InputHandle {
+            stdout_identifier: None,
+        };
+        let mut opened_input = input.open(&input_handle).unwrap();
 
         assert_eq!(
             test.assets

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -148,6 +148,26 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 )
     }
 
+    #[cfg(feature = "preprocessor")]
+    {
+        let mut preprocessors: Vec<&'static str> = vec!["none"];
+
+        #[cfg(feature = "preprocessor-lessopen")]
+        preprocessors.push("lessopen");
+
+        app = app.arg(
+            Arg::with_name("preprocessor")
+                .long("preprocessor")
+                .overrides_with("preprocessor")
+                .takes_value(true)
+                .value_name("preprocessor")
+                .possible_values(&preprocessors)
+                .default_value("none")
+                .hide_default_value(true)
+                .help("Specify the preprocessor to use on input files."),
+        )
+    }
+
     app = app.arg(
         Arg::with_name("tabs")
             .long("tabs")

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -55,6 +55,10 @@ pub fn generate_config_file() -> bat::error::Result<()> {
 # terminal emulators (like tmux, by default):
 #--italic-text=always
 
+# Uncomment the following line to enable LESSOPEN/LESSCLOSE preprocessing.
+# You can disable preprocessing on the command line with `--preprocessor=none`.
+#--preprocessor=lessopen
+
 # Uncomment the following line to disable automatic paging:
 #--paging=never
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -130,27 +130,26 @@ impl<'b> Controller<'b> {
                     let line_changes = if self.config.visible_lines.diff_mode()
                         || (!self.config.loop_through && self.config.style_components.changes())
                     {
-                        match opened_input.kind {
-                            crate::input::OpenedInputKind::OrdinaryFile(ref path) => {
-                                let diff = get_git_diff(path);
+                        let path = opened_input.original_name();
+                        if let Some(path) = path {
+                            let diff = get_git_diff(path);
 
-                                // Skip files without Git modifications
-                                if self.config.visible_lines.diff_mode()
-                                    && diff
-                                        .as_ref()
-                                        .map(|changes| changes.is_empty())
-                                        .unwrap_or(false)
-                                {
-                                    continue;
-                                }
-
-                                diff
-                            }
-                            _ if self.config.visible_lines.diff_mode() => {
-                                // Skip non-file inputs in diff mode
+                            // Skip files without Git modifications
+                            if self.config.visible_lines.diff_mode()
+                                && diff
+                                    .as_ref()
+                                    .map(|changes| changes.is_empty())
+                                    .unwrap_or(false)
+                            {
                                 continue;
                             }
-                            _ => None,
+
+                            diff
+                        } else if self.config.visible_lines.diff_mode() {
+                            // Skip non-file inputs in diff mode
+                            continue;
+                        } else {
+                            None
                         }
                     } else {
                         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod output;
 mod pager;
 #[cfg(feature = "paging")]
 pub(crate) mod paging;
-mod preprocessor;
+pub mod preprocessor;
 mod pretty_printer;
 pub(crate) mod printer;
 pub mod style;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -292,15 +292,24 @@ impl<'a> Printer for InteractivePrinter<'a> {
             write!(handle, "{}", " ".repeat(self.panel_width))?;
         }
 
-        let mode = match self.content_type {
+        let description = &input.description;
+        let mode = String::from(match self.content_type {
             Some(ContentType::BINARY) => "   <BINARY>",
             Some(ContentType::UTF_16LE) => "   <UTF-16LE>",
             Some(ContentType::UTF_16BE) => "   <UTF-16BE>",
             None => "   <EMPTY>",
             _ => "",
-        };
+        });
 
-        let description = &input.description;
+        #[cfg(feature = "preprocessor")]
+        let mode = if description.preprocessed() {
+            match mode.as_str() {
+                "" => "    <PP>".to_owned(),
+                mode => format!("{} <PP>", mode),
+            }
+        } else {
+            mode
+        };
 
         writeln!(
             handle,


### PR DESCRIPTION
This pull request adds opt-in support for preprocessors using the `LESSOPEN` and `LESSCLOSE` environment variables.

To enable the preprocessor, `--preprocessor=lessopen` must be set either be passed as a command line argument or set in the config file. This was made opt-in to avoid breaking default installations that provide an incompatible `LESSOPEN` program.

![image](https://user-images.githubusercontent.com/32112321/112308519-781ed380-8c5f-11eb-997a-4da2ad7b809b.png)

When used with something like `lesspipe.sh`, this can potentially fix #237, #642, #748, and #971.


## Implementation (Preprocessor Abstraction)

The preprocessor implementation is basically a `map` operation on `Input<'a> -> OpenedInput<'a>`.
It can either open the source input and return that directly (e.g. nothing to be done), or create a new `Input<'a>` and return that instead.

Preprocessors (or inputs like `InputKind::StdIn`) can attach "handles" to `OpenedInput<'a>` structs.
Handles can be used to perform cleanup actions (like deleting temporary files), or in the case of `InputKind::StdIn`, used to (`unsafe`ly) keep a reference to a `Stdin` object alive as long as its corresponding `InputReader`.

Note: handles will either be closed automatically when dropped (panicking on errors), or explicitly closed with `OpenedInput::close`.

## Implementation (Lessopen)

Using the new preprocessor abstraction, basic `LESSOPEN`/`LESSCLOSE` support was added to `bat`.
**Note:** This only supports file inputs.

1. If `LESSOPEN` is defined and invalid (as determined by `shell_words::split`), `bat` will silently do nothing.
  This doesn't follow the behavior of `less`, but it's more consistent with how `bat` handles the pager.

2. If `LESSOPEN` is defined but the process could not be spawned, `bat` will print a warning.
  For consistency with `less` (which simply ignores the exit code), this does not include the exit code of an unsuccessfully-exited command.

3. If `LESSOPEN` is defined and starts with `"|"`, `bat` will use its standard output as the preprocessed file contents.
  If no output is provided by the LESSOPEN function, `bat` will use the original file.

4.  If `LESSOPEN` is defined and does not start with `"|"`, `bat` will read the first line of output as the path to a temporary file containing the preprocessed file contents.

5. If any preprocessor command was executed and `LESSCLOSE` is defined, `bat` will execute `LESSCLOSE`.
  If the process could not be spawned, `bat` will print a warning.


## Caveats

- Git changes will be displayed with LESSOPEN, even if it outputs something different than the original file.
  This is intentional, and it's an unfortunate side-effect of the way that `lesspipe.sh` will always `cat` the file, even if it doesn't need to preprocess it.
  Without this, git changes would not be displayed at all.

- Due to some rewrites with the `input` module in order to add support for preprocessors, two instances of `unsafe` were added. 
  - A comment with safety information was included.

- It is not 100% compatible with `less`'s implementation.
  - This implementation tries to avoid invoking the user's shell, which limits the support to a shell-quoted list of arguments.
  - This implementation only replaces substitutes `%s` if it is an entire argument. Something like `LESSOPEN='| echo File:%s'` will not work.

- No tests were added. I couldn't think of a way to add tests without writing to the filesystem.