### PR TITLE
Add release checklist

### DIFF
--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -1,0 +1,27 @@
+Release checklist:
+
+- [ ] Check for outdated dependencies (`cargo outdated`)
+- [ ] Optional: update dependencies with `cargo update`.
+      See also https://deps.rs/repo/github/sharkdp/bat
+- [ ] Update syntaxes and themes (`cargo install -f --path .; assets/create.sh`).
+- [ ] Update README (features, usage, languages, ..).
+- [ ] Update man page
+
+
+- [ ] Update version in `Cargo.toml`. Run `cargo build` to update `Cargo.lock`
+- [ ] Update version in README and possibly update minimum Rust version
+- [ ] Run `cargo fmt`
+- [ ] Run `cargo test`
+- [ ] Run `cargo install --path . -f`
+- [ ] Test new features & command-line options
+- [ ] Check `-h` and `--help` texts
+
+
+- [ ] `cargo publish --dry-run --allow-dirty`.
+- [ ] write GitHub release notes
+- [ ] check if CI succeeds
+- [ ] `git tag vX.Y.Z; git push --tags`
+- [ ] check binaries (that were uploaded via Travis/AppVeyor)
+- [ ] publish to crates.io by cloning a fresh repo and calling `cargo publish`.
+- [ ] Inform package maintainers about the update:
+    - https://www.archlinux.org/packages/community/x86_64/bat/

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -4,11 +4,11 @@
 
 See this page for a good overview: https://deps.rs/repo/github/sharkdp/bat
 
-- [ ] Optional: update dependencies with `cargo update`. This is also done
-      by dependabot, so it is not strictly necessary.
-- [ ] Check for outdated dependencies (`cargo outdated`) and decide for each
-      of them whether we want to (manually) upgrade. This will require changes
-      to `Cargo.toml`.
+- [ ] Optional: update dependencies with `cargo update`. This is also done by
+      dependabot, so it is not strictly necessary.
+- [ ] Check for outdated dependencies (`cargo outdated`) and decide for each of
+      them whether we want to (manually) upgrade. This will require changes to
+      `Cargo.toml`.
 
 ## Version bump
 
@@ -18,8 +18,8 @@ See this page for a good overview: https://deps.rs/repo/github/sharkdp/bat
       `grep '^\s*MIN_SUPPORTED_RUST_VERSION' .github/workflows/CICD.yml`.
 - [ ] Update the version and the min. supported Rust version in `README.md` and
       `doc/README-*.md`.
-- [ ] Update `CHANGELOG.md`. Introduce a section for the new release and prepare
-      a new (empty) "unreleased" section at the top.
+- [ ] Update `CHANGELOG.md`. Introduce a section for the new release and
+      prepare a new (empty) "unreleased" section at the top.
 
 ## Update syntaxes and themes (build assets)
 
@@ -55,9 +55,4 @@ See this page for a good overview: https://deps.rs/repo/github/sharkdp/bat
 - [ ] Check if the binary deployment works (archives and Debian packages should
       appear when the CI run for the Git tag has finished).
 - [ ] Publish to crates.io by running `cargo publish` in a *clean* repository.
-      The safest way to do this is to cloning a fresh copy.
-
-## Post release
-
-- [ ] Optional: Inform package maintainers about the update:
-      - https://www.archlinux.org/packages/community/x86_64/bat/
+      The safest way to do this is to clone a fresh copy.

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -35,26 +35,29 @@ See this page for a good overview: https://deps.rs/repo/github/sharkdp/bat
 
 ## Pre-release checks
 
-- [ ] Push all changes and wait for CI to succeed (before continuing with the next
-      section).
-- [ ] Optional: manually test the new features and command-line options. To do this,
-      install the latest `bat` version again (to include the new syntaxes/themes).
-- [ ] Run `cargo publish --dry-run --allow-dirty` to make sure that it will succeed
-      later (after creating the GitHub release).
+- [ ] Push all changes and wait for CI to succeed (before continuing with the
+      next section).
+- [ ] Optional: manually test the new features and command-line options. To do
+      this, install the latest `bat` version again (to include the new synaxes
+      and themes).
+- [ ] Run `cargo publish --dry-run --allow-dirty` to make sure that it will
+      succeed later (after creating the GitHub release).
 
 ## Release
 
 - [ ] Create a tag and push it to the remote `git tag vX.Y.Z; git push --tags`.
       This will trigger the deployment via GitHub Actions.
-- [ ] Create a new release on GitHub: https://github.com/sharkdp/bat/releases/new
-      Select the new tag and also use it as the release title. Copy the
-      corresponding section from `CHANGELOG.md` and possibly add remarks for
-      package maintainers. Publish the release.
+- [ ] Go to https://github.com/sharkdp/bat/releases/new to create the new
+      release. Select the new tag and also use it as the release title. For the
+      release notes, copy the corresponding section from `CHANGELOG.md` and
+      possibly add additional remarks for package maintainers.
+      Publish the release.
 - [ ] Check if the binary deployment works (archives and Debian packages should
       appear when the CI run for the Git tag has finished).
