### PR TITLE
Make loading of cached assets closer in performance to integrated assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Other
 
+- Load cached assets as fast as integrated assets, see #1753 (@Enselic)
+
 
 ## Syntaxes
 


### PR DESCRIPTION
When [measuring performance](https://github.com/sharkdp/bat/pull/1747#issuecomment-886392521) of lazy loading, I noticed a somewhat surprising discrepancy for loop-through performance with and without cached assets. So I looked into possible causes for that and noticed we can make loading of cached assets faster. (Remember: we still eagerly load themes.bin in the above lazy-load PR.)

Using `BufReader` makes sense for large files, but I am convinced assets are never large enough (until proven otherwise) to require buffering. It is significantly faster to load the file contents in one go, so let's do that instead.

The numbers are identical when loading integrated assets. Here are the performance measurements when loading assets that are identical to the integrated assets. I am comparing git master with the code in this PR:
```
% mkdir -p ~/.cache/bat
% echo "---\nbat_version: 0.18.2" > ~/.cache/bat/metadata.yaml
% cp assets/syntaxes.bin ~/.cache/bat/syntaxes.bin
% cp assets/themes.bin ~/.cache/bat/themes.bin
% hyperfine --export-markdown /dev/tty -L bat bat,bat-pr '{bat} --color always examples/simple.rs'
```
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat --color always examples/simple.rs` | 115.9 ± 1.6 | 113.1 | 121.0 | 1.06 ± 0.03 |
| `bat-pr --color always examples/simple.rs` | 109.3 ± 2.4 | 105.0 | 113.2 | 1.00 |

Closes #1753