### PR TITLE
Warn when building assets from files if some referenced contexts are missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.3.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91abf6555234338687bb47913978d275539235fcb77ba9863b779090b42b14"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
 dependencies = [
  "bit-set",
  "regex",
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfac2b23b4d049dc9a89353b4e06bbc85a8f42020cccbe5409a115cf19031e5"
+checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
 dependencies = [
  "bincode",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ optional = true
 default-features = false
 
 [dependencies.syntect]
-version = "4.5.0"
+version = "4.6.0"
 default-features = false
 features = ["parsing", "yaml-load", "dump-load", "dump-create"]
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -111,8 +111,17 @@ impl HighlightingAssets {
             );
         }
 
+        let syntax_set = syntax_set_builder.build();
+        let missing_contexts = syntax_set.find_unlinked_contexts();
+        if !missing_contexts.is_empty() {
+            println!("Some referenced contexts could not be found!");
+            for context in missing_contexts {
+                println!("- {}", context);
+            }
+        }
+
         Ok(HighlightingAssets::new(
-            Some(syntax_set_builder.build()),
+            Some(syntax_set),
             None,
             theme_set,
         ))


### PR DESCRIPTION
Upgrade to syntect 4.6.0 and add a warning to stdout when building assets from files and some context references are unresolved. Fixes #1616 and makes it easier to work on #915 and prevent such cases occurring again in future :)