### PR TITLE
Consolidate environment variable lists in tests

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -34,13 +34,17 @@ const EXAMPLES_DIR: &str = "tests/examples";
 fn bat_raw_command_with_config() -> Command {
     let mut cmd = Command::cargo_bin("bat").unwrap();
     cmd.current_dir("tests/examples");
-    cmd.env_remove("PAGER");
-    cmd.env_remove("BAT_PAGER");
-    cmd.env_remove("BAT_CONFIG_PATH");
-    cmd.env_remove("BAT_STYLE");
-    cmd.env_remove("BAT_THEME");
-    cmd.env_remove("BAT_TABS");
+    cmd.env_remove("BAT_CACHE_PATH");
     cmd.env_remove("BAT_CONFIG_DIR");
+    cmd.env_remove("BAT_CONFIG_PATH");
+    cmd.env_remove("BAT_OPTS");
+    cmd.env_remove("BAT_PAGER");
+    cmd.env_remove("BAT_STYLE");
+    cmd.env_remove("BAT_TABS");
+    cmd.env_remove("BAT_THEME");
+    cmd.env_remove("COLORTERM");
+    cmd.env_remove("NO_COLOR");
+    cmd.env_remove("PAGER");
     cmd
 }
 

--- a/tests/syntax-tests/create_highlighted_versions.py
+++ b/tests/syntax-tests/create_highlighted_versions.py
@@ -47,12 +47,16 @@ def create_highlighted_versions(output_basepath):
     ):
         try:
             env = os.environ.copy()
-            env.pop("PAGER", None)
-            env.pop("BAT_PAGER", None)
+            env.pop("BAT_CACHE_PATH", None)
+            env.pop("BAT_CONFIG_DIR", None)
             env.pop("BAT_CONFIG_PATH", None)
+            env.pop("BAT_OPTS", None)
+            env.pop("BAT_PAGER", None)
             env.pop("BAT_STYLE", None)
-            env.pop("BAT_THEME", None)
             env.pop("BAT_TABS", None)
+            env.pop("BAT_THEME", None)
+            env.pop("NO_COLOR", None)
+            env.pop("PAGER", None)
             env["COLORTERM"] = "truecolor"  # make sure to output 24bit colors
 
             source_dirname = path.basename(path.dirname(source))


### PR DESCRIPTION
We want to make sure that all of our test environments are clean from
possible outside modification. This consolidates the list of used
environment variables in Rust-based and Python-based integration tests.

Note that there is also a similar list in `src/bin/bat/main.rs` which
is even more exhaustive (for bug report collection). However, some
of these variables can not possibly have an effect on test environments.