### PR TITLE
Add increment option in `--highlight-line` and `--line-range`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `$BAT_CONFIG_DIR` is now a recognized environment variable. It has precedence over `$XDG_CONFIG_HOME`, see #1727 (@billrisher)
 - Support for `x:+delta` syntax in line ranges (e.g. `20:+10`). See  #1810 (@bojan88)
+- Add increment option in `--highlight-line` and `--line-range`, see #1611 (@t-mangoe)
 
 ## Bugfixes
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -216,8 +216,12 @@ impl App {
                 _ => VisibleLines::Ranges(
                     self.matches
                         .values_of("line-range")
-                        .map(|vs| vs.map(LineRange::from).collect())
-                        .transpose()?
+                        .map(|vs| {
+                            vs.map(LineRange::from)
+                                .flatten()
+                                .flatten()
+                                .collect::<Vec<_>>()
+                        })
                         .map(LineRanges::from)
                         .unwrap_or_default(),
                 ),
@@ -229,8 +233,12 @@ impl App {
             highlighted_lines: self
                 .matches
                 .values_of("highlight-line")
-                .map(|ws| ws.map(LineRange::from).collect())
-                .transpose()?
+                .map(|ws| {
+                    ws.map(LineRange::from)
+                        .flatten()
+                        .flatten()
+                        .collect::<Vec<_>>()
+                })
                 .map(LineRanges::from)
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -216,13 +216,7 @@ impl App {
                 _ => VisibleLines::Ranges(
                     self.matches
                         .values_of("line-range")
-                        .map(|vs| {
-                            vs.map(LineRange::from)
-                                .flatten()
-                                .flatten()
-                                .collect::<Vec<_>>()
-                        })
-                        .map(LineRanges::from)
+                        .map(App::get_line_ranges)
                         .unwrap_or_default(),
                 ),
             },
@@ -233,17 +227,20 @@ impl App {
             highlighted_lines: self
                 .matches
                 .values_of("highlight-line")
-                .map(|ws| {
-                    ws.map(LineRange::from)
-                        .flatten()
-                        .flatten()
-                        .collect::<Vec<_>>()
-                })
-                .map(LineRanges::from)
+                .map(App::get_line_ranges)
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
             use_custom_assets: !self.matches.is_present("no-custom-assets"),
         })
+    }
+
+    fn get_line_ranges(clap_val: clap::Values) -> LineRanges {
+        let line_range_vec = clap_val
+            .map(LineRange::from)
+            .flatten()
+            .flatten()
+            .collect::<Vec<_>>();
+        LineRanges::from(line_range_vec)
     }
 
     pub fn inputs(&self) -> Result<Vec<Input>> {

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -79,9 +79,11 @@ impl LineRange {
         match self.increment {
             Some(v) => {
                 let increment = line.checked_sub(self.lower);
-                increment.map_or(false,|inc| line >= self.lower && line <= self.upper && v > 0 && ((inc + 1) % v) == 0)
-            },
-            None => line >= self.lower && line <= self.upper
+                increment.map_or(false, |inc| {
+                    line >= self.lower && line <= self.upper && v > 0 && ((inc + 1) % v) == 0
+                })
+            }
+            None => line >= self.lower && line <= self.upper,
         }
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -224,6 +224,16 @@ fn line_range_multiple() {
         .stdout("line 1\nline 2\nline 4\n");
 }
 
+#[test]
+fn line_range_increment() {
+    bat()
+        .arg("multiline.txt")
+        .arg("--line-range=1:4:2")
+        .assert()
+        .success()
+        .stdout("line 2\nline 4\n");
+}
+
 #[cfg(unix)]
 fn setup_temp_file(content: &[u8]) -> io::Result<(PathBuf, tempfile::TempDir)> {
     let dir = tempfile::tempdir().expect("Couldn't create tempdir");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -231,7 +231,7 @@ fn line_range_increment() {
         .arg("--line-range=1:4~2")
         .assert()
         .success()
-        .stdout("line 2\nline 4\n");
+        .stdout("line 1\nline 3\n");
 }
 
 #[cfg(unix)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -228,7 +228,7 @@ fn line_range_multiple() {
 fn line_range_increment() {
     bat()
         .arg("multiline.txt")
-        .arg("--line-range=1:4:2")
+        .arg("--line-range=1:4~2")
         .assert()
         .success()
         .stdout("line 2\nline 4\n");


### PR DESCRIPTION
This pull request adds increment option in `--highlight-line` and `--line-range`.
By this PR, you will become able to pass an increment value to these options, for example `--highlight-line 30:40:2`.

This PR solves this #1611 issue.

![スクリーンショット 2021-08-21 18 00 46](https://user-images.githubusercontent.com/22494246/132076174-63141892-1fd1-42cc-9fd4-d0bb4609ee97.png)
