### PR TITLE
When returning a SyntaxReference, also return the SyntaxSet that contains it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## `bat` as a library
 
-- Deprecate `HighlightingAssets::syntaxes()` and `HighlightingAssets::syntax_for_file_name()`. Use `HighlightingAssets::get_syntaxes()` and `HighlightingAssets::get_syntax_for_file_name()` instead. They return a `Result` which is needed for upcoming lazy-loading work to improve startup performance. See #1747 and #1755 (@Enselic)
+- Deprecate `HighlightingAssets::syntaxes()` and `HighlightingAssets::syntax_for_file_name()`. Use `HighlightingAssets::get_syntaxes()` and `HighlightingAssets::get_syntax_for_file_name()` instead. They return a `Result` which is needed for upcoming lazy-loading work to improve startup performance. They also return what `SyntaxSet` the returned `SyntaxReference` belongs to. See #1747, #1755 and #1776 (@Enselic)
 
 
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -101,11 +101,11 @@ pub fn get_languages(config: &Config) -> Result<String> {
                 true
             } else {
                 let test_file = Path::new("test").with_extension(extension);
-                let syntax = assets
+                let syntax_in_set = assets
                     .get_syntax_for_file_name(test_file, &config.syntax_mapping)
                     .unwrap(); // safe since .get_syntaxes() above worked
-                match syntax {
-                    Some(syntax) => syntax.name == lang_name,
+                match syntax_in_set {
+                    Some(syntax_in_set) => syntax_in_set.syntax.name == lang_name,
                     None => false,
                 }
             }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -163,7 +163,7 @@ impl<'a> InteractivePrinter<'a> {
             panel_width = 0;
         }
 
-        let highlighter_and_syntax_set = if input
+        let (highlighter, syntax_set) = if input
             .reader
             .content_type
             .map_or(false, |c| c.is_binary() && !config.show_nonprintable)
@@ -197,8 +197,8 @@ impl<'a> InteractivePrinter<'a> {
             ansi_prefix_sgr: String::new(),
             #[cfg(feature = "git")]
             line_changes,
-            highlighter: highlighter_and_syntax_set.0,
-            syntax_set: highlighter_and_syntax_set.1,
+            highlighter,
+            syntax_set,
             background_color_highlight,
         })
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -18,7 +18,7 @@ use encoding::{DecoderTrap, Encoding};
 
 use unicode_width::UnicodeWidthChar;
 
-use crate::assets::HighlightingAssets;
+use crate::assets::{HighlightingAssets, SyntaxReferenceInSet};
 use crate::config::Config;
 #[cfg(feature = "git")]
 use crate::decorations::LineChangesDecoration;
@@ -163,23 +163,29 @@ impl<'a> InteractivePrinter<'a> {
             panel_width = 0;
         }
 
-        let highlighter = if input
+        let highlighter_and_syntax_set = if input
             .reader
             .content_type
             .map_or(false, |c| c.is_binary() && !config.show_nonprintable)
         {
-            None
+            (None, assets.get_syntax_set()?)
         } else {
             // Determine the type of syntax for highlighting
-            let syntax = match assets.get_syntax(config.language, input, &config.syntax_mapping) {
-                Ok(syntax) => syntax,
-                Err(Error(ErrorKind::UndetectedSyntax(_), _)) => {
-                    assets.get_syntax_set()?.find_syntax_plain_text()
-                }
-                Err(e) => return Err(e),
-            };
+            let syntax_in_set =
+                match assets.get_syntax(config.language, input, &config.syntax_mapping) {
+                    Ok(syntax_in_set) => syntax_in_set,
+                    Err(Error(ErrorKind::UndetectedSyntax(_), _)) => {
+                        let syntax_set = assets.get_syntax_set()?;
+                        let syntax = syntax_set.find_syntax_plain_text();
+                        SyntaxReferenceInSet { syntax, syntax_set }
+                    }
+                    Err(e) => return Err(e),
+                };
 
-            Some(HighlightLines::new(syntax, theme))
+            (
+                Some(HighlightLines::new(syntax_in_set.syntax, theme)),
+                syntax_in_set.syntax_set,
+            )
         };
 
         Ok(InteractivePrinter {
@@ -191,8 +197,8 @@ impl<'a> InteractivePrinter<'a> {
             ansi_prefix_sgr: String::new(),
             #[cfg(feature = "git")]
             line_changes,
-            highlighter,
-            syntax_set: assets.get_syntax_set()?,
+            highlighter: highlighter_and_syntax_set.0,
+            syntax_set: highlighter_and_syntax_set.1,
             background_color_highlight,
         })
     }


### PR DESCRIPTION
Here comes what I think will be the most controversial change on the #951 journey, because it has the highest impact on the bat-as-a-library API. Let me know what you think about it.

To improve startup performance, we will later load smaller `SyntaxSet`s instead of one giant one. However, the current API assumes only one `SyntaxSet` is ever used, and that that implicitly is the `SyntaxSet` from which returned `SyntaxReference`s comes.

This change changes the API to reflect that `SyntaxSet` and `SyntaxReference` are tightly coupled, and enables the use of several `SyntaxSet`.

I think it will make sense to add a helper method to reduce the boilerplate a bit, but I would like to get early feedback on the change itself before I do that.
