### PR TITLE
Don't take a HighlightingAssets detour to build assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ## `bat` as a library
 
 - Deprecate `HighlightingAssets::syntaxes()` and `HighlightingAssets::syntax_for_file_name()`. Use `HighlightingAssets::get_syntaxes()` and `HighlightingAssets::get_syntax_for_file_name()` instead. They return a `Result` which is needed for upcoming lazy-loading work to improve startup performance. They also return what `SyntaxSet` the returned `SyntaxReference` belongs to. See #1747, #1755 and #1776 (@Enselic)
+- Deprecate `HighlightingAssets::from_files` and `HighlightingAssets::save_to_cache` and make them always fail. Instead of calling the former and then the latter you now make a single call to `bat::assets::build`.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 ## `bat` as a library
 
 - Deprecate `HighlightingAssets::syntaxes()` and `HighlightingAssets::syntax_for_file_name()`. Use `HighlightingAssets::get_syntaxes()` and `HighlightingAssets::get_syntax_for_file_name()` instead. They return a `Result` which is needed for upcoming lazy-loading work to improve startup performance. They also return what `SyntaxSet` the returned `SyntaxReference` belongs to. See #1747, #1755 and #1776 (@Enselic)
-- Deprecate `HighlightingAssets::from_files` and `HighlightingAssets::save_to_cache` and make them always fail. Instead of calling the former and then the latter you now make a single call to `bat::assets::build`.
+- Remove `HighlightingAssets::from_files` and `HighlightingAssets::save_to_cache`. Instead of calling the former and then the latter you now make a single call to `bat::assets::build`. See #1802 (@Enselic)
 
 
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -60,15 +60,6 @@ impl HighlightingAssets {
         "Monokai Extended"
     }
 
