### PR TITLE
CICD: Swap target and os in matrix job name

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -101,17 +101,17 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-20.04, target: arm-unknown-linux-gnueabihf , use-cross: true }
-          - { os: ubuntu-20.04, target: arm-unknown-linux-musleabihf, use-cross: true }
-          - { os: ubuntu-20.04, target: aarch64-unknown-linux-gnu   , use-cross: true }
-          - { os: ubuntu-20.04, target: i686-unknown-linux-gnu      , use-cross: true }
-          - { os: ubuntu-20.04, target: i686-unknown-linux-musl     , use-cross: true }
-          - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu    }
-          - { os: ubuntu-20.04, target: x86_64-unknown-linux-musl   , use-cross: true }
-          - { os: macos-10.15 , target: x86_64-apple-darwin         }
-          - { os: windows-2019, target: i686-pc-windows-msvc        }
-          - { os: windows-2019, target: x86_64-pc-windows-gnu       }
-          - { os: windows-2019, target: x86_64-pc-windows-msvc      }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, use-cross: true }
+          - { target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, use-cross: true }
+          - { target: i686-pc-windows-msvc        , os: windows-2019                  }
+          - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true }
+          - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-10.15                   }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                  }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
     steps:
     - name: Checkout source code
       uses: actions/checkout@v2

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -109,7 +109,6 @@ jobs:
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu    }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-musl   , use-cross: true }
           - { os: macos-10.15 , target: x86_64-apple-darwin         }
-          # - { os: windows-2019, target: i686-pc-windows-gnu         }  ## disabled; error: linker `i686-w64-mingw32-gcc` not found
           - { os: windows-2019, target: i686-pc-windows-msvc        }
           - { os: windows-2019, target: x86_64-pc-windows-gnu       }
           - { os: windows-2019, target: x86_64-pc-windows-msvc      }

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -95,7 +95,7 @@ jobs:
         args: --locked --no-deps --document-private-items --all-features
 
   build:
-    name: ${{ matrix.job.os }} (${{ matrix.job.target }})
+    name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
I frequently find myself struggling to find the CI matrix job I'm after. This is partly because the name is truncated and does not display the full `target` (in my desktop at least). Since the OS can easily be seen via the `target`, I think it make sense to put `target` first.

To make the right target as easy as possible to find, I have sorted build job by target. Note that GitHub keeps the order from the .yml in the web UI.

Also remove the disabled windows target which is just in the way.

P.S. I get a deja vu feeling, did we already discuss this? :thinking: 

Before and after screenshots:
![before-after-os-target](https://user-images.githubusercontent.com/115040/131217969-6d62518f-4364-4c12-99c2-d33ffaa0fc71.png)
