### PR TITLE
Cargo.toml: Introduce 'quick-build-application' feature

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -246,6 +246,13 @@ jobs:
         command: check
         args: --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig,git,paging
 
+    - name: "Feature check: quick-build-application"
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ matrix.job.use-cross }}
+        command: check
+        args: --locked --target=${{ matrix.job.target }} --verbose --no-default-features --features quick-build-application
+
     - name: Create tarball
       id: package
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "bugreport"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e97e538864a7c95d33accbf64c8d354018ba3b6e032502fd0fe7259cf1aa3d"
+checksum = "0014b4b2b4f63bfe69c3838470121290cc437fdc79785d408a761a21e8b2404c"
 dependencies = [
  "git-version",
  "shell-escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ default = ["application"]
 # bat as a library.
 application = [
     "atty",
+    "bugreport",
     "clap",
     "dirs-next",
     "git",
     "lazy_static",
     "paging",
-    "wild",
     "regex-onig",
+    "wild",
 ]
 git = ["git2"] # Support indicating git modifications
 paging = ["shell-words"] # Support applying a pager on the output
@@ -50,7 +51,7 @@ serde_yaml = "0.8"
 semver = "1.0"
 path_abs = { version = "0.5", default-features = false }
 clircle = "0.3"
-bugreport = "0.4"
+bugreport = { version = "0.4", optional = true }
 dirs-next = { version = "2.0.0", optional = true }
 grep-cli = "0.1.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ build = "build.rs"
 edition = '2018'
 
 [features]
-default = ["application"]
+default = ["full-application"]
 # Feature required for bat the application. Should be disabled when depending on
 # bat as a library.
-application = [
+full-application = [
+    "application",
     "atty",
     "bugreport",
     "clap",
@@ -26,6 +27,19 @@ application = [
     "regex-onig",
     "wild",
 ]
+# Mainly for developers that want to iterate quickly
+# Be aware that the included features might change in the future
+quick-build-application = [
+    "application",
+    "atty",
+    "clap",
+    "dirs-next",
+    "lazy_static",
+    "paging",
+    "regex-onig",
+    "wild",
+]
+application = []
 git = ["git2"] # Support indicating git modifications
 paging = ["shell-words"] # Support applying a pager on the output
 


### PR DESCRIPTION
I frequently find myself having to rebuild the whole project (.e.g when switching between MSRV, stable, nightly). Because of that, it is useful if a rebuild goes fast. Two features in particular contribute significantly to build time, and those are `git` and `bugreport` (with `git_hash`).

This PR introduces a feature called `quick-build-application` that allows the app to be built without the above features. On my system, that results in ~25% faster builds:
```
hyperfine --max-runs 2 --time-unit second --export-markdown /dev/tty --parameter-list feature quick-build-application,full-application --prepare 'cargo clean' 'cargo build --no-default-features --features {feature}'
```
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cargo build --no-default-features --features quick-build-application` | 123.318 ± 0.405 | 123.032 | 123.605 | 1.00 |
| `cargo build --no-default-features --features full-application` | 164.614 ± 1.137 | 163.810 | 165.417 | 1.33 ± 0.01 |

I also took the opportunity to bump `bugreport` to `0.4.1` in this PR.