### PR TITLE
Find syntax ignoring known backup/template filename suffixes

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -293,13 +293,8 @@ impl HighlightingAssets {
                 ).or_else(|| {
                     let file_str = file_path.to_str().unwrap_or_default();
                     for suffix in IGNORED_SUFFIXES.iter() {
-                        if file_str.ends_with(suffix) {
-                            return self.get_extension_syntax(
-                                OsStr::new(
-                                    file_str
-                                        .strip_suffix(suffix)
-                                        .unwrap_or_default()
-                                ));
+                        if let Some(stripped_filename) = file_str.strip_suffix(suffix) {
+                            return self.get_extension_syntax(OsStr::new(stripped_filename));
                         }
                     }
                     None

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -291,10 +291,11 @@ impl HighlightingAssets {
                         .and_then(|x| x.to_str())
                         .unwrap_or_default(),
                 ).or_else(|| {
-                    let file_str = file_path.to_str().unwrap_or_default();
-                    for suffix in IGNORED_SUFFIXES.iter() {
-                        if let Some(stripped_filename) = file_str.strip_suffix(suffix) {
-                            return self.get_extension_syntax(OsStr::new(stripped_filename));
+                    if let Some(file_str) = file_path.to_str() {
+                        for suffix in IGNORED_SUFFIXES.iter() {
+                            if let Some(stripped_filename) = file_str.strip_suffix(suffix) {
+                                return self.get_extension_syntax(OsStr::new(stripped_filename));
+                            }
                         }
                     }
                     None

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.bak
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.bak
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.bak (editor etc backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.dpkg-dist
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.dpkg-dist
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.dpkg-dist (Debian dpkg backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.dpkg-old
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.dpkg-old
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.dpkg-old (Debian dpkg backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.in
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.in
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.in (build system input) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.in.in
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.in.in
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.in.in (build system input, doubly replaced) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.old
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.old
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.old (editor etc backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.orig
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.orig
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.orig (editor, diff etc backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.orig~
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.orig~
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.orig~ (backup of an editor, diff etc backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.rpmnew
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.rpmnew
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.rpmnew (Red Hat rpm backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.rpmorig
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.rpmorig
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.rpmorig (Red Hat rpm backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.rpmsave
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs.rpmsave
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo.rpmsave (Red Hat rpm backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.rs~
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.rs~
@@ -1,0 +1,1 @@
+[38;2;117;113;94m//[0m[38;2;117;113;94m foo~ (editor backup) should highlight same as foo[0m

--- a/tests/syntax-tests/highlighted/Ignored suffixes/test.unknown~
+++ b/tests/syntax-tests/highlighted/Ignored suffixes/test.unknown~
@@ -1,0 +1,1 @@
+[38;2;248;248;242m// foo~ for unknown foo should not highlight[0m

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.bak
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.bak
@@ -1,0 +1,1 @@
+// foo.bak (editor etc backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.dpkg-dist
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.dpkg-dist
@@ -1,0 +1,1 @@
+// foo.dpkg-dist (Debian dpkg backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.dpkg-old
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.dpkg-old
@@ -1,0 +1,1 @@
+// foo.dpkg-old (Debian dpkg backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.in
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.in
@@ -1,0 +1,1 @@
+// foo.in (build system input) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.in.in
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.in.in
@@ -1,0 +1,1 @@
+// foo.in.in (build system input, doubly replaced) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.old
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.old
@@ -1,0 +1,1 @@
+// foo.old (editor etc backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.orig
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.orig
@@ -1,0 +1,1 @@
+// foo.orig (editor, diff etc backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.orig~
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.orig~
@@ -1,0 +1,1 @@
+// foo.orig~ (backup of an editor, diff etc backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.rpmnew
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.rpmnew
@@ -1,0 +1,1 @@
+// foo.rpmnew (Red Hat rpm backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.rpmorig
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.rpmorig
@@ -1,0 +1,1 @@
+// foo.rpmorig (Red Hat rpm backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs.rpmsave
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs.rpmsave
@@ -1,0 +1,1 @@
+// foo.rpmsave (Red Hat rpm backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.rs~
+++ b/tests/syntax-tests/source/Ignored suffixes/test.rs~
@@ -1,0 +1,1 @@
+// foo~ (editor backup) should highlight same as foo

--- a/tests/syntax-tests/source/Ignored suffixes/test.unknown~
+++ b/tests/syntax-tests/source/Ignored suffixes/test.unknown~
@@ -1,0 +1,1 @@
+// foo~ for unknown foo should not highlight


### PR DESCRIPTION
For example, fall back to `foo.extension` for `foo.extension~`, `foo.extension.orig`, `foo.extension.in.in` etc.

Rust newbie alert, likely clumsy/not idiomatic, but appears to work. Critique/guidance very much welcome, for example redundant/repeated conversion between `OsStr`, `Path`, and `str` doesn't seem that clean to me.