### PR TITLE
integration_tests: Add diagnostic_sanity_check()

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -701,6 +701,16 @@ fn pager_failed_to_parse() {
 }
 
 #[test]
+fn diagnostic_sanity_check() {
+    bat()
+        .arg("--diagnostic")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("BAT_PAGER="))
+        .stderr("");
+}
+
+#[test]
 fn config_location_test() {
     bat_with_config()
         .env("BAT_CONFIG_PATH", "bat.conf")


### PR DESCRIPTION
I'm playing around with code coverage in nightly (see https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/instrument-coverage.html) and from that noticed that we have no automated tests for `--diagnostic`.

So add a simple sanity check test for `--diagnostic` so we catch in CI if that feature breaks completely.

### How to generate code coverage for bat

For future reference (not least for myself :P), here are some commands that can be used to generate code coverage data for `bat` **and** its dependencies:

```
# Installation and setup
rustup default nightly
rustup update nightly
cargo install cargo-binutils
rustup component add llvm-tools-preview
export LLVM_PROFILE_FILE="/tmp/coverage/%h-%p-%m.profraw"

# Generate fresh, raw and broad code coverage data
rm -rf /tmp/coverage
cargo clean
RUSTFLAGS="-Z instrument-coverage" cargo test
# No cargo tests currently runs below commands, so manually create coverage for those code paths
./target/debug/bat cache --build --source=assets --blank --target=/tmp
./target/debug/bat cache --clear
./target/debug/bat -f --list-languages | tee
./target/debug/bat -f --list-themes | tee
cargo profdata -- merge -sparse -o /tmp/coverage/merged.profdata /tmp/coverage/*.profraw

# Exampeles of ways to study the code coverage data:
cargo cov -- report --use-color --instr-profile=/tmp/coverage/merged.profdata  --object target/debug/bat --object target/debug/deps/bat-c6a73c106dd2fad2 --object target/debug/deps/bat-475928d69fae452c --object target/debug/deps/assets-92dfcf99ce879949 --object target/debug/deps/integration_tests-182ccff1ff2b0a99 --object target/debug/deps/no_duplicate_extensions-88b0929ce16cf779 --object target/debug/deps/snapshot_tests-045e205813298711 --object target/debug/deps/tester-19f8f381c2571ded
cargo cov -- show --use-color --ignore-filename-regex='/.cargo/registry' --instr-profile=/tmp/coverage/merged.profdata  --object target/debug/bat --object target/debug/deps/bat-c6a73c106dd2fad2 --object target/debug/deps/bat-475928d69fae452c --object target/debug/deps/assets-92dfcf99ce879949 --object target/debug/deps/integration_tests-182ccff1ff2b0a99 --object target/debug/deps/no_duplicate_extensions-88b0929ce16cf779 --object target/debug/deps/snapshot_tests-045e205813298711 --object target/debug/deps/tester-19f8f381c2571ded | less -R
```

Note that above code coverage is with the new more capable `-Z instrument-coverage` flag, and not the old `-Zprofile` flag that we used to use in CI (see 557a748ac76)