### PR TITLE
Support a hidden arg --no-custom-assets that skips loading assets from the cache

### DIFF
--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -45,6 +45,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         '(-r --line-range)'{-r+,--line-range=}'[Only print the lines from N to M]:<N\:M>...'
         '(: --list-themes --list-languages -L)'{-L,--list-languages}'[Display all supported languages]'
         '(: --no-config)'--no-config'[Do not use the configuration file]'
+        '(: --no-custom-assets)'--no-custom-assets'[Do not load custom assets]'
         '(: --config-dir)'--config-dir'[Show bat'"'"'s configuration directory]'
         '(: --config-file)'--config-file'[Show path to the configuration file]'
         '(: --generate-config-file)'--generate-config-file'[Generates a default configuration file]'

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -234,6 +234,7 @@ impl App {
                 .map(LineRanges::from)
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
+            use_custom_assets: !self.matches.is_present("no-custom-assets"),
         })
     }
 

--- a/src/bin/bat/assets.rs
+++ b/src/bin/bat/assets.rs
@@ -23,7 +23,7 @@ pub fn clear_assets() {
     clear_asset("metadata.yaml", "metadata file");
 }
 
-pub fn assets_from_cache_or_binary() -> Result<HighlightingAssets> {
+pub fn assets_from_cache_or_binary(use_custom_assets: bool) -> Result<HighlightingAssets> {
     let cache_dir = PROJECT_DIRS.cache_dir();
     if let Some(metadata) = AssetsMetadata::load_from_folder(&cache_dir)? {
         if !metadata.is_compatible_with(crate_version!()) {
@@ -41,8 +41,12 @@ pub fn assets_from_cache_or_binary() -> Result<HighlightingAssets> {
         }
     }
 
-    Ok(HighlightingAssets::from_cache(&cache_dir)
-        .unwrap_or_else(|_| HighlightingAssets::from_binary()))
+    let custom_assets = if use_custom_assets {
+        HighlightingAssets::from_cache(&cache_dir).ok()
+    } else {
+        None
+    };
+    Ok(custom_assets.unwrap_or_else(HighlightingAssets::from_binary))
 }
 
 fn clear_asset(filename: &str, description: &str) {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -451,6 +451,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .help("Do not use the configuration file"),
         )
         .arg(
+            Arg::with_name("no-custom-assets")
+                .long("no-custom-assets")
+                .hidden(true)
+                .help("Do not load custom assets"),
+        )
+        .arg(
             Arg::with_name("config-file")
                 .long("config-file")
                 .conflicts_with("list-languages")

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -80,7 +80,7 @@ fn get_syntax_mapping_to_paths<'a>(
 pub fn get_languages(config: &Config) -> Result<String> {
     let mut result: String = String::new();
 
-    let assets = assets_from_cache_or_binary()?;
+    let assets = assets_from_cache_or_binary(config.use_custom_assets)?;
     let mut languages = assets
         .syntaxes()
         .iter()
@@ -175,7 +175,7 @@ fn theme_preview_file<'a>() -> Input<'a> {
 }
 
 pub fn list_themes(cfg: &Config) -> Result<()> {
-    let assets = assets_from_cache_or_binary()?;
+    let assets = assets_from_cache_or_binary(cfg.use_custom_assets)?;
     let mut config = cfg.clone();
     let mut style = HashSet::new();
     style.insert(StyleComponent::Plain);
@@ -216,7 +216,7 @@ pub fn list_themes(cfg: &Config) -> Result<()> {
 }
 
 fn run_controller(inputs: Vec<Input>, config: &Config) -> Result<bool> {
-    let assets = assets_from_cache_or_binary()?;
+    let assets = assets_from_cache_or_binary(config.use_custom_assets)?;
     let controller = Controller::new(&config, &assets);
     controller.run(inputs)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,10 @@ pub struct Config<'a> {
 
     /// Ranges of lines which should be highlighted with a special background color
     pub highlighted_lines: HighlightedLineRanges,
+
+    /// Whether or not to allow custom assets. If this is false or if custom assets (a.k.a.
+    /// cached assets) are not available, assets from the binary will be used instead.
+    pub use_custom_assets: bool,
 }
 
 #[cfg(all(feature = "application", feature = "paging"))]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -796,6 +796,17 @@ fn does_not_print_unwanted_file_named_cache() {
 }
 
 #[test]
+fn accepts_no_custom_assets_arg() {
+    // Just make sure --no-custom-assets is considered a valid arg
+    // Don't bother to actually verify that it works
+    bat()
+        .arg("--no-custom-assets")
+        .arg("test.txt")
+        .assert()
+        .success();
+}
+
+#[test]
 fn unicode_wrap() {
     bat_with_config()
         .arg("unicode-wrap.txt")


### PR DESCRIPTION
The main use-case I have in mind for this flag is to make it easy to parameterize hyperfine (`hyperfine --parameter-list assets --no-custom-assets, 'bat {assets} examples/simple.rs'`) to compare performance between custom vs integrated assets, as we work on #951. But I would be surprised if it would not come in handy for other uses as well in the future.

I choose to name the arg `--no-custom-assets` rather than `--no-cache` in order to be more future-proof with upcoming changes. Since it is a hidden arg, I figured it would be OK to do it like this. I do not mention it in CHANGELOG.md though, since I don't think we need to make it publicly visible at this point. But let me know if you disagree!