### PR TITLE
Add regression testing for the custom assets functionality

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -86,6 +86,8 @@ jobs:
       run: bat --list-languages
     - name: List of themes
       run: bat --list-themes
+    - name: Test custom assets
+      run: tests/syntax-tests/test_custom_assets.sh
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings

--- a/tests/syntax-tests/BatTestCustomAssets.sublime-syntax
+++ b/tests/syntax-tests/BatTestCustomAssets.sublime-syntax
@@ -1,0 +1,21 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: BatTestCustomAssets
+file_extensions:
+  - battestcustomassets
+scope: source.battestcustomassets
+
+# This syntax is used to test if custom assets work with bat.
+# The way it works is that this syntax is only allowed to be included with
+# custom assets. That way it is easy to test if custom assets are used (and works)
+# or not.
+#
+# This syntax is based on CpuInfo.sublime-syntax.
+
+contexts:
+  main:
+    - match: '^([^:]+)\w*:\w*(.*)$'
+      captures:
+        1: keyword.other.battestcustomassets-key
+        2: string.other.battestcustomassets-value

--- a/tests/syntax-tests/highlighted/BatTestCustomAssets/NoColorsUnlessCustomAssetsAreUsed.battestcustomassets
+++ b/tests/syntax-tests/highlighted/BatTestCustomAssets/NoColorsUnlessCustomAssetsAreUsed.battestcustomassets
@@ -1,0 +1,2 @@
+[38;2;248;248;242mcustom assets : 0[0m
+[38;2;248;248;242mare           : the best[0m

--- a/tests/syntax-tests/source/BatTestCustomAssets/NoColorsUnlessCustomAssetsAreUsed.battestcustomassets
+++ b/tests/syntax-tests/source/BatTestCustomAssets/NoColorsUnlessCustomAssetsAreUsed.battestcustomassets
@@ -1,0 +1,2 @@
+custom assets : 0
+are           : the best

--- a/tests/syntax-tests/test_custom_assets.sh
+++ b/tests/syntax-tests/test_custom_assets.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 
+### ENVIRONMENT
+
+BAT_CONFIG_DIR=$(mktemp -d)
+export BAT_CONFIG_DIR
+
+BAT_CACHE_PATH=$(mktemp -d)
+export BAT_CACHE_PATH
+
+echo "
+BAT_CONFIG_DIR = ${BAT_CONFIG_DIR}
+BAT_CACHE_PATH = ${BAT_CACHE_PATH}
+"
+
 ### HELPER VARS
-
-custom_syntaxes_dir="$(bat --config-dir)/syntaxes"
-
-installed_custom_syntax="${custom_syntaxes_dir}/BatTestCustomAssets.sublime-syntax"
 
 custom_syntax_args=(
     "--language=BatTestCustomAssets"
@@ -24,7 +33,7 @@ echo_step() {
 }
 
 fail_test() {
-    echo "FAIL: $1"
+    echo -e "FAIL: $1"
     exit 1
 }
 
@@ -32,12 +41,13 @@ fail_test() {
 
 echo_step "TEST: Make sure 'BatTestCustomAssets' is not part of integrated syntaxes"
 bat -f "${custom_syntax_args[@]}" &&
-    fail_test "EXPECTED: 'unknown syntax' error ACTUAL: no error occured
-               HINT: try manually doing 'bat cache --clear' before running tests"
+    fail_test "EXPECTED: 'unknown syntax' error ACTUAL: no error occured"
 
 echo_step "PREPARE: Install custom syntax 'BatTestCustomAssets'"
+custom_syntaxes_dir="$(bat --config-dir)/syntaxes"
 mkdir -p "${custom_syntaxes_dir}"
-cp -v "tests/syntax-tests/BatTestCustomAssets.sublime-syntax" "${installed_custom_syntax}"
+cp -v "tests/syntax-tests/BatTestCustomAssets.sublime-syntax" \
+    "${custom_syntaxes_dir}/BatTestCustomAssets.sublime-syntax"
 
 echo_step "PREPARE: Build custom assets to enable 'BatTestCustomAssets' syntax"
 bat cache --build
@@ -48,12 +58,17 @@ bat -f "${custom_syntax_args[@]}" ||
 
 echo_step "TEST: The 'Rust' syntax is still available"
 bat -f "${integrated_syntax_args[@]}" ||
-    fail_test "EXPECTED: syntax highlighting to still work for integrated assets ACTUAL: there was an error"
+    fail_test "EXPECTED: syntax highlighting still works with integrated assets ACTUAL: there was an error"
 
 echo_step "TEST: 'BatTestCustomAssets' is an unknown syntax with --no-custom-assets"
 bat -f --no-custom-assets "${custom_syntax_args[@]}" &&
-    fail_test "EXPECTED: 'unknown syntax' error because of --no-custom-assets, but no error occured"
+    fail_test "EXPECTED: 'unknown syntax' error because of --no-custom-assets ACTUAL: no error occured"
 
-echo_step "CLEANING: To avoid unwanted side effects of running tests"
+echo_step "TEST: 'bat cache --clear' removes all files"
 bat cache --clear
-rm -rfv "${installed_custom_syntax}"
+remaining_files=$(ls -A "${BAT_CACHE_PATH}")
+[ -z "${remaining_files}" ] ||
+    fail_test "EXPECTED: no files remain ACTUAL: some files remain:\n${remaining_files}"
+
+echo_step "CLEAN"
+rm -rv "${BAT_CONFIG_DIR}" "${BAT_CACHE_PATH}"

--- a/tests/syntax-tests/test_custom_assets.sh
+++ b/tests/syntax-tests/test_custom_assets.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+test_file="tests/syntax-tests/source/BatTestCustomAssets/NoColorsUnlessCustomAssetsAreUsed.battestcustomassets"
+
+# First make sure our test syntax is not part of integrated syntaxes
+
+echo "Testing that BatTestCustomAssets is an unknown syntax:"
+bat -f --language BatTestCustomAssets "${test_file}" &&
+    echo "should have failed because of unknown syntax" &&
+    exit 1
+
+# Now build custom assets and include our test syntax
+# We do as instructed to regular users at
+# https://github.com/sharkdp/bat/blob/master/README.md#adding-new-syntaxes--language-definitions
+
+# Create dir to put our test syntax
+custom_syntaxes_dir="$(bat --config-dir)/syntaxes"
+mkdir -p "${custom_syntaxes_dir}"
+
+# Put the syntax in place
+cp tests/syntax-tests/BatTestCustomAssets.sublime-syntax "${custom_syntaxes_dir}/BatTestCustomAssets.sublime-syntax"
+
+# Build custom assets to include the above syntax
+echo "Buidling custom assets to include the BatTestCustomAssets syntax"
+bat cache --build
+
+# Now bat shall not fail when the syntax is used. If it does not fail, we can be reasonably sure
+# that the custom assets functionality is working
+echo "Testing that BatTestCustomAssets is a KNOWN syntax:"
+bat -f --language BatTestCustomAssets "${test_file}" ||
+    (echo "command shall not have failed this time, but did" &&
+        exit 1)
+
+# While we're at it  and for extra safety in the test, we also
+# make sure that the --no-custom-assets flag work as intended
+echo "Testing that BatTestCustomAssets is an unknown syntax when using --no-custom-assets:"
+bat -f --no-custom-assets --language BatTestCustomAssets "${test_file}" &&
+    echo "should have failed because of unknown syntax via --no-custom-assets" &&
+    exit 1
+
+# We clean up after ourselves to reduce risk of problems later
+bat cache --clear

--- a/tests/syntax-tests/test_custom_assets.sh
+++ b/tests/syntax-tests/test_custom_assets.sh
@@ -4,7 +4,6 @@ set -o errexit -o nounset -o pipefail
 test_file="tests/syntax-tests/source/BatTestCustomAssets/NoColorsUnlessCustomAssetsAreUsed.battestcustomassets"
 
 # First make sure our test syntax is not part of integrated syntaxes
-
 echo "Testing that BatTestCustomAssets is an unknown syntax:"
 bat -f --language BatTestCustomAssets "${test_file}" &&
     echo "should have failed because of unknown syntax" &&
@@ -22,7 +21,7 @@ mkdir -p "${custom_syntaxes_dir}"
 cp tests/syntax-tests/BatTestCustomAssets.sublime-syntax "${custom_syntaxes_dir}/BatTestCustomAssets.sublime-syntax"
 
 # Build custom assets to include the above syntax
-echo "Buidling custom assets to include the BatTestCustomAssets syntax"
+echo "Building custom assets to include the BatTestCustomAssets syntax"
 bat cache --build
 
 # Now bat shall not fail when the syntax is used. If it does not fail, we can be reasonably sure
@@ -41,3 +40,4 @@ bat -f --no-custom-assets --language BatTestCustomAssets "${test_file}" &&
 
 # We clean up after ourselves to reduce risk of problems later
 bat cache --clear
+rm -rf "${custom_syntaxes_dir}"


### PR DESCRIPTION
Our current CI pipeline does not regression test the custom assets functionality at all. We get a [green](https://github.com/Enselic/bat/runs/3459232947) pipeline even if we replace `HighlitingAssets::from_cache` with this:

```rust
    pub fn from_cache(cache_path: &Path) -> Result<Self> {
        #[allow(unused_variables)]
        let res = Ok(HighlightingAssets::new(
            SerializedSyntaxSet::FromFile(cache_path.join("syntaxes.bin")),
            asset_from_cache(&cache_path.join("themes.bin"), "theme set")?,
        ));

        panic!("does this code run in CI?");

        #[allow(unreachable_code)]
        res
    }
```

This PR adds code to regression test the custom assets functionality. It can be seen as preparatory work for the verification of #1825, but is of course useful on its own.