### PR TITLE
Highlight mtab files with fstab highlighting

### DIFF
--- a/assets/syntaxes/02_Extra/Fstab.sublime-syntax
+++ b/assets/syntaxes/02_Extra/Fstab.sublime-syntax
@@ -5,6 +5,7 @@ name: fstab
 file_extensions:
   - fstab
   - crypttab
+  - mtab
 scope: source.fstab
 
 contexts:


### PR DESCRIPTION
This is mentioned in https://github.com/sharkdp/bat/pull/696#issuecomment-544692236, but somehow not implemented.