### PR TITLE
README.md: Mention that PAGER is ignored if set to more or most

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,8 @@ set, `less` is used by default. If you want to use a different pager, you can ei
 `PAGER` variable or set the `BAT_PAGER` environment variable to override what is specified in
 `PAGER`.
 
+**Note**: If `PAGER` is `more` or `most`, `bat` will silently use `less` instead to ensure support for colors.
+
 If you want to pass command-line arguments to the pager, you can also set them via the
 `PAGER`/`BAT_PAGER` variables:
 


### PR DESCRIPTION
Quick and dirty fix for #1666. I think the whole "Using a different pager" section would probably benefit from some restructuring and cleanup, but with this PR, we at least have _something_ in the readme that informs the user of PAGER + most/more, which decidedly is better than _nothing_.
