### PR TITLE
Fix Clippy lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Other
 
+- Fix Clippy lints, see #1661 (@mohamed-abdelnour)
+
 
 ## Syntaxes
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -201,7 +201,7 @@ impl HighlightingAssets {
                     bat_warning!("Theme '{}' is deprecated, using 'ansi' instead.", theme);
                     return self.get_theme("ansi");
                 }
-                if theme != "" {
+                if !theme.is_empty() {
                     bat_warning!("Unknown theme '{}', using default.", theme)
                 }
                 &self.theme_set.themes[self.fallback_theme.unwrap_or_else(|| Self::default_theme())]

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -98,18 +98,21 @@ pub(crate) fn get_pager(config_pager: Option<&str>) -> Result<Option<Pager>, Par
         Some((bin, args)) => {
             let kind = PagerKind::from_bin(bin);
 
-            let use_less_instead = match (&source, &kind) {
-                // 'more' and 'most' do not supports colors; automatically use 'less' instead
-                // if the problematic pager came from the generic PAGER env var
-                (PagerSource::EnvVarPager, PagerKind::More) => true,
-                (PagerSource::EnvVarPager, PagerKind::Most) => true,
+            // Is false if the given expression does not match any of the
+            // patterns; this ensures 'less' is never silently used if BAT_PAGER
+            // or --pager has been specified.
+            let use_less_instead = matches!(
+                (&source, &kind),
+                // 'more' and 'most' do not supports colors; automatically use
+                // 'less' instead if the problematic pager came from the
+                // generic PAGER env var
+                (PagerSource::EnvVarPager, PagerKind::More)
+                    | (PagerSource::EnvVarPager, PagerKind::Most)
 
-                // If PAGER=bat, silently use 'less' instead to prevent recursion ...
-                (PagerSource::EnvVarPager, PagerKind::Bat) => true,
-
-                // Never silently use less if BAT_PAGER or --pager has been specified
-                _ => false,
-            };
+                // If PAGER=bat, silently use 'less' instead to prevent
+                // recursion ...
+                    | (PagerSource::EnvVarPager, PagerKind::Bat)
+            );
 
             Ok(Some(if use_less_instead {
                 let no_args = vec![];

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -40,10 +40,11 @@ pub struct PrettyPrinter<'a> {
 
 impl<'a> PrettyPrinter<'a> {
     pub fn new() -> Self {
-        let mut config = Config::default();
-
-        config.colored_output = true;
-        config.true_color = true;
+        let config = Config {
+            colored_output: true,
+            true_color: true,
+            ..Default::default()
+        };
 
         PrettyPrinter {
             inputs: vec![],

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -336,14 +336,14 @@ impl<'a> Input<'a> {
     }
 }
 
-impl<'a> Into<Input<'a>> for input::Input<'a> {
-    fn into(self) -> Input<'a> {
-        Input { input: self }
+impl<'a> From<input::Input<'a>> for Input<'a> {
+    fn from(input: input::Input<'a>) -> Self {
+        Self { input }
     }
 }
 
-impl<'a> Into<input::Input<'a>> for Input<'a> {
-    fn into(self) -> input::Input<'a> {
-        self.input
+impl<'a> From<Input<'a>> for input::Input<'a> {
+    fn from(Input { input }: Input<'a>) -> Self {
+        input
     }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -447,8 +447,10 @@ impl<'a> Printer for InteractivePrinter<'a> {
 
                 if text.len() != text_trimmed.len() {
                     if let Some(background_color) = background_color {
-                        let mut ansi_style = Style::default();
-                        ansi_style.background = to_ansi_color(background_color, true_color);
+                        let ansi_style = Style {
+                            background: to_ansi_color(background_color, true_color),
+                            ..Default::default()
+                        };
                         let width = if cursor_total <= cursor_max {
                             cursor_max - cursor_total + 1
                         } else {
@@ -588,8 +590,10 @@ impl<'a> Printer for InteractivePrinter<'a> {
             }
 
             if let Some(background_color) = background_color {
-                let mut ansi_style = Style::default();
-                ansi_style.background = to_ansi_color(background_color, self.config.true_color);
+                let ansi_style = Style {
+                    background: to_ansi_color(background_color, self.config.true_color),
+                    ..Default::default()
+                };
 
                 write!(
                     handle,


### PR DESCRIPTION
The Minimum Supported Rust Version (MSRV) for `bat` is 1.45.0. Setting `msrv = "1.45.0"` in `.clippy.toml` (not part of the repository) and running `cargo clippy` emits 7 warnings. These are proposed fixes to said warnings. If there are any lints we would rather allow, I can revert the relevant commit(s) and add the appropriate lint attribute(s).

Also, do you think we should create `.clippy.toml`/`clippy.toml` and set the MSRV to ensure consistency amongst contributors?