### PR TITLE
pretty_printer.rs: Don't use a URL as an example Input title

### DIFF
--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -328,7 +328,7 @@ impl<'a> Input<'a> {
         self
     }
 
-    /// The title for the input (e.g. "http://example.com/example.txt")
+    /// The title for the input (e.g. "Descriptive title")
     /// This defaults to the file name.
     pub fn title(mut self, title: impl Into<String>) -> Self {
         self.input.description_mut().set_title(Some(title.into()));


### PR DESCRIPTION
Otherwise Rust 1.53.0 gets confused during `cargo doc` because it thinks
we want an actual URL:

    warning: this URL is not a hyperlink
    --> src/pretty_printer.rs:331:40
        |
    331 |     /// The title for the input (e.g. "http://example.com/example.txt")
        |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://example.com/example.txt>`
        |
        = note: `#[warn(rustdoc::bare_urls)]` on by default
        = note: bare URLs are not automatically turned into clickable links

It was perhaps also a bit confusing to give an URL as an example in the
first place, because according to our own API example
`examples/inputs.rs` it is meant to be more a free-text thing.