-- [ ] Publish to crates.io by cloning *a fresh repository* and calling `cargo publish`.
+- [ ] Publish to crates.io by running `cargo publish` in a *clean* repository.
+      The safest way to do this is to cloning a fresh copy.
 
 ## Post release
 
-- [ ] Optional: inform package maintainers about the update:
-    - https://www.archlinux.org/packages/community/x86_64/bat/
+- [ ] Optional: Inform package maintainers about the update:
+      - https://www.archlinux.org/packages/community/x86_64/bat/

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -1,27 +1,60 @@
-Release checklist:
+# Release checklist
 
-- [ ] Check for outdated dependencies (`cargo outdated`)
-- [ ] Optional: update dependencies with `cargo update`.
-      See also https://deps.rs/repo/github/sharkdp/bat
-- [ ] Update syntaxes and themes (`cargo install -f --path .; assets/create.sh`).
-- [ ] Update README (features, usage, languages, ..).
-- [ ] Update man page
+## Dependencies
 
+See this page for a good overview: https://deps.rs/repo/github/sharkdp/bat
 
-- [ ] Update version in `Cargo.toml`. Run `cargo build` to update `Cargo.lock`
-- [ ] Update version in README and possibly update minimum Rust version
-- [ ] Run `cargo fmt`
-- [ ] Run `cargo test`
-- [ ] Run `cargo install --path . -f`
-- [ ] Test new features & command-line options
-- [ ] Check `-h` and `--help` texts
+- [ ] Optional: update dependencies with `cargo update`. This is also done
+      by dependabot, so it is not strictly necessary.
+- [ ] Check for outdated dependencies (`cargo outdated`) and decide for each
+      of them whether we want to (manually) upgrade. This will require changes
+      to `Cargo.toml`.
 
+## Version bump
 
-- [ ] `cargo publish --dry-run --allow-dirty`.
-- [ ] write GitHub release notes
-- [ ] check if CI succeeds
-- [ ] `git tag vX.Y.Z; git push --tags`
-- [ ] check binaries (that were uploaded via Travis/AppVeyor)
-- [ ] publish to crates.io by cloning a fresh repo and calling `cargo publish`.
-- [ ] Inform package maintainers about the update:
+- [ ] Update version in `Cargo.toml`. Run `cargo build` to update `Cargo.lock`.
+      Make sure to `git add` the `Cargo.lock` changes as well.
+- [ ] Find the current min. supported Rust version by running
+      `grep '^\s*MIN_SUPPORTED_RUST_VERSION' .github/workflows/CICD.yml`.
+- [ ] Update the version and the min. supported Rust version in `README.md` and
+      `doc/README-*.md`.
+- [ ] Update `CHANGELOG.md`. Introduce a section for the new release and prepare
+      a new (empty) "unreleased" section at the top.
+
+## Update syntaxes and themes (build assets)
+
+- [ ] Install the latest master version (`cargo install -f --path .`) and make
+      sure that it is available on the `PATH` (`bat --version` should show the
+      new version).
+- [ ] Run `assets/create.sh` and check in the binary asset files.
+
+## Documentation
+
+- [ ] Review the `-h` and `--help` texts
+- [ ] Review the `man` page
+
+## Pre-release checks
+
+- [ ] Push all changes and wait for CI to succeed (before continuing with the next
+      section).
+- [ ] Optional: manually test the new features and command-line options. To do this,
+      install the latest `bat` version again (to include the new syntaxes/themes).
+- [ ] Run `cargo publish --dry-run --allow-dirty` to make sure that it will succeed
+      later (after creating the GitHub release).
+
+## Release
+
+- [ ] Create a tag and push it to the remote `git tag vX.Y.Z; git push --tags`.
+      This will trigger the deployment via GitHub Actions.
+- [ ] Create a new release on GitHub: https://github.com/sharkdp/bat/releases/new
+      Select the new tag and also use it as the release title. Copy the
+      corresponding section from `CHANGELOG.md` and possibly add remarks for
+      package maintainers. Publish the release.
+- [ ] Check if the binary deployment works (archives and Debian packages should
+      appear when the CI run for the Git tag has finished).
+- [ ] Publish to crates.io by cloning *a fresh repository* and calling `cargo publish`.
+
+## Post release
+
+- [ ] Optional: inform package maintainers about the update:
     - https://www.archlinux.org/packages/community/x86_64/bat/


### PR DESCRIPTION
This adds some documentation concerning the release of new `bat` versions. The first commit is my partially outdated version. Let's discuss which steps can be removed / should be changed / should be added.