### PR TITLE
Support for line range plus syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - `$BAT_CONFIG_DIR` is now a recognized environment variable. It has precedence over `$XDG_CONFIG_HOME`, see #1727 (@billrisher)
+- Support for `x:+x` syntax in line ranges (e.g. `20:+10`). See  #1810 (@bojan88)
 
 ## Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - `$BAT_CONFIG_DIR` is now a recognized environment variable. It has precedence over `$XDG_CONFIG_HOME`, see #1727 (@billrisher)
-- Support for `x:+x` syntax in line ranges (e.g. `20:+10`). See  #1810 (@bojan88)
+- Support for `x:+delta` syntax in line ranges (e.g. `20:+10`). See  #1810 (@bojan88)
 
 ## Bugfixes
 

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -50,6 +50,8 @@ highlights lines 30 to 40
 highlights lines 1 to 40
 .IP "\-\-highlight\-line 40:"
 highlights lines 40 to the end of the file
+.IP "\-\-highlight\-line 30:+10"
+highlights lines 30 to 40
 .RE
 .HP
 \fB\-\-file\-name\fR <name>...
@@ -154,6 +156,8 @@ prints lines 30 to 40
 prints lines 1 to 40
 .IP "\-\-line\-range 40:"
 prints lines 40 to the end of the file
+.IP "\-\-line\-range 30:+10"
+prints lines 30 to 40
 .RE
 .HP
 \fB\-L\fR, \fB\-\-list\-languages\fR
@@ -218,7 +222,7 @@ git clone https://github.com/tellnobody1/sublime-purescript-syntax
 
 Once the cache is built, the new language will be visible in `\fB{{PROJECT_EXECUTABLE}} --list-languages\fR`.
 .br
-If you ever want to remove the custom languages, you can clear the cache with `\fB{{PROJECT_EXECUTABLE}} cache --clear\fR`. 
+If you ever want to remove the custom languages, you can clear the cache with `\fB{{PROJECT_EXECUTABLE}} cache --clear\fR`.
 
 .SH "ADDING CUSTOM THEMES"
 Similarly to custom languages, {{PROJECT_EXECUTABLE}} supports Sublime Text \fB.tmTheme\fR themes.

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -95,7 +95,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      '--highlight-line 40' highlights line 40\n  \
                      '--highlight-line 30:40' highlights lines 30 to 40\n  \
                      '--highlight-line :40' highlights lines 1 to 40\n  \
-                     '--highlight-line 40:' highlights lines 40 to the end of the file",
+                     '--highlight-line 40:' highlights lines 40 to the end of the file\n  \
+                     '--highlight-line 30:+10' highlights lines 30 to 40",
                 ),
         )
         .arg(
@@ -423,7 +424,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      '--line-range 30:40' prints lines 30 to 40\n  \
                      '--line-range :40' prints lines 1 to 40\n  \
                      '--line-range 40:' prints lines 40 to the end of the file\n  \
-                     '--line-range 40' only prints line 40",
+                     '--line-range 40' only prints line 40\n  \
+                     '--line-range 30:+10' prints lines 30 to 40",
                 ),
         )
         .arg(

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -48,10 +48,10 @@ impl LineRange {
             2 => {
                 new_range.lower = line_numbers[0].parse()?;
 
-                new_range.upper = if line_numbers[1].bytes().next().unwrap() == b'+' {
+                new_range.upper = if line_numbers[1].bytes().next() == Some(b'+') {
                     let more_lines = &line_numbers[1][1..]
                         .parse()
-                        .map_err(|_| "Invalid line number after +")?;
+                        .map_err(|_| "Invalid character after +")?;
                     new_range.lower + more_lines
                 } else {
                     line_numbers[1].parse()?

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -47,7 +47,16 @@ impl LineRange {
             }
             2 => {
                 new_range.lower = line_numbers[0].parse()?;
-                new_range.upper = line_numbers[1].parse()?;
+
+                new_range.upper = if line_numbers[1].bytes().next().unwrap() == b'+' {
+                    let more_lines = &line_numbers[1][1..]
+                        .parse()
+                        .map_err(|_| "Invalid line number after +")?;
+                    new_range.lower + more_lines
+                } else {
+                    line_numbers[1].parse()?
+                };
+
                 Ok(new_range)
             }
             _ => Err(
@@ -97,6 +106,23 @@ fn test_parse_fail() {
     let range = LineRange::from("40::80");
     assert!(range.is_err());
     let range = LineRange::from(":40:");
+    assert!(range.is_err());
+}
+
+#[test]
+fn test_parse_plus() {
+    let range = LineRange::from("40:+10").expect("Shouldn't fail on test!");
+    assert_eq!(40, range.lower);
+    assert_eq!(50, range.upper);
+}
+
+#[test]
+fn test_parse_plus_fail() {
+    let range = LineRange::from("40:+z");
+    assert!(range.is_err());
+    let range = LineRange::from("40:+-10");
+    assert!(range.is_err());
+    let range = LineRange::from("40:+");
     assert!(range.is_err());
 }
 


### PR DESCRIPTION
Working with long files and using line range can be hard sometimes. For example if we want to see just a few lines after line `55478`, we would need to write both numbers which are large, and that can lead to mistakes.
It's much easier to write `55478:+5` or `55478:+30`.

This is influenced by similar syntax in `git` for `log` sub-command with `-L` argument.