### PR TITLE
Make --no-paging and --no-pager work again, plus regression tests

### DIFF
--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -294,6 +294,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("no-paging")
                 .short("P")
+                .long("no-paging")
                 .alias("no-pager")
                 .overrides_with("no-paging")
                 .hidden(true)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1123,6 +1123,42 @@ fn show_all_mode() {
 }
 
 #[test]
+fn no_paging_arg() {
+    bat()
+        .arg("--no-paging")
+        .arg("--color=never")
+        .arg("--decorations=never")
+        .arg("single-line.txt")
+        .assert()
+        .success()
+        .stdout("Single Line");
+}
+
+#[test]
+fn no_paging_short_arg() {
+    bat()
+        .arg("-P")
+        .arg("--color=never")
+        .arg("--decorations=never")
+        .arg("single-line.txt")
+        .assert()
+        .success()
+        .stdout("Single Line");
+}
+
+#[test]
+fn no_pager_arg() {
+    bat()
+        .arg("--no-pager")
+        .arg("--color=never")
+        .arg("--decorations=never")
+        .arg("single-line.txt")
+        .assert()
+        .success()
+        .stdout("Single Line");
+}
+
+#[test]
 fn plain_mode_does_not_add_nonexisting_newline() {
     bat()
         .arg("--paging=never")


### PR DESCRIPTION
I frequently find myself intuitively passing `--no-pager` to bat, only to be equally frequently slightly annoyed that it does not work.

Then I by accident found that it seemed like it *should* work, since we set it up in `clap_app.rs`. It used to work actually, before it stopped working with c264f747.

I'm fine with keeping `--no-pager` hidden, but I would really prefer if it worked, so here is a PR to make it work again. (Since it is hidden, I am skipping updating `CHANGELOG.md`.)
