### PR TITLE
Add code for analyzing dependencies between syntaxes

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -111,6 +111,12 @@ impl HighlightingAssets {
             );
         }
 
+        if std::env::var("BAT_PRINT_SYNTAX_DEPENDENCIES").is_ok() {
+            // To trigger this code, run:
+            // BAT_PRINT_SYNTAX_DEPENDENCIES=1 cargo run -- cache --build --source assets --blank --target /tmp
+            crate::syntax_dependencies::print_syntax_dependencies(&syntax_set_builder);
+        }
+
         let syntax_set = syntax_set_builder.build();
         let missing_contexts = syntax_set.find_unlinked_contexts();
         if !missing_contexts.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod preprocessor;
 mod pretty_printer;
 pub(crate) mod printer;
 pub mod style;
+mod syntax_dependencies;
 pub(crate) mod syntax_mapping;
 mod terminal;
 pub(crate) mod wrapping;

--- a/src/syntax_dependencies.rs
+++ b/src/syntax_dependencies.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+use syntect::parsing::syntax_definition::{
+    ContextReference, MatchOperation, MatchPattern, Pattern, SyntaxDefinition,
+};
+use syntect::parsing::{Scope, SyntaxSet, SyntaxSetBuilder};
+
+type SyntaxName = String;
+
+/// Used to look up what dependencies a given [SyntaxDefinition] has
+type SyntaxToDependencies = HashMap<SyntaxName, Vec<Dependency>>;
+
+/// Used to look up which [SyntaxDefinition] corresponds to a given [Dependency]
+type DependencyToSyntax<'a> = HashMap<Dependency, &'a SyntaxDefinition>;
+
+/// Represents a dependency on an external `.sublime-syntax` file.
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+enum Dependency {
+    /// By name. Example YAML: `include: C.sublime-syntax`
+    ByName(String),
+
+    /// By scope. Example YAML: `embed: scope:source.c`
+    ByScope(Scope),
+}
+
+/// Generates independent [SyntaxSet]s after analyzing dependencies between syntaxes
+/// in a [SyntaxSetBuilder], and then prints the reults.
+pub(crate) fn print_syntax_dependencies(syntax_set_builder: &SyntaxSetBuilder) {
+    println!("Constructing independent SyntaxSets...");
+    let independent_syntax_sets = build_independent_syntax_sets(syntax_set_builder);
+
+    println!("Independent SyntaxSets:");
+    for syntax_set in independent_syntax_sets {
+        let names = syntax_set
+            .syntaxes()
+            .iter()
+            .map(|syntax| &syntax.name)
+            .collect::<Vec<_>>();
+        println!("{:?}", names);
+    }
+}
+
+/// Analyzes dependencies between syntaxes in a [SyntaxSetBuilder].
+/// From that, it builds independent [SyntaxSet]s.
+fn build_independent_syntax_sets(
+    syntax_set_builder: &'_ SyntaxSetBuilder,
+) -> impl Iterator<Item = SyntaxSet> + '_ {
+    let syntaxes = syntax_set_builder.syntaxes();
+
+    // Build the data structures we need for dependency resolution
+    let (syntax_to_dependencies, dependency_to_syntax) = generate_maps(syntaxes);
+
+    // Create one independent SyntaxSet from each (non-hidden) SyntaxDefinition
+    syntaxes.iter().filter_map(move |syntax| {
+        if syntax.hidden {
+            return None;
+        }
+
+        let mut builder = SyntaxSetDependencyBuilder::new();
+        builder.add_with_dependencies(syntax, &syntax_to_dependencies, &dependency_to_syntax);
+        Some(builder.build())
+    })
+}
+
+/// In order to analyze dependencies, we need two key pieces of data.
+/// First, when we have a [Dependency], we need to know what [SyntaxDefinition] that
+/// corresponds to. Second, when we have a [SyntaxDefinition], we need to know
+/// what dependencies it has. This functions generates that data for each syntax.
+fn generate_maps(syntaxes: &[SyntaxDefinition]) -> (SyntaxToDependencies, DependencyToSyntax) {
+    let mut syntax_to_dependencies = HashMap::new();
+    let mut dependency_to_syntax = HashMap::new();
+
+    for syntax in syntaxes {
+        syntax_to_dependencies.insert(syntax.name.clone(), dependencies_for_syntax(syntax));
+
+        dependency_to_syntax.insert(Dependency::ByName(syntax.name.clone()), syntax);
+        dependency_to_syntax.insert(Dependency::ByScope(syntax.scope), syntax);
+    }
+
+    (syntax_to_dependencies, dependency_to_syntax)
+}
+
+/// Gets what external dependencies a given [SyntaxDefinition] has.
+/// An external dependency is another `.sublime-syntax` file.
+/// It does that by looking for variants of the following YAML patterns:
+/// - `include: C.sublime-syntax`
+/// - `embed: scope:source.c`
+fn dependencies_for_syntax(syntax: &SyntaxDefinition) -> Vec<Dependency> {
+    let mut dependencies: Vec<Dependency> = syntax
+        .contexts
+        .values()
+        .flat_map(|context| &context.patterns)
+        .flat_map(dependencies_from_pattern)
+        .collect();
+
+    // No need to track a dependency more than once
+    dependencies.dedup();
+
+    dependencies
+}
+
+fn dependencies_from_pattern(pattern: &Pattern) -> Vec<Dependency> {
+    match *pattern {
+        Pattern::Match(MatchPattern {
+            operation: MatchOperation::Push(ref context_references),
+            ..
+        }) => context_references
+            .iter()
+            .map(dependency_from_context_reference)
+            .collect(),
+        Pattern::Include(ref context_reference) => {
+            vec![dependency_from_context_reference(context_reference)]
+        }
+        _ => vec![],
+    }
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+fn dependency_from_context_reference(context_reference: &ContextReference) -> Option<Dependency> {
+    match &context_reference {
+        ContextReference::File { ref name, .. } => Some(Dependency::ByName(name.clone())),
+        ContextReference::ByScope { ref scope, .. } => Some(Dependency::ByScope(*scope)),
+        _ => None,
+    }
+}
+
+/// Helper to construct a [SyntaxSetBuilder] that contains only [SyntaxDefinition]s
+/// that have dependencies among them.
+struct SyntaxSetDependencyBuilder {
+    syntax_set_builder: SyntaxSetBuilder,
+}
+
+impl SyntaxSetDependencyBuilder {
+    fn new() -> Self {
+        SyntaxSetDependencyBuilder {
+            syntax_set_builder: SyntaxSetBuilder::new(),
+        }
+    }
+
+    /// Add a [SyntaxDefinition] to the underlying [SyntaxSetBuilder].
+    /// Also resolve any dependencies it has and add those [SyntaxDefinition]s too.
+    /// This is a recursive process.
+    fn add_with_dependencies(
+        &mut self,
+        syntax: &SyntaxDefinition,
+        syntax_to_dependencies: &SyntaxToDependencies,
+        dependency_to_syntax: &DependencyToSyntax,
+    ) {
+        let name = &syntax.name;
+        if self.is_syntax_already_added(name) {
+            return;
+        }
+
+        self.syntax_set_builder.add(syntax.clone());
+
+        let dependencies = syntax_to_dependencies.get(name);
+        if dependencies.is_none() {
+            eprintln!("ERROR: Unknown dependencies for {}", name);
+            return;
+        }
+
+        for dependency in dependencies.unwrap() {
+            if let Some(syntax_definition_dependency) = dependency_to_syntax.get(dependency) {
+                self.add_with_dependencies(
+                    syntax_definition_dependency,
+                    syntax_to_dependencies,
+                    dependency_to_syntax,
+                )
+            }
+        }
+    }
+
+    fn is_syntax_already_added(&self, name: &str) -> bool {
+        self.syntax_set_builder
+            .syntaxes()
+            .iter()
+            .any(|syntax| syntax.name == name)
+    }
+
+    fn build(self) -> SyntaxSet {
+        self.syntax_set_builder.build()
+    }
+}


### PR DESCRIPTION
This will eventually allow us to improve the startup speed of bat. See #951.

It adds code to analyze dependencies between `SyntaxDefinition`s. It currently comes up with the following  list of independent syntaxes.

One thing I'm curious about is if you think this list, and the code I use to produce it, looks reasonable? Or can you spot any obvious dependencies that it fails to find?

I'm sure we're going to have to tweak the code that does the analysis, but it would be nice to get the basics of it in place so we can iterate on it.

<details>
<summary>List of independent syntaxes</summary>
<p>

```
Independent SyntaxSets:
["Plain Text"]
["ASP", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "HTML (ASP)", "ASP"]
["HTML (ASP)", "ASP", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "HTML (ASP)"]
["ActionScript"]
["AppleScript"]
["Batch File"]
["NAnt Build File"]
["C#"]
["C++", "C"]
["C"]
["CSS"]
["Clojure", "Regular Expression"]
["D"]
["DMD Output"]
["Diff"]
["Erlang"]
["HTML (Erlang)", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Erlang"]
["Git Attributes", "Git Common", "Git Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Git Commit", "Git Common", "Git Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Git Common", "Git Config", "Git Common", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Git Config", "Git Common", "Git Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Git Ignore", "Git Common", "Git Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Git Link", "Git Common", "Git Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Git Log", "Git Common", "Git Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "Git Commit"]
["Git Mailmap", "Git Common", "Git Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Git Rebase Todo", "Git Common", "Git Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Go"]
["Graphviz (DOT)", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS"]
["Groovy", "Javadoc", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS"]
["HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS"]
["Haskell"]
["Literate Haskell", "LaTeX", "TeX", "YAML", "XML", "SQL", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "HTML", "R", "Python", "Regular Expressions (Python)", "PHP Source", "Regular Expressions (PHP)", "JSON", "Perl", "Regular Expression", "Lua", "Lisp", "Java", "Javadoc", "Haskell", "C++", "C", "Objective-C++", "Objective-C", "Go", "Diff"]
["JSON"]
["Java Server Page (JSP)", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Java", "Javadoc", "Java Server Page (JSP)"]
["Java", "Javadoc", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS"]
["Javadoc", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS"]
["Java Properties"]
["JavaScript", "Regular Expressions (Javascript)"]
["Regular Expressions (Javascript)"]
["BibTeX"]
["LaTeX Log"]
["LaTeX", "TeX", "YAML", "XML", "SQL", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "HTML", "R", "Python", "Regular Expressions (Python)", "PHP Source", "Regular Expressions (PHP)", "JSON", "Perl", "Regular Expression", "Lua", "Lisp", "LaTeX", "Java", "Javadoc", "Haskell", "C++", "C", "Objective-C++", "Objective-C", "Go", "Diff"]
["TeX"]
["Lisp"]
["Lua"]
["Make Output"]
["Makefile", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Markdown", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Regular Expression", "C++", "C", "Objective-C++", "Objective-C", "Ruby", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "Go", "R", "PHP", "PHP Source", "Regular Expressions (PHP)", "JSON", "XML", "Rust", "C#", "Java", "Javadoc", "Graphviz (DOT)", "Python", "Regular Expressions (Python)"]
["MultiMarkdown", "Markdown", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Regular Expression", "C++", "C", "Objective-C++", "Objective-C", "Ruby", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "Go", "R", "PHP", "PHP Source", "Regular Expressions (PHP)", "JSON", "XML", "Rust", "C#", "Java", "Javadoc", "Graphviz (DOT)", "Python", "Regular Expressions (Python)"]
["MATLAB"]
["OCaml", "camlp4", "OCaml"]
["OCamllex", "OCaml", "camlp4"]
["OCamlyacc", "OCaml", "camlp4"]
["camlp4", "OCaml"]
["Objective-C++", "C", "C++", "Objective-C"]
["Objective-C", "C"]
["PHP Source", "Regular Expressions (PHP)", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "JSON", "SQL", "XML"]
["PHP", "PHP Source", "Regular Expressions (PHP)", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "JSON", "SQL", "XML"]
["Regular Expressions (PHP)"]
["Pascal"]
["Perl", "XML", "Regular Expression", "JSON", "SQL", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "HTML", "CSS"]
["Python", "Regular Expressions (Python)", "SQL"]
["Regular Expressions (Python)"]
["R Console", "R"]
["R"]
["Rd (R Documentation)", "R", "LaTeX", "TeX", "YAML", "XML", "SQL", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "HTML", "Python", "Regular Expressions (Python)", "PHP Source", "Regular Expressions (PHP)", "JSON", "Perl", "Regular Expression", "Lua", "Lisp", "Java", "Javadoc", "Haskell", "C++", "C", "Objective-C++", "Objective-C", "Go", "Diff"]
["HTML (Rails)", "Ruby on Rails", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "HTML"]
["JavaScript (Rails)", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "Ruby on Rails", "Ruby", "CSS", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "HTML"]
["Ruby Haml", "Ruby on Rails", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "HTML", "Ruby Haml"]
["Ruby on Rails", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "HTML"]
["SQL (Rails)", "Ruby on Rails", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "HTML"]
["Regular Expression"]
["reStructuredText", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS"]
["Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "HTML"]
["Cargo Build Results"]
["Rust"]
["SQL"]
["Scala"]
["Bourne Again Shell (bash)", "commands-builtin-shell-bash", "Bourne Again Shell (bash)"]
["Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["commands-builtin-shell-bash", "Bourne Again Shell (bash)"]
["HTML (Tcl)", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Tcl"]
["Tcl"]
["Textile", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS"]
["XML"]
["YAML"]
["AWK", "Regular Expression"]
["Apache Conf"]
["AsciiDoc (Asciidoctor)", "XML"]
["ARM Assembly"]
["Assembly (x86_64)"]
["CMake C Header", "C"]
["CMake C++ Header", "C++", "C"]
["CMake", "CMakeCommands", "CMake", "Regular Expression"]
["CMakeCache"]
["CMakeCommands", "CMake", "CMakeCommands", "Regular Expression"]
["Comma Separated Values"]
["Cabal"]
["CoffeeScript"]
["CpuInfo"]
["Crystal", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Crystal", "C++", "C", "SQL", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["Dart Analysis Output"]
["Dart"]
["Dockerfile"]
["DotENV"]
["Elixir", "Regular Expressions (Elixir)"]
["HTML (EEx)", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Elixir", "Regular Expressions (Elixir)"]
["Regular Expressions (Elixir)"]
["Elm Compile Messages", "Elm", "GLSL"]
["Elm Documentation", "Elm", "GLSL"]
["Elm", "GLSL"]
["Email", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "XML"]
["F#"]
["Friendly Interactive Shell (fish)"]
["Fortran (Fixed Form)"]
["Fortran (Modern)"]
["Fortran Namelist"]
["GFortran Build Results"]
["OpenMP (Fortran)"]
["fstab"]
["GLSL"]
["GraphQL"]
["Man Page (groff/troff)"]
["group"]
["HTML (Twig)", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "HTML", "Python", "Regular Expressions (Python)"]
["hosts"]
["INI"]
["JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)"]
["HTML (Jinja2)", "HTML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Jinja2"]
["Jinja2"]
["jsonnet"]
["Julia", "Regular Expressions (Python)"]
["Kotlin"]
["Less"]
["Lean"]
["Manpage", "C"]
["MemInfo"]
["nginx", "Lua"]
["Nim", "Nim"]
["Ninja"]
["Nix"]
["orgmode", "Ruby", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SQL", "HTML", "Python", "Regular Expressions (Python)", "Lisp", "LaTeX", "TeX", "YAML", "XML", "R", "PHP Source", "Regular Expressions (PHP)", "JSON", "Perl", "Regular Expression", "Lua", "Java", "Javadoc", "Haskell", "C++", "C", "Objective-C++", "Objective-C", "Go", "Diff"]
["passwd"]
["PowerShell"]
["Protocol Buffer", "Protocol Buffer (TEXT)"]
["Protocol Buffer (TEXT)"]
["Puppet"]
["PureScript", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)"]
["QML", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)"]
["Rego"]
["resolv"]
["Robot Framework"]
["SCSS", "Sass", "YAML"]
["Sass", "YAML"]
["Salt State (SLS)", "YAML", "Jinja2"]
["SML"]
["Strace"]
["Stylus"]
["Solidity"]
["Vyper"]
["Svelte", "CSS", "Stylus", "CoffeeScript", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "TypeScript", "JavaScript", "Less", "Sass", "YAML", "SCSS"]
["Swift", "Swift"]
["SystemVerilog"]
["Navigational Bar SV"]
["TOML"]
["JSON (Terraform)", "JSON"]
["Terraform"]
["TypeScript"]
["TypeScriptReact"]
["Verilog"]
["VimL"]
["Vue Component", "Stylus", "SCSS", "Sass", "YAML", "TypeScript", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CoffeeScript", "CSS", "Less"]
["Zig"]
["gnuplot"]
["HTTP Request and Response", "JavaScript (Babel)", "GraphQL", "Regular Expressions (Javascript)", "CSS", "Plain Text", "JSON", "HTML", "XML"]
["log"]
["requirements.txt"]
["Highlight non-printables"]
["Authorized Keys", "SSH Common", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SSH Crypto"]
["Known Hosts", "SSH Crypto", "SSH Common"]
["Private Key"]
["SSH Common"]
["SSH Config", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash", "SSH Common", "SSH Crypto"]
["SSH Crypto", "SSH Common"]
["SSHD Config", "SSH Common", "SSH Crypto", "Shell-Unix-Generic", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["syslog", "log", "Bourne Again Shell (bash)", "commands-builtin-shell-bash"]
["varlink"]
\```
