### PR TITLE
HighlightingAssets: Simplify absolute_path code

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -212,10 +212,8 @@ impl HighlightingAssets {
 
         let path_syntax = if let Some(path) = path {
             // If a path was provided, we try and detect the syntax based on extension mappings.
-            let absolute_path = PathAbs::new(path)
-                .ok()
-                .map(|p| p.as_path().to_path_buf())
-                .unwrap_or_else(|| path.to_owned());
+            let absolute_path =
+                PathAbs::new(path).map_or_else(|_| path.to_owned(), |p| p.as_path().to_path_buf());
 
             match mapping.get_syntax_for(absolute_path) {
                 Some(MappingTarget::MapToUnknown) => {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -201,7 +201,7 @@ impl HighlightingAssets {
         // Get the path of the file:
         // If this was set by the metadata, that will take priority.
         // If it wasn't, it will use the real file path (if available).
-        let path_str = input
+        let path = input
             .metadata
             .user_provided_name
             .as_ref()
@@ -210,9 +210,8 @@ impl HighlightingAssets {
                 _ => None,
             });
 
-        let path_syntax = if let Some(path_str) = path_str {
+        let path_syntax = if let Some(path) = path {
             // If a path was provided, we try and detect the syntax based on extension mappings.
-            let path = Path::new(path_str);
             let absolute_path = PathAbs::new(path)
                 .ok()
                 .map(|p| p.as_path().to_path_buf())

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -212,10 +212,9 @@ impl HighlightingAssets {
 
         let path_syntax = if let Some(path) = path {
             // If a path was provided, we try and detect the syntax based on extension mappings.
-            let absolute_path =
-                PathAbs::new(path).map_or_else(|_| path.to_owned(), |p| p.as_path().to_path_buf());
-
-            match mapping.get_syntax_for(absolute_path) {
+            match mapping.get_syntax_for(
+                PathAbs::new(path).map_or_else(|_| path.to_owned(), |p| p.as_path().to_path_buf()),
+            ) {
                 Some(MappingTarget::MapToUnknown) => {
                     Err(Error::UndetectedSyntax(path.to_string_lossy().into()))
                 }


### PR DESCRIPTION
This is three commits. The last one is perhaps a matter of taste, but the problem with the `absolute_path` variable was that it did not necessarily contain an absolute path. Rather then renaming it to, say, `maybe_absolute_path`, I inlined it. That way one does not have to come up with a good name. It was only used once anyway.