### PR TITLE
Draft: Replace cache subcommand with --custom-assets-* args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- TODO: Write about new CLI
+
 
 ## Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -447,10 +447,10 @@ syntax:
    git clone https://github.com/tellnobody1/sublime-purescript-syntax
    ```
 
-2. Now use the following command to parse these files into a binary cache:
+2. Now use the following command to parse and store these files in a binary format:
 
    ```bash
-   bat cache --build
+   bat --custom-assets-build
    ```
 
 3. Finally, use `bat --list-languages` to check if the new languages are available.
@@ -458,7 +458,7 @@ syntax:
    If you ever want to go back to the default settings, call:
 
    ```bash
-   bat cache --clear
+   bat --custom-assets-clear
    ```
 
 4. If you think that a specific syntax should be included in `bat` by default, please
@@ -477,8 +477,8 @@ cd "$(bat --config-dir)/themes"
 # Download a theme in '.tmTheme' format, for example:
 git clone https://github.com/greggb/sublime-snazzy
 
-# Update the binary cache
-bat cache --build
+# Parse and store in a binary format
+bat --custom-assets-build
 ```
 
 Finally, use `bat --list-themes` to check if the new themes are available.

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -6,6 +6,7 @@ _bat() {
 	local cur prev words cword split
 	_init_completion -s || return 0
 
+	# TODO: Adapt to new CLI
 	if [[ ${words[1]-} == cache ]]; then
 		case $prev in
 		--source | --target)

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -70,6 +70,7 @@ complete -c {{PROJECT_EXECUTABLE}} -s V -l version -d "Show version information"
 
 complete -c {{PROJECT_EXECUTABLE}} -l wrap -xka "auto never character" -d "<mode> Specify the text-wrapping mode (default: auto)" -n "not __fish_seen_subcommand_from cache"
 