-    /// Deprecated.
-    /// Instead of first [HighlightingAssets::from_files] and then [HighlightingAssets::save_to_cache]
-    /// you now make a single call to [crate::assets::build]. A temporary [HighlightingAssets] object is
-    /// not needed any longer to build assets.
-    #[deprecated]
-    pub fn from_files(_source_dir: &Path, _include_integrated_assets: bool) -> Result<Self> {
-        Err("Deprecated. See rustdoc for more info.".to_owned().into())
-    }
-
     pub fn from_cache(cache_path: &Path) -> Result<Self> {
         Ok(HighlightingAssets::new(
             SerializedSyntaxSet::FromFile(cache_path.join("syntaxes.bin")),
@@ -81,15 +72,6 @@ impl HighlightingAssets {
             SerializedSyntaxSet::FromBinary(get_serialized_integrated_syntaxset()),
             get_integrated_themeset(),
         )
-    }
-
-    /// Deprecated.
-    /// Instead of first [HighlightingAssets::from_files] and then [HighlightingAssets::save_to_cache]
-    /// you now make a single call to [crate::assets::build]. A temporary [HighlightingAssets] object is
-    /// not needed any longer to build assets.
-    #[deprecated]
-    pub fn save_to_cache(&self, _target_dir: &Path, _current_version: &str) -> Result<()> {
-        Err("Deprecated. See rustdoc for more info.".to_owned().into())
     }
 
     pub fn set_fallback_theme(&mut self, theme: &'static str) {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -62,7 +62,7 @@ impl HighlightingAssets {
 
     /// Deprecated.
     /// Instead of first [HighlightingAssets::from_files] and then [HighlightingAssets::save_to_cache]
-    /// you now make a single call to [bat::assets::build]. A temporary [HighlightingAssets] object is
+    /// you now make a single call to [crate::assets::build]. A temporary [HighlightingAssets] object is
     /// not needed any longer to build assets.
     #[deprecated]
     pub fn from_files(_source_dir: &Path, _include_integrated_assets: bool) -> Result<Self> {
@@ -85,7 +85,7 @@ impl HighlightingAssets {
 
     /// Deprecated.
     /// Instead of first [HighlightingAssets::from_files] and then [HighlightingAssets::save_to_cache]
-    /// you now make a single call to [bat::assets::build]. A temporary [HighlightingAssets] object is
+    /// you now make a single call to [crate::assets::build]. A temporary [HighlightingAssets] object is
     /// not needed any longer to build assets.
     #[deprecated]
     pub fn save_to_cache(&self, _target_dir: &Path, _current_version: &str) -> Result<()> {

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -27,7 +27,6 @@ use directories::PROJECT_DIRS;
 use globset::GlobMatcher;
 
 use bat::{
-    assets as lib_assets,
     config::Config,
     controller::Controller,
     error::*,
@@ -51,7 +50,7 @@ fn build_assets(matches: &clap::ArgMatches) -> Result<()> {
 
     let blank = matches.is_present("blank");
 
-    lib_assets::build(source_dir, !blank, target_dir, clap::crate_version!())
+    bat::assets::build(source_dir, !blank, target_dir, clap::crate_version!())
 }
 
 fn run_cache_subcommand(matches: &clap::ArgMatches) -> Result<()> {

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -27,6 +27,7 @@ use directories::PROJECT_DIRS;
 use globset::GlobMatcher;
 
 use bat::{
+    assets as lib_assets,
     config::Config,
     controller::Controller,
     error::*,
@@ -50,8 +51,7 @@ fn build_assets(matches: &clap::ArgMatches) -> Result<()> {
 
     let blank = matches.is_present("blank");
 
-    let assets = bat::assets::HighlightingAssets::from_files(source_dir, !blank)?;
-    assets.save_to_cache(target_dir, clap::crate_version!())
+    lib_assets::build(source_dir, !blank, target_dir, clap::crate_version!())
 }
 
 fn run_cache_subcommand(matches: &clap::ArgMatches) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ mod macros;
 
 pub mod assets;
 pub mod assets_metadata;
+#[cfg(feature = "build-assets")]
+mod build_assets;
 pub mod config;
 pub mod controller;
 mod decorations;
@@ -40,8 +42,6 @@ mod preprocessor;
 mod pretty_printer;
 pub(crate) mod printer;
 pub mod style;
-#[cfg(feature = "build-assets")]
-mod syntax_dependencies;
 pub(crate) mod syntax_mapping;
 mod terminal;
 pub(crate) mod wrapping;


### PR DESCRIPTION
In the current code base, it is necessary to create a temporary `HighlightingAssets` instance to be able to build assets.

This PR moves the code to build assets to its own place, independent of `HighlightingAssets`. This allows us to significantly simplify `HighlightingAssets` since we can make `SerializedSyntaxSet` mandatory.

This also makes sense on a conceptual level. When building assets, it will never be necessary to also highlight source code. So it makes sense to stop using `HighlightingAssets` for this.

This means that we no longer allow clients of our API to build assets during startup. But that is very slow, and I can't imagine why anyone would want to do that. And this simplification is worth a lot in terms of flexibility. So IMHO it is worth having to deprecate API.

### New public API

I currently put the new API at
* `bat::assets::build`

to not introduce a new module. Another option I was considering was `bat::build_assets`. I am open to further ideas.

### Deprecated and no longer functional API

* `bat::assets::HighlightingAssets::from_files`
* `bat::assets::HighlightingAssets::save_to_cache`

### Background information

As I was experimenting with zero-copy deserialization (see #1787) I bumped into the problem of having to use `HighlightingAssets` to build assets. To support zero-copy deserialization, it will be natural to serialize temporarily owned data. Having to take a `HighlightingAssets` detour really complicates things.

But IMO this PR has merits of its own, regardless of the work related to #1787.

### Status of PR

I'm happy with the code, and consider it ready for CR. But I have not yet done broad verification. I would prefer to get your thoughts on this before I put much time on verification. In case you think this is way too wild :)