### PR TITLE
HighlightingAssets: Encapsulate syntax_set behind a getter

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -18,7 +18,7 @@ use crate::syntax_mapping::{MappingTarget, SyntaxMapping};
 
 #[derive(Debug)]
 pub struct HighlightingAssets {
-    pub(crate) syntax_set: SyntaxSet,
+    syntax_set: SyntaxSet,
     pub(crate) theme_set: ThemeSet,
     fallback_theme: Option<&'static str>,
 }
@@ -127,7 +127,7 @@ impl HighlightingAssets {
         let _ = fs::create_dir_all(target_dir);
         asset_to_cache(&self.theme_set, &target_dir.join("themes.bin"), "theme set")?;
         asset_to_cache(
-            &self.syntax_set,
+            self.get_syntax_set(),
             &target_dir.join("syntaxes.bin"),
             "syntax set",
         )?;
@@ -146,8 +146,12 @@ impl HighlightingAssets {
         self.fallback_theme = Some(theme);
     }
 
+    pub(crate) fn get_syntax_set(&self) -> &SyntaxSet {
+        &self.syntax_set
+    }
+
     pub fn syntaxes(&self) -> &[SyntaxReference] {
-        self.syntax_set.syntaxes()
+        self.get_syntax_set().syntaxes()
     }
 
     pub fn themes(&self) -> impl Iterator<Item = &str> {
@@ -163,7 +167,7 @@ impl HighlightingAssets {
         match mapping.get_syntax_for(file_name) {
             Some(MappingTarget::MapToUnknown) => None,
             Some(MappingTarget::MapTo(syntax_name)) => {
-                self.syntax_set.find_syntax_by_name(syntax_name)
+                self.get_syntax_set().find_syntax_by_name(syntax_name)
             }
             None => self.get_extension_syntax(file_name.as_os_str()),
         }
@@ -192,7 +196,7 @@ impl HighlightingAssets {
         mapping: &SyntaxMapping,
     ) -> Result<&SyntaxReference> {
         if let Some(language) = language {
-            self.syntax_set
+            self.get_syntax_set()
                 .find_syntax_by_token(language)
                 .ok_or_else(|| ErrorKind::UnknownSyntax(language.to_owned()).into())
         } else {
@@ -225,7 +229,7 @@ impl HighlightingAssets {
                     }),
 
                     Some(MappingTarget::MapTo(syntax_name)) => self
-                        .syntax_set
+                        .get_syntax_set()
                         .find_syntax_by_name(syntax_name)
                         .ok_or_else(|| ErrorKind::UnknownSyntax(syntax_name.to_owned()).into()),
 
@@ -246,11 +250,11 @@ impl HighlightingAssets {
     }
 
     fn get_extension_syntax(&self, file_name: &OsStr) -> Option<&SyntaxReference> {
-        self.syntax_set
+        self.get_syntax_set()
             .find_syntax_by_extension(file_name.to_str().unwrap_or_default())
             .or_else(|| {
                 let file_path = Path::new(file_name);
-                self.syntax_set
+                self.get_syntax_set()
                     .find_syntax_by_extension(
                         file_path
                             .extension()
@@ -274,7 +278,7 @@ impl HighlightingAssets {
     fn get_first_line_syntax(&self, reader: &mut InputReader) -> Option<&SyntaxReference> {
         String::from_utf8(reader.first_line.clone())
             .ok()
-            .and_then(|l| self.syntax_set.find_syntax_by_first_line(&l))
+            .and_then(|l| self.get_syntax_set().find_syntax_by_first_line(&l))
     }
 }
 
@@ -347,7 +351,7 @@ mod tests {
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
-                .unwrap_or_else(|_| self.assets.syntax_set.find_syntax_plain_text())
+                .unwrap_or_else(|_| self.assets.get_syntax_set().find_syntax_plain_text())
                 .name
                 .clone()
         }
@@ -361,7 +365,7 @@ mod tests {
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
-                .unwrap_or_else(|_| self.assets.syntax_set.find_syntax_plain_text())
+                .unwrap_or_else(|_| self.assets.get_syntax_set().find_syntax_plain_text())
                 .name
                 .clone()
         }
@@ -385,7 +389,7 @@ mod tests {
 
             self.assets
                 .get_syntax(None, &mut opened_input, &self.syntax_mapping)
-                .unwrap_or_else(|_| self.assets.syntax_set.find_syntax_plain_text())
+                .unwrap_or_else(|_| self.assets.get_syntax_set().find_syntax_plain_text())
                 .name
                 .clone()
         }
@@ -543,7 +547,7 @@ mod tests {
         assert_eq!(
             test.assets
                 .get_syntax(None, &mut opened_input, &test.syntax_mapping)
-                .unwrap_or_else(|_| test.assets.syntax_set.find_syntax_plain_text())
+                .unwrap_or_else(|_| test.assets.get_syntax_set().find_syntax_plain_text())
                 .name,
             "SSH Config"
         );

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -174,7 +174,7 @@ impl<'a> InteractivePrinter<'a> {
             let syntax = match assets.get_syntax(config.language, input, &config.syntax_mapping) {
                 Ok(syntax) => syntax,
                 Err(Error(ErrorKind::UndetectedSyntax(_), _)) => {
-                    assets.syntax_set.find_syntax_plain_text()
+                    assets.get_syntax_set().find_syntax_plain_text()
                 }
                 Err(e) => return Err(e),
             };
@@ -192,7 +192,7 @@ impl<'a> InteractivePrinter<'a> {
             #[cfg(feature = "git")]
             line_changes,
             highlighter,
-            syntax_set: &assets.syntax_set,
+            syntax_set: assets.get_syntax_set(),
             background_color_highlight,
         })
     }


### PR DESCRIPTION
Since we only modify `pub(crate)` items, the stable bat-as-a-library API is not
affected.

This takes us one step closer to making SyntaxSet lazy-loaded, which in turn
takes us one step closer to solving #951. This change has proven useful in the prototype I made to improve startup time, see https://github.com/sharkdp/bat/issues/951#issuecomment-882098532

By my estimation, it will always be convenient to have the full SyntaxSet available, for things such as `--list-languages`. So regardless of the fate of the prototype in #951, I think this will end up being a sensible change. Because we only want to load the full syntax set when necessary (since it is slow).