### PR TITLE
Experiment: remove CARGO_TEST_OPTIONS

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -194,21 +194,12 @@ jobs:
         echo ::set-output name=BIN_PATH::${BIN_PATH}
         echo ::set-output name=BIN_NAME::${BIN_NAME}
 
-    - name: Set testing options
-      id: test-options
-      shell: bash
-      run: |
-        # test only library unit tests and binary for arm-type targets
-        unset CARGO_TEST_OPTIONS
-        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--lib --bin ${PROJECT_NAME}" ;; esac;
-        echo ::set-output name=CARGO_TEST_OPTIONS::${CARGO_TEST_OPTIONS}
-
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:
         use-cross: ${{ matrix.job.use-cross }}
         command: test
-        args: --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
+        args: --locked --target=${{ matrix.job.target }}
 
     - name: Run bat
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
In principle, this *could* work. `cargo cross` runs the tests via QEMU.
For integration tests, the only difficulty is that we run `bat` from
within the tests. But maybe this is handled by assert_cmd.