+# TODO: Adapt to new CLI
 # Sub-command 'cache' completions
 complete -c {{PROJECT_EXECUTABLE}} -a "cache" -d "Modify the syntax/language definition cache" -n "not __fish_seen_subcommand_from cache"
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -83,6 +83,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
 # first positional argument
 if (( ${#words} == 2 )); then
     local -a subcommands
+    # TODO: Adapt to new CLI
     subcommands=('cache:Modify the syntax-definition and theme cache')
     _describe subcommand subcommands
     _{{PROJECT_EXECUTABLE}}_main

--- a/assets/create.sh
+++ b/assets/create.sh
@@ -39,8 +39,8 @@ if [ -t 0 ]; then
 	update_submodules
 fi
 
-# Always remove the local cache to avoid any confusion
-bat cache --clear
+# Always remove the custom assets to avoid any confusion
+bat --custom-assets-clear
 
 # TODO:
 # - Remove the JavaDoc patch once https://github.com/trishume/syntect/issues/222 has been fixed
@@ -53,7 +53,7 @@ bat cache --clear
     done
 )
 
-bat cache --build --blank --source="$ASSET_DIR" --target="$ASSET_DIR"
+bat --custom-assets-build="$ASSET_DIR" --custom-assets-blank --custom-assets-target="$ASSET_DIR"
 
 (
     cd "$ASSET_DIR"

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -8,6 +8,8 @@
 {{PROJECT_EXECUTABLE}} prints the syntax-highlighted content of a collection of FILEs to the
 terminal. If no FILE is specified, or when FILE is '-', it reads from standard input.
 
+TODO: Adapt to new CLI
+
 {{PROJECT_EXECUTABLE}} supports a large number of programming and markup languages.
 It also communicates with git(1) to show modifications with respect to the git index.
 {{PROJECT_EXECUTABLE}} automatically pipes its output through a pager (by default: less).

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -423,7 +423,7 @@ git clone https://github.com/tellnobody1/sublime-purescript-syntax
 次のコマンドを使用して、これらのファイルをバイナリキャッシュに解析します:
 
 ```bash
-bat cache --build
+bat --custom-assets-build
 ```
 
 最後に `bat --list-languages` と入力すると新しい言語が利用可能かどうかチェックします。
@@ -431,7 +431,7 @@ bat cache --build
 デフォルトの設定に戻したいときは以下のコマンドを実行します:
 
 ```bash
-bat cache --clear
+bat --custom-assets-clear
 ```
 
 ### 新しいテーマの追加
@@ -446,8 +446,8 @@ cd "$(bat --config-dir)/themes"
 # Download a theme in '.tmTheme' format, for example:
 git clone https://github.com/greggb/sublime-snazzy
 
-# Update the binary cache
-bat cache --build
+# Parse and store in a binary format
+bat --custom-assets-build
 ```
 
 最後に、 `bat --list-themes` で新しいテーマが利用可能かチェックします

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -502,7 +502,7 @@ bat --list-themes | fzf --preview="bat --theme={} --color=always /path/to/file"
 2. 이제 다음 명령어를 통해 파일들을 파싱(parse)하여 바이너리 캐시를 만듭니다.
 
   ```bash
-  bat cache --build
+  bat --custom-assets-build
   ```
 
 3. 마지막으로, `bat --list-languages`로 새로 추가한 언어가 사용 가능한지
@@ -511,7 +511,7 @@ bat --list-themes | fzf --preview="bat --theme={} --color=always /path/to/file"
   만약 기본 설정으로 돌아갈 일이 생긴다면, 다음 명령어를 이용합니다:
 
   ```bash
-  bat cache --clear
+  bat --custom-assets-clear
   ```
 
 4. 만약 특정 문법이 `bat`에 기본적으로 포함되어 있어야 한다고 생각한다면, 방침과
@@ -530,8 +530,8 @@ cd "$(bat --config-dir)/themes"
 # Download a theme in '.tmTheme' format, for example:
 git clone https://github.com/greggb/sublime-snazzy
 
-# Update the binary cache
-bat cache --build
+# Parse and store in a binary format
+bat --custom-assets-build
 ```
 
 마지막으로 `bat --list-themes`을 통해 새로 추가한 테마들이 사용 가능한지

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -387,7 +387,7 @@ git clone https://github.com/tellnobody1/sublime-purescript-syntax
 Теперь используйте следующую команду, чтобы превратить эти файлы в бинарный кеш:
 
 ```bash
-bat cache --build
+bat --custom-assets-build
 ```
 
 Теперь вы можете использовать `bat --list-languages`, чтобы проверить, доступны ли новые языки.
@@ -395,7 +395,7 @@ bat cache --build
 Если когда-нибудь вы заходите вернуться к настройкам по умолчанию, введите
 
 ```bash
-bat cache --clear
+bat --custom-assets-clear
 ```
 
 ### Добавление новых тем
@@ -411,7 +411,7 @@ cd "$(bat --config-dir)/themes"
 git clone https://github.com/greggb/sublime-snazzy
 
 # Обновите кеш
-bat cache --build
+bat --custom-assets-build
 ```
 
 Теперь используйте `bat --list-themes`, чтобы проверить доступность новых тем.

--- a/doc/assets.md
+++ b/doc/assets.md
@@ -17,7 +17,7 @@ in the `.sublime-syntax` format.
    Sublime Text and convert it to a `.sublime-syntax` file via *Tools* -> *Developer* ->
    *New Syntax from XXX.tmLanguage...*. Save the new file in the `assets/syntaxes` folder.
 
-3. Run the `assets/create.sh` script. It calls `bat cache --build` to parse all available
+3. Run the `assets/create.sh` script. It calls `bat --custom-assets-build` to parse all available
    `.sublime-syntax` files and serialize them to a `syntaxes.bin` file.
 
 4. Re-compile `bat`. At compilation time, the `syntaxes.bin` file will be stored inside the
@@ -28,7 +28,7 @@ in the `.sublime-syntax` format.
 6. Add a syntax test for the new language. See [below](#Syntax-tests) for details.
 
 7. If you send a pull request with your changes, please do *not* include the changed `syntaxes.bin`
-   file. A new binary cache file will be created once before every new release of `bat`. This
+   file. A new binary file will be created once before every new release of `bat`. This
    avoids bloating the repository size unnecessarily.
 
 ### Syntax tests
@@ -66,8 +66,8 @@ In order to add a new test file, please follow these steps (let's take "Ruby" as
 
 ### Troubleshooting
 
-Make sure that the local cache does not interfere with the internally stored syntaxes and
-themes (`bat cache --clear`).
+Make sure that the custom assets does not interfere with the internally stored syntaxes and
+themes (`bat --custom-assets-clear`).
 
 ## Criteria for inclusion of new syntaxes
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -369,7 +369,7 @@ impl HighlightingAssets {
 /// We keep it in this format since we want to load it lazily.
 #[derive(Debug)]
 enum SerializedSyntaxSet {
-    /// The data comes from a user-generated cache file.
+    /// The data comes from a user-generated file.
     FromFile(PathBuf),
 
     /// The data to use is embedded into the bat binary.

--- a/src/assets_metadata.rs
+++ b/src/assets_metadata.rs
@@ -35,7 +35,7 @@ impl AssetsMetadata {
         Ok(serde_yaml::from_reader(file)?)
     }
 
-    /// Load metadata about the stored cache file from the given folder.
+    /// Load metadata about custom assets from the given folder.
     ///
     /// There are several possibilities:
     ///   - We find a metadata.yaml file and are able to parse it

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -50,9 +50,7 @@ impl App {
     }
 
     fn matches(interactive_output: bool) -> Result<ArgMatches<'static>> {
-        let args = if wild::args_os().nth(1) == Some("cache".into())
-            || wild::args_os().any(|arg| arg == "--no-config")
-        {
+        let args = if wild::args_os().any(|arg| arg == "--no-config") {
             // Skip the arguments in bats config file
 
             wild::args_os().collect::<Vec<_>>()

--- a/src/bin/bat/assets.rs
+++ b/src/bin/bat/assets.rs
@@ -18,8 +18,8 @@ pub fn cache_dir() -> Cow<'static, str> {
 }
 
 pub fn clear_assets() {
-    clear_asset("themes.bin", "theme set cache");
-    clear_asset("syntaxes.bin", "syntax set cache");
+    clear_asset("themes.bin", "theme set");
+    clear_asset("syntaxes.bin", "syntax set");
     clear_asset("metadata.yaml", "metadata file");
 }
 
@@ -28,10 +28,10 @@ pub fn assets_from_cache_or_binary(use_custom_assets: bool) -> Result<Highlighti
     if let Some(metadata) = AssetsMetadata::load_from_folder(&cache_dir)? {
         if !metadata.is_compatible_with(crate_version!()) {
             return Err(format!(
-                "The binary caches for the user-customized syntaxes and themes \
+                "The user-customized syntaxes and themes (stored in a binary format) \
                  in '{}' are not compatible with this version of bat ({}). To solve this, \
-                 either rebuild the cache (bat cache --build) or remove \
-                 the custom syntaxes/themes (bat cache --clear).\n\
+                 either rebuild the custom assets (bat --custom-assets-build) or remove \
+                 the custom syntaxes/themes (bat --custom-assets-clear).\n\
                  For more information, see:\n\n  \
                  https://github.com/sharkdp/bat#adding-new-syntaxes--language-definitions",
                 cache_dir.to_string_lossy(),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -1,6 +1,5 @@
-use clap::{crate_name, crate_version, App as ClapApp, AppSettings, Arg, ArgGroup, SubCommand};
+use clap::{crate_name, crate_version, App as ClapApp, AppSettings, Arg};
 use std::env;
-use std::path::Path;
 
 pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
     let clap_color_setting = if interactive_output && env::var_os("NO_COLOR").is_none() {
@@ -15,10 +14,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .global_setting(AppSettings::DeriveDisplayOrder)
         .global_setting(AppSettings::UnifiedHelpMessage)
         .global_setting(AppSettings::HidePossibleValuesInHelp)
-        .setting(AppSettings::ArgsNegateSubcommands)
-        .setting(AppSettings::AllowExternalSubcommands)
         .setting(AppSettings::DisableHelpSubcommand)
-        .setting(AppSettings::VersionlessSubcommands)
         .max_term_width(100)
         .about(
             "A cat(1) clone with wings.\n\n\
@@ -491,65 +487,49 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .hidden_short_help(true)
                 .help("Show diagnostic information for bug reports.")
         )
+        .arg(
+            Arg::with_name("custom-assets-build")
+                .long("custom-assets-build")
+                .conflicts_with("custom-assets-clear")
+                .takes_value(true)
+                .value_name("dir")
+                .help("Initialize (or update) the custom syntaxes/themes.")
+                .long_help(
+                    "Initialize (or update) the custom syntaxes/themees by loading from \
+                     the given directory (default: the configuration directory).",
+                ),
+        )
+        .arg(
+            Arg::with_name("custom-assets-blank") // TODO: Better name?
+                .long("custom-assets-blank")
+                .requires("custom-assets-build")
+                .conflicts_with("custom-assets-clear")
+                .help(
+                    "Create completely new syntax and theme sets \
+                     (instead of appending to the default sets).",
+                ),
+        )
+        .arg(
+            Arg::with_name("custom-assets-target")
+                .long("custom-assets-target")
+                .requires("custom-assets-build")
+                .conflicts_with("custom-assets-clear")
+                .takes_value(true)
+                .value_name("dir")
+                .help(
+                    "Use a different directory to store the cached syntax and theme set.",
+                ),
+        )
+        .arg(
+            Arg::with_name("custom-assets-clear")
+                .long("custom-assets-clear")
+                .conflicts_with("custom-assets-source")
+                .conflicts_with("custom-assets-target")
+                .conflicts_with("custom-assets-blank")
+                .help("Remove the cached syntax definitions and themes."),
+        )
         .help_message("Print this help message.")
         .version_message("Show version information.");
 
-    // Check if the current directory contains a file name cache. Otherwise,
-    // enable the 'bat cache' subcommand.
-    if Path::new("cache").exists() {
-        app
-    } else {
-        app.subcommand(
-            SubCommand::with_name("cache")
-                .about("Modify the syntax-definition and theme cache")
-                .arg(
-                    Arg::with_name("build")
-                        .long("build")
-                        .short("b")
-                        .help("Initialize (or update) the syntax/theme cache.")
-                        .long_help(
-                            "Initialize (or update) the syntax/theme cache by loading from \
-                             the source directory (default: the configuration directory).",
-                        ),
-                )
-                .arg(
-                    Arg::with_name("clear")
-                        .long("clear")
-                        .short("c")
-                        .help("Remove the cached syntax definitions and themes."),
-                )
-                .group(
-                    ArgGroup::with_name("cache-actions")
-                        .args(&["build", "clear"])
-                        .required(true),
-                )
-                .arg(
-                    Arg::with_name("source")
-                        .long("source")
-                        .requires("build")
-                        .takes_value(true)
-                        .value_name("dir")
-                        .help("Use a different directory to load syntaxes and themes from."),
-                )
-                .arg(
-                    Arg::with_name("target")
-                        .long("target")
-                        .requires("build")
-                        .takes_value(true)
-                        .value_name("dir")
-                        .help(
-                            "Use a different directory to store the cached syntax and theme set.",
-                        ),
-                )
-                .arg(
-                    Arg::with_name("blank")
-                        .long("blank")
-                        .requires("build")
-                        .help(
-                            "Create completely new syntax and theme sets \
-                             (instead of appending to the default sets).",
-                        ),
-                ),
-        )
-    }
+    app
 }


### PR DESCRIPTION
This PR goes over the code base and replaces the `cache` subcommand with new `--custom-assets-*` equivalents, to see what that would be like.

This is Proposal C in https://github.com/sharkdp/bat/issues/1726#issuecomment-892862794