### PR TITLE
Enable optional dump of syntax dependencies to Graphviz dot file

### DIFF
--- a/src/assets/build_assets.rs
+++ b/src/assets/build_assets.rs
@@ -20,8 +20,8 @@ type SyntaxToDependencies = HashMap<SyntaxName, Vec<OtherSyntax>>;
 type SyntaxToDependents<'a> = HashMap<SyntaxName, Vec<OtherSyntax>>;
 
 /// Represents some other `*.sublime-syntax` file, i.e. another [SyntaxDefinition].
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
-enum OtherSyntax {
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Clone, Hash)]
+pub(crate) enum OtherSyntax {
     /// By name. Example YAML: `include: C.sublime-syntax` (name is `"C"`)
     ByName(String),
 
@@ -304,6 +304,7 @@ fn dependencies_for_syntax(syntax: &SyntaxDefinition) -> Vec<OtherSyntax> {
         .collect();
 
     // No need to track a dependency more than once
+    dependencies.sort();
     dependencies.dedup();
 
     dependencies

--- a/src/assets/build_assets/graphviz_utils.rs
+++ b/src/assets/build_assets/graphviz_utils.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+pub(crate) fn try_syntax_dependencies_to_graphviz_dot_file(
+    other_syntax_lookup: &OtherSyntaxLookup,
+    syntax_to_dependencies: &SyntaxToDependencies,
+    dot_file_path: &str,
+) {
+    match syntax_dependencies_to_graphviz_dot_file(
+        other_syntax_lookup,
+        syntax_to_dependencies,
+        dot_file_path,
+    ) {
+        Ok(_) => println!("Wrote graphviz dot file to {}", dot_file_path),
+        Err(e) => eprintln!(
+            "Failed to write graphviz dot file to {}: {}",
+            dot_file_path, e
+        ),
+    };
+}
+
+fn syntax_dependencies_to_graphviz_dot_file(
+    other_syntax_lookup: &OtherSyntaxLookup,
+    syntax_to_dependencies: &SyntaxToDependencies,
+    dot_file_path: &str,
+) -> Result<()> {
+    use std::io::Write;
+
+    let mut dot_file = std::fs::File::create(dot_file_path)?;
+
+    writeln!(dot_file, "digraph BatSyntaxDependencies {{")?;
+    for (key, dependencies) in syntax_to_dependencies {
+        for dependency in dependencies {
+            if let Some(dep) = other_syntax_lookup.get(dependency) {
+                writeln!(dot_file, "    \"{}\" -> \"{}\"", key, dep.name)?;
+            }
+        }
+    }
+    writeln!(dot_file, "}}")?;
+
+    Ok(())
+}


### PR DESCRIPTION
Also include a couple of fixes for dependency analysis (that does not affect the existing `minimal_syntaxes.bin` file) that I discovered by looking at the generated file. (There is still a problem left with dependencies being tracked on "self", that I might fix in some other PR.)

Here is a map of current syntax dependencies (click to enlarge):
![bat-syntax-dependencies](https://user-images.githubusercontent.com/115040/134302764-ed967c5c-7101-4c44-bdb8-0468584a5328.png)

Instructions on how to build a PNG yourself is included in the code as a comment, but I also duplicate it here for convenience:

```
% sudo apt install graphviz
% BAT_SYNTAX_DEPENDENCIES_TO_GRAPHVIZ_DOT_FILE=/tmp/bat-syntax-dependencies.dot cargo run -- cache --build --source assets --blank --target /tmp
% dot /tmp/bat-syntax-dependencies.dot -Tpng -o /tmp/bat-syntax-dependencies.png
% open /tmp/bat-syntax-dependencies.png
```
