### PR TITLE
HighlightingAssets: Make .syntaxes() and .syntax_for_file_name() failable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ## `bat` as a library
 
+- Deprecate `HighlightingAssets::syntaxes()` and `HighlightingAssets::syntax_for_file_name()`. Use `HighlightingAssets::get_syntaxes()` and `HighlightingAssets::get_syntax_for_file_name()` instead. They return a `Result` which is needed for upcoming lazy-loading work to improve startup performance. See #1747 and #1755 (@Enselic)
 
 
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -82,7 +82,7 @@ pub fn get_languages(config: &Config) -> Result<String> {
 
     let assets = assets_from_cache_or_binary()?;
     let mut languages = assets
-        .syntaxes()
+        .get_syntaxes()?
         .iter()
         .filter(|syntax| !syntax.hidden && !syntax.file_extensions.is_empty())
         .cloned()
@@ -101,7 +101,10 @@ pub fn get_languages(config: &Config) -> Result<String> {
                 true
             } else {
                 let test_file = Path::new("test").with_extension(extension);
-                match assets.syntax_for_file_name(test_file, &config.syntax_mapping) {
+                let syntax = assets
+                    .get_syntax_for_file_name(test_file, &config.syntax_mapping)
+                    .unwrap(); // safe since .get_syntaxes() above worked
+                match syntax {
                     Some(syntax) => syntax.name == lang_name,
                     None => false,
                 }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -235,7 +235,9 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     pub fn syntaxes(&self) -> impl Iterator<Item = &SyntaxReference> {
-        self.assets.syntaxes().iter()
+        // We always use assets from the binary, which are guaranteed to always
+        // be valid, so get_syntaxes() can never fail here
+        self.assets.get_syntaxes().unwrap().iter()
     }
 
     /// Pretty-print all specified inputs. This method will "use" all stored inputs.

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -174,7 +174,7 @@ impl<'a> InteractivePrinter<'a> {
             let syntax = match assets.get_syntax(config.language, input, &config.syntax_mapping) {
                 Ok(syntax) => syntax,
                 Err(Error(ErrorKind::UndetectedSyntax(_), _)) => {
-                    assets.get_syntax_set().find_syntax_plain_text()
+                    assets.get_syntax_set()?.find_syntax_plain_text()
                 }
                 Err(e) => return Err(e),
             };
@@ -192,7 +192,7 @@ impl<'a> InteractivePrinter<'a> {
             #[cfg(feature = "git")]
             line_changes,
             highlighter,
-            syntax_set: assets.get_syntax_set(),
+            syntax_set: assets.get_syntax_set()?,
             background_color_highlight,
         })
     }

--- a/tests/no_duplicate_extensions.rs
+++ b/tests/no_duplicate_extensions.rs
@@ -26,7 +26,7 @@ fn no_duplicate_extensions() {
 
     let mut extensions = HashSet::new();
 
-    for syntax in assets.syntaxes() {
+    for syntax in assets.get_syntaxes().expect("this is a #[test]") {
         for extension in &syntax.file_extensions {
             assert!(
                 KNOWN_EXCEPTIONS.contains(&extension.as_str()) || extensions.insert(extension),


### PR DESCRIPTION
Or rather, introduce new versions of these methods and deprecate the old ones.

This is preparation to enable robust and user-friendly support for lazy-loading.
With lazy-loading, we don't know if the SyntaxSet is valid until after we try to
use it, so wherever we try to use it, we need to return a Result. See discussion
about panics in #1747.
