### PR TITLE
Reduce startup time in loop-through mode by 80%-90%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Other
 
 - Load cached assets as fast as integrated assets, see #1753 (@Enselic)
+- Greatly reduce startup time in loop-through mode, e.g. when redirecting output. Instead of *50 ms* - *100 ms*, startup takes *5 ms* - *10 ms*. See #1747 (@Enselic)
 
 
 ## Syntaxes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "globset",
  "grep-cli",
  "lazy_static",
+ "lazycell",
  "nix",
  "path_abs",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ ansi_term = "^0.12.1"
 ansi_colours = "^1.0"
 console = "0.14.1"
 lazy_static = { version = "1.4", optional = true }
+lazycell = "1.0"
 wild = { version = "2.0", optional = true }
 content_inspector = "0.2.4"
 encoding = "0.2"

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -54,7 +54,7 @@ impl HighlightingAssets {
 
     pub fn from_files(source_dir: &Path, include_integrated_assets: bool) -> Result<Self> {
         let mut theme_set = if include_integrated_assets {
-            Self::get_integrated_themeset()
+            get_integrated_themeset()
         } else {
             ThemeSet {
                 themes: BTreeMap::new(),
@@ -83,7 +83,7 @@ impl HighlightingAssets {
             builder.add_plain_text_syntax();
             builder
         } else {
-            Self::get_integrated_syntaxset().into_builder()
+            get_integrated_syntaxset().into_builder()
         };
 
         let syntax_dir = source_dir.join("syntaxes");
@@ -109,19 +109,8 @@ impl HighlightingAssets {
         ))
     }
 
-    fn get_integrated_syntaxset() -> SyntaxSet {
-        from_binary(include_bytes!("../assets/syntaxes.bin"))
-    }
-
-    fn get_integrated_themeset() -> ThemeSet {
-        from_binary(include_bytes!("../assets/themes.bin"))
-    }
-
     pub fn from_binary() -> Self {
-        HighlightingAssets::new(
-            Self::get_integrated_syntaxset(),
-            Self::get_integrated_themeset(),
-        )
+        HighlightingAssets::new(get_integrated_syntaxset(), get_integrated_themeset())
     }
 
     pub fn save_to_cache(&self, target_dir: &Path, current_version: &str) -> Result<()> {
@@ -325,6 +314,14 @@ impl HighlightingAssets {
             .ok()
             .and_then(|l| syntax_set.find_syntax_by_first_line(&l)))
     }
+}
+
+fn get_integrated_syntaxset() -> SyntaxSet {
+    from_binary(include_bytes!("../assets/syntaxes.bin"))
+}
+
+fn get_integrated_themeset() -> ThemeSet {
+    from_binary(include_bytes!("../assets/themes.bin"))
 }
 
 fn asset_to_cache<T: serde::Serialize>(asset: &T, path: &Path, description: &str) -> Result<()> {


### PR DESCRIPTION
`HighlightingAssets::get_syntax_set()` is never called when e.g. piping the `bat` output to a file (see `Config::loop_through`), so by loading the `SyntaxSet` only when needed, we radically improve startup time when it is not needed.

On my low-end machine, I get the following numbers when doing
`time bat tests/examples/multiline.txt > /tmp/output.txt`:

**git master**
```
0,09s user 0,00s system 93% cpu 0,103 total
```

**git master + this PR**
```
0,01s user 0,00s system 63% cpu 0,026 total
```

We can also benchmark with `hyperfine` , in which case we don't need to redirect the output manually, because the internal redirection of `hyperfine` is enough to trigger loop-through mode:
`hyperfine --export-markdown /dev/tty 'bat tests/examples/multiline.txt'`

**git master**
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat tests/examples/multiline.txt` | 96.1 ± 2.2 | 93.3 | 104.3 | 1.00 |

**git master + this PR**
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat tests/examples/multiline.txt` | 11.2 ± 1.1 | 9.7 | 15.9 | 1.00 |

So on my system, the speedup amounts to (1-11.2/96.1)*100 ~ 88%.

Lazy-loading was one of the key aspects of my [prototype](https://github.com/sharkdp/bat/issues/951#issuecomment-882098532) on how to improve the startup speed of bat, and this PR is one step on the journey to improve startup speed in general.

I have done sanity checking of this change, and all regression tests pass, so this PR should not be far off production-quality code. But don't hesitate to give criticism when doing code review :) And if you think my approach is completely off track, I would gladly like to know!

I also want to clarify that I think this is a good move long term, even if we start to load partial syntax sets for improved  performance. The ability to load the full syntax set is still useful, both for fallback purposes, and for implementing things like `—list-languages`