### PR TITLE
Fix less version parsing for minor versions of less

### DIFF
--- a/src/less.rs
+++ b/src/less.rs
@@ -11,7 +11,7 @@ pub fn retrieve_less_version(less_path: &dyn AsRef<OsStr>) -> Option<usize> {
 fn parse_less_version(output: &[u8]) -> Option<usize> {
     if output.starts_with(b"less ") {
         let version = std::str::from_utf8(&output[5..]).ok()?;
-        let end = version.find(' ')?;
+        let end = version.find(|c: char| !c.is_ascii_digit())?;
         version[..end].parse::<usize>().ok()
     } else {
         None
@@ -55,6 +55,19 @@ see the file named README in the less distribution.
 Home page: http://www.greenwoodsoftware.com/less";
 
     assert_eq!(Some(551), parse_less_version(output));
+}
+
+#[test]
+fn test_parse_less_version_581_2() {
+    let output = b"less 581.2 (PCRE2 regular expressions)
+Copyright (C) 1984-2021  Mark Nudelman
+
+less comes with NO WARRANTY, to the extent permitted by law.
+For information about the terms of redistribution,
+see the file named README in the less distribution.
+Home page: https://greenwoodsoftware.com/less";
+
+    assert_eq!(Some(581), parse_less_version(output));
 }
 
 #[test]


### PR DESCRIPTION
Less 581.2 is here, and it has a ".2" in the version string, which can't
be parsed as a usize.

Update the check to find a non-digit character rather than a space. This
ignores the minor version, but parses the major version correctly.