### PR TITLE
Add bash completion

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -268,6 +268,7 @@ jobs:
         cp "README.md" "LICENSE-MIT" "LICENSE-APACHE" "CHANGELOG.md" "$ARCHIVE_DIR"
 
         # Autocompletion files
+        cp 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}'-*/out/assets/completions/bat.bash "$ARCHIVE_DIR/autocomplete/${{ env.PROJECT_NAME }}.bash"
         cp 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}'-*/out/assets/completions/bat.fish "$ARCHIVE_DIR/autocomplete/${{ env.PROJECT_NAME }}.fish"
         cp 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}'-*/out/assets/completions/bat.zsh "$ARCHIVE_DIR/autocomplete/${{ env.PROJECT_NAME }}.zsh"
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/*.rs.bk
 
 # Generated files
+/assets/completions/bat.bash
 /assets/completions/bat.fish
 /assets/completions/bat.zsh
 /assets/manual/bat.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix Clippy lints, see #1661 (@mohamed-abdelnour)
 - Add syntax highlighting test files, see #1213 and #1668 (@mohamed-abdelnour)
+- Add bash completion, see #1678 (@scop)
 
 
 ## Syntaxes

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -1,0 +1,84 @@
+# shellcheck disable=SC2207
+
+_bat() {
+	if [[ ${COMP_WORDS[1]-} == cache ]]; then
+		case $3 in
+		--source | --target)
+			local IFS=$'\n'
+			COMPREPLY=($(compgen -d -- "$2"))
+			compopt -o filenames
+			return 0
+			;;
+		esac
+		COMPREPLY=($(compgen -W "
+			--build --clear --source --target --blank --help
+		" -- "$2"))
+		return 0
+	fi
+
+	case $3 in
+	-l | --language)
+		local IFS=$'\n'
+		COMPREPLY=($(compgen -W "$(
+			"$1" --list-languages | while IFS=: read -r lang _; do
+				printf "%s\n" "$lang"
+			done
+		)" -- "$2"))
+		compopt -o filenames  # for escaping
+		return 0
+		;;
+	-H | --highlight-line | --diff-context | --tabs | --terminal-width | \
+	-m | --map-syntax | --style | --line-range | -h | --help | -V | \
+	--version)
+		# argument required but no completion available, or argument
+		# causes an exit
+		return 0
+		;;
+	--file-name)
+		local IFS=$'\n'
+		COMPREPLY=($(compgen -f -- "$2"))
+		compopt -o filenames
+		return 0
+		;;
+	--wrap)
+		COMPREPLY=($(compgen -W "auto never character" -- "$2"))
+		return 0
+		;;
+	--color | --decorations | --paging)
+		COMPREPLY=($(compgen -W "auto never always" -- "$2"))
+		return 0
+		;;
+	--italic-text)
+		COMPREPLY=($(compgen -W "always never" -- "$2"))
+		return 0
+		;;
+	--pager)
+		COMPREPLY=($(compgen -c -- "$2"))
+		return 0
+		;;
+	--theme)
+		local IFS=$'\n'
+		COMPREPLY=($(compgen -W "$("$1" --list-themes)" -- "$2"))
+		compopt -o filenames
+		return 0
+		;;
+	esac
+
+	if [[ $2 == -* ]]; then
+		COMPREPLY=($(compgen -W "
+			--show-all --plain --language --highlight-line
+			--file-name --diff --diff-context --tabs --wrap
+			--terminal-width --number --color --italic-text
+			--decorations --paging --pager --map-syntax --theme
+			--list-themes --style --line-range --list-languages
+			--help --version
+		" -- "$2"))
+		return 0
+	fi
+
+	local IFS=$'\n'
+	COMPREPLY=($(compgen -f -- "$2"))
+	compopt -o filenames
+	((COMP_CWORD == 1)) && COMPREPLY+=($(compgen -W cache -- "$2"))
+
+} && complete -F _bat {{PROJECT_EXECUTABLE}}

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -1,29 +1,32 @@
 # shellcheck disable=SC2207
 
+# Requires https://github.com/scop/bash-completion
+
 _bat() {
-	if [[ ${COMP_WORDS[1]-} == cache ]]; then
-		case $3 in
+	local cur prev words cword split
+	_init_completion -s || return 0
+
+	if [[ ${words[1]-} == cache ]]; then
+		case $prev in
 		--source | --target)
-			local IFS=$'\n'
-			COMPREPLY=($(compgen -d -- "$2"))
-			compopt -o filenames
+			_filedir -d
 			return 0
 			;;
 		esac
 		COMPREPLY=($(compgen -W "
 			--build --clear --source --target --blank --help
-		" -- "$2"))
+		" -- "$cur"))
 		return 0
 	fi
 
-	case $3 in
+	case $prev in
 	-l | --language)
 		local IFS=$'\n'
 		COMPREPLY=($(compgen -W "$(
 			"$1" --list-languages | while IFS=: read -r lang _; do
 				printf "%s\n" "$lang"
 			done
-		)" -- "$2"))
+		)" -- "$cur"))
 		compopt -o filenames  # for escaping
 		return 0
 		;;
@@ -35,36 +38,36 @@ _bat() {
 		return 0
 		;;
 	--file-name)
-		local IFS=$'\n'
-		COMPREPLY=($(compgen -f -- "$2"))
-		compopt -o filenames
+		_filedir
 		return 0
 		;;
 	--wrap)
-		COMPREPLY=($(compgen -W "auto never character" -- "$2"))
+		COMPREPLY=($(compgen -W "auto never character" -- "$cur"))
 		return 0
 		;;
 	--color | --decorations | --paging)
-		COMPREPLY=($(compgen -W "auto never always" -- "$2"))
+		COMPREPLY=($(compgen -W "auto never always" -- "$cur"))
 		return 0
 		;;
 	--italic-text)
-		COMPREPLY=($(compgen -W "always never" -- "$2"))
+		COMPREPLY=($(compgen -W "always never" -- "$cur"))
 		return 0
 		;;
 	--pager)
-		COMPREPLY=($(compgen -c -- "$2"))
+		COMPREPLY=($(compgen -c -- "$cur"))
 		return 0
 		;;
 	--theme)
 		local IFS=$'\n'
-		COMPREPLY=($(compgen -W "$("$1" --list-themes)" -- "$2"))
+		COMPREPLY=($(compgen -W "$("$1" --list-themes)" -- "$cur"))
 		compopt -o filenames  # for escaping
 		return 0
 		;;
 	esac
 
-	if [[ $2 == -* ]]; then
+	$split && return 0
+
+	if [[ $cur == -* ]]; then
 		COMPREPLY=($(compgen -W "
 			--show-all --plain --language --highlight-line
 			--file-name --diff --diff-context --tabs --wrap
@@ -72,13 +75,11 @@ _bat() {
 			--decorations --paging --pager --map-syntax --theme
 			--list-themes --style --line-range --list-languages
 			--help --version
-		" -- "$2"))
+		" -- "$cur"))
 		return 0
 	fi
 
-	local IFS=$'\n'
-	COMPREPLY=($(compgen -f -- "$2"))
-	compopt -o filenames
-	((COMP_CWORD == 1)) && COMPREPLY+=($(compgen -W cache -- "$2"))
+	_filedir
+	((cword == 1)) && COMPREPLY+=($(compgen -W cache -- "$cur"))
 
 } && complete -F _bat {{PROJECT_EXECUTABLE}}

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -59,7 +59,7 @@ _bat() {
 	--theme)
 		local IFS=$'\n'
 		COMPREPLY=($(compgen -W "$("$1" --list-themes)" -- "$2"))
-		compopt -o filenames
+		compopt -o filenames  # for escaping
 		return 0
 		;;
 	esac

--- a/build.rs
+++ b/build.rs
@@ -56,6 +56,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     template(
         &variables,
+        "assets/completions/bat.bash.in",
+        out_dir.join("assets/completions/bat.bash"),
+    )?;
+    template(
+        &variables,
         "assets/completions/bat.fish.in",
         out_dir.join("assets/completions/bat.fish"),
     )?;


### PR DESCRIPTION
Closes https://github.com/sharkdp/bat/issues/1010

This implementation is self contained and does not require https://github.com/scop/bash-completion. If a dependency on it would be ok, adding it would make it possible to clean this up some, and would gain easy support for completing long options separated by `=` (which this one doesn't currently, and I'd rather not duplicate the code for that). Let me know if that would be desirable and I can adjust this.