### PR TITLE
Make 'build-assets' an optional capability for application

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -246,12 +246,12 @@ jobs:
         command: check
         args: --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig,git,paging
 
-    - name: "Feature check: quick-build-application"
+    - name: "Feature check: minimal-application"
       uses: actions-rs/cargo@v1
       with:
         use-cross: ${{ matrix.job.use-cross }}
         command: check
-        args: --locked --target=${{ matrix.job.target }} --verbose --no-default-features --features quick-build-application
+        args: --locked --target=${{ matrix.job.target }} --verbose --no-default-features --features minimal-application
 
     - name: Create tarball
       id: package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,25 +12,18 @@ build = "build.rs"
 edition = '2018'
 
 [features]
-default = ["full-application"]
+default = ["application"]
 # Feature required for bat the application. Should be disabled when depending on
 # bat as a library.
-full-application = [
-    "application",
-    "atty",
+application = [
     "bugreport",
-    "clap",
-    "dirs-next",
+    "build-assets",
     "git",
-    "lazy_static",
-    "paging",
-    "regex-onig",
-    "wild",
+    "minimal-application",
 ]
 # Mainly for developers that want to iterate quickly
 # Be aware that the included features might change in the future
-quick-build-application = [
-    "application",
+minimal-application = [
     "atty",
     "clap",
     "dirs-next",
@@ -39,9 +32,10 @@ quick-build-application = [
     "regex-onig",
     "wild",
 ]
-application = []
 git = ["git2"] # Support indicating git modifications
 paging = ["shell-words"] # Support applying a pager on the output
+# Add "syntect/plist-load" when https://github.com/trishume/syntect/pull/345 reaches us
+build-assets = ["syntect/yaml-load", "syntect/dump-create"]
 
 # You need to use one of these if you depend on bat as a library:
 regex-onig = ["syntect/regex-onig"] # Use the "oniguruma" regex engine
@@ -77,7 +71,7 @@ default-features = false
 [dependencies.syntect]
 version = "4.6.0"
 default-features = false
-features = ["parsing", "yaml-load", "dump-load", "dump-create"]
+features = ["parsing", "dump-load"]
 
 [dependencies.clap]
 version = "2.33"

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -77,9 +76,7 @@ impl HighlightingAssets {
         let mut theme_set = if include_integrated_assets {
             get_integrated_themeset()
         } else {
-            ThemeSet {
-                themes: BTreeMap::new(),
-            }
+            ThemeSet::new()
         };
 
         let theme_dir = source_dir.join("themes");

--- a/src/assets_metadata.rs
+++ b/src/assets_metadata.rs
@@ -16,6 +16,7 @@ pub struct AssetsMetadata {
 const FILENAME: &str = "metadata.yaml";
 
 impl AssetsMetadata {
+    #[cfg(feature = "build-assets")]
     pub(crate) fn new(current_version: &str) -> AssetsMetadata {
         AssetsMetadata {
             bat_version: Some(current_version.to_owned()),
@@ -23,6 +24,7 @@ impl AssetsMetadata {
         }
     }
 
+    #[cfg(feature = "build-assets")]
     pub(crate) fn save_to_folder(&self, path: &Path) -> Result<()> {
         let file = File::create(path.join(FILENAME))?;
         serde_yaml::to_writer(file, self)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,7 +88,7 @@ pub struct Config<'a> {
     pub use_custom_assets: bool,
 }
 
-#[cfg(all(feature = "application", feature = "paging"))]
+#[cfg(all(feature = "minimal-application", feature = "paging"))]
 pub fn get_pager_executable(config_pager: Option<&str>) -> Option<String> {
     if let Ok(Some(pager)) = crate::pager::get_pager(config_pager) {
         Some(pager.bin)

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 error_chain! {
     foreign_links {
-        Clap(::clap::Error) #[cfg(feature = "application")];
+        Clap(::clap::Error) #[cfg(feature = "minimal-application")];
         Io(::std::io::Error);
         SyntectError(::syntect::LoadingError);
         ParseIntError(::std::num::ParseIntError);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod preprocessor;
 mod pretty_printer;
 pub(crate) mod printer;
 pub mod style;
+#[cfg(feature = "build-assets")]
 mod syntax_dependencies;
 pub(crate) mod syntax_mapping;
 mod terminal;


### PR DESCRIPTION
The main short-term benefit of this PR is to make building `minimal-application` (previously called `quick-build-application`) even faster.

But it also opens up a major long-term possibility:
* If we end up creating a separate `bat-assets` binary to build assets, we can still allow users to optionally keep the current capability in the main app

For the curious, here are some numbers, comparing `minimal-application` with `application` for stripped release builds. Note that I am including https://github.com/trishume/syntect/pull/345 in below numbers:

| variant               | stripped release binary size | dependencies to build |
| ----------------------|------------------------------|-----------------------|
| `minimal-application` | 3,5M                         | 121                   |
| `application`         | 4,7M                         | 166                   |

I have not yet done broad verification of this PR. Would be great to get your high-level feedback on it before I polish it.

