### PR TITLE
reference Rob Pike's classical USENIX presentation on cat(1)

### DIFF
--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -229,3 +229,6 @@ These can be installed to `\fB$({{PROJECT_EXECUTABLE}} --config-dir)/themes\fR`,
 For more information and up-to-date documentation, visit the {{PROJECT_EXECUTABLE}} repo:
 .br
 \fBhttps://github.com/sharkdp/bat\fR
+.PP
+Rob Pike, \(lqUNIX Style, or cat -v Considered Harmful\(rq,
+.I USENIX Summer Conference Proceedings, 1983.


### PR DESCRIPTION
Almost all cat(1) manual pages reference Rob Pike's classical USENIX presentation on cat(1) below SEE ALSO, for example:

    https://man.openbsd.org/cat.1#SEE_ALSO
    https://www.freebsd.org/cgi/man.cgi?query=cat#end
    https://man.netbsd.org/cat.1#SEE%20ALSO
    https://leaf.dragonflybsd.org/cgi/web-man?command=cat
    https://man.bsd.lv/4.4BSD-Lite2/cat#SEE_ALSO
    https://en.wikipedia.org/wiki/Cat_(Unix)   [below "External links"]

I believe bat(1) users would benefit from being offered the same pointer below MORE INFORMATION.