### PR TITLE
Include bash completion in deb package

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -348,6 +348,7 @@ jobs:
         gzip -n --best "${DPKG_DIR}/usr/share/man/man1/${{ env.PROJECT_NAME }}.1"
 
         # Autocompletion files
+        install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}'-*/out/assets/completions/bat.bash "${DPKG_DIR}/usr/share/bash-completion/completions/${{ steps.strip.outputs.BIN_NAME }}"
         install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}'-*/out/assets/completions/bat.fish "${DPKG_DIR}/usr/share/fish/vendor_completions.d/${{ env.PROJECT_NAME }}.fish"
         install -Dm644 'target/${{ matrix.job.target }}/release/build/${{ env.PROJECT_NAME }}'-*/out/assets/completions/bat.zsh "${DPKG_DIR}/usr/share/zsh/vendor-completions/_${{ env.PROJECT_NAME }}"
 


### PR DESCRIPTION
Get correct path to install in from bash-completion using
`pkg-config`, install as `steps.strip.outputs.BIN_NAME` as the filename
needs to match the called executable for bash-completion's on demand
loading to work.
    
This `BIN_NAME` needs to stay in sync with `env.PROJECT_EXECUTABLE`
which is replaced in the template, but not available for the deb build
at this stage.

Closes https://github.com/sharkdp/bat/issues/1733
