### PR TITLE
Simplify HighlightingAssets::get_syntax() first_line logic

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -298,9 +298,9 @@ impl HighlightingAssets {
         match path_syntax {
             // If a path wasn't provided, or if path based syntax detection
             // above failed, we fall back to first-line syntax detection.
-            Err(Error::UndetectedSyntax(syntax_name)) => self
+            Err(Error::UndetectedSyntax(path)) => self
                 .get_first_line_syntax(&mut input.reader)?
-                .ok_or(Error::UndetectedSyntax(syntax_name)),
+                .ok_or(Error::UndetectedSyntax(path)),
             _ => path_syntax,
         }
     }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -256,8 +256,6 @@ impl HighlightingAssets {
                 .ok_or_else(|| Error::UnknownSyntax(language.to_owned()));
         }
 
-        let line_syntax = self.get_first_line_syntax(&mut input.reader)?;
-
         // Get the path of the file:
         // If this was set by the metadata, that will take priority.
         // If it wasn't, it will use the real file path (if available).
@@ -270,7 +268,7 @@ impl HighlightingAssets {
                 _ => None,
             });
 
-        if let Some(path_str) = path_str {
+        let path_syntax = if let Some(path_str) = path_str {
             // If a path was provided, we try and detect the syntax based on extension mappings.
             let path = Path::new(path_str);
             let absolute_path = PathAbs::new(path)
@@ -279,24 +277,28 @@ impl HighlightingAssets {
                 .unwrap_or_else(|| path.to_owned());
 
             match mapping.get_syntax_for(absolute_path) {
-                Some(MappingTarget::MapToUnknown) => line_syntax
-                    .ok_or_else(|| Error::UndetectedSyntax(path.to_string_lossy().into())),
+                Some(MappingTarget::MapToUnknown) => {
+                    Err(Error::UndetectedSyntax(path.to_string_lossy().into()))
+                }
 
                 Some(MappingTarget::MapTo(syntax_name)) => self
                     .find_syntax_by_name(syntax_name)?
-                    .or(line_syntax)
                     .ok_or_else(|| Error::UnknownSyntax(syntax_name.to_owned())),
 
                 None => {
                     let file_name = path.file_name().unwrap_or_default();
                     self.get_extension_syntax(file_name)?
-                        .or(line_syntax)
                         .ok_or_else(|| Error::UndetectedSyntax(path.to_string_lossy().into()))
                 }
             }
         } else {
             // If a path wasn't provided, we fall back to the detect first-line syntax.
-            line_syntax.ok_or_else(|| Error::UndetectedSyntax("[unknown]".into()))
+            Err(Error::UndetectedSyntax("[unknown]".into()))
+        };
+
+        match path_syntax {
+            Err(err) => self.get_first_line_syntax(&mut input.reader)?.ok_or(err),
+            _ => path_syntax,
         }
     }
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -292,11 +292,12 @@ impl HighlightingAssets {
                 }
             }
         } else {
-            // If a path wasn't provided, we fall back to the detect first-line syntax.
             Err(Error::UndetectedSyntax("[unknown]".into()))
         };
 
         match path_syntax {
+            // If a path wasn't provided, or if path based syntax detection
+            // above failed, we fall back to first-line syntax detection.
             Err(err) => self.get_first_line_syntax(&mut input.reader)?.ok_or(err),
             _ => path_syntax,
         }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -298,7 +298,9 @@ impl HighlightingAssets {
         match path_syntax {
             // If a path wasn't provided, or if path based syntax detection
             // above failed, we fall back to first-line syntax detection.
-            Err(err) => self.get_first_line_syntax(&mut input.reader)?.ok_or(err),
+            Err(Error::UndetectedSyntax(syntax_name)) => self
+                .get_first_line_syntax(&mut input.reader)?
+                .ok_or(Error::UndetectedSyntax(syntax_name)),
             _ => path_syntax,
         }
     }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -284,6 +284,7 @@ impl HighlightingAssets {
 
                 Some(MappingTarget::MapTo(syntax_name)) => self
                     .find_syntax_by_name(syntax_name)?
+                    .or(line_syntax)
                     .ok_or_else(|| Error::UnknownSyntax(syntax_name.to_owned())),
 
                 None => {

--- a/tests/examples/regression_tests/first_line_fallback.invalid-syntax
+++ b/tests/examples/regression_tests/first_line_fallback.invalid-syntax
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Hello"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1138,7 +1138,8 @@ fn first_line_fallback_when_mapping_to_invalid_syntax() {
         .arg("--style=plain")
         .arg(file)
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("unknown syntax: 'InvalidSyntax'"));
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1128,7 +1128,7 @@ fn do_not_detect_different_syntax_for_stdin_and_files() {
 }
 
 #[test]
-fn first_line_fallback_when_mapping_to_invalid_syntax() {
+fn no_first_line_fallback_when_mapping_to_invalid_syntax() {
     let file = "regression_tests/first_line_fallback.invalid-syntax";
 
     bat()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1128,6 +1128,20 @@ fn do_not_detect_different_syntax_for_stdin_and_files() {
 }
 
 #[test]
+fn first_line_fallback_when_mapping_to_invalid_syntax() {
+    let file = "regression_tests/first_line_fallback.invalid-syntax";
+
+    bat()
+        .arg("--color=always")
+        .arg("--map-syntax=*.invalid-syntax:InvalidSyntax")
+        .arg(&format!("--file-name={}", file))
+        .arg("--style=plain")
+        .arg(file)
+        .assert()
+        .success();
+}
+
+#[test]
 fn show_all_mode() {
     bat()
         .arg("--show-all")


### PR DESCRIPTION
The first commit makes the following work via first_line_match:

```
bat --map-syntax='*.invalid-syntax:InvalidSyntax' tests/examples/regression_tests/first_line_fallback.invalid-syntax
```
and adds a regression test for it.

The second commit simplifies the code, thanks to the fix in the first commit. It is funny how adding features can result in simpler code.

All regression tests pass, but we don't seem to have that many regression tests for `--map-syntax`, so I might add some more after code review of this.

(The reason I am bothering to simplify the code at all is of course to make #951 easier to implement.)