### PR TITLE
src/printer.rs: Simplify Plain Text fallback code

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -232,7 +232,10 @@ impl HighlightingAssets {
         }
     }
 
-    fn find_syntax_by_name(&self, syntax_name: &str) -> Result<Option<SyntaxReferenceInSet>> {
+    pub(crate) fn find_syntax_by_name(
+        &self,
+        syntax_name: &str,
+    ) -> Result<Option<SyntaxReferenceInSet>> {
         let syntax_set = self.get_syntax_set()?;
         Ok(syntax_set
             .find_syntax_by_name(syntax_name)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -187,11 +187,9 @@ impl<'a> InteractivePrinter<'a> {
             let syntax_in_set =
                 match assets.get_syntax(config.language, input, &config.syntax_mapping) {
                     Ok(syntax_in_set) => syntax_in_set,
-                    Err(Error::UndetectedSyntax(_)) => {
-                        let syntax_set = assets.get_syntax_set()?;
-                        let syntax = syntax_set.find_syntax_plain_text();
-                        SyntaxReferenceInSet { syntax, syntax_set }
-                    }
+                    Err(Error::UndetectedSyntax(_)) => assets
+                        .find_syntax_by_name("Plain Text")?
+                        .expect("A plain text syntax is available"),
                     Err(e) => return Err(e),
                 };
 


### PR DESCRIPTION
By forwarding the task to find the `Plain Text` syntax to `assets`. Not only does
the code become simpler; we also get rid of a call to `self.get_syntax_set()`
which is beneficial to the long term goal of replacing `syntaxes.bin` with
`minimal_syntaxes.bin`.

Note that the use of `.expect()` is not a regression in error handling. It was previously hidden in `.find_syntax_plain_text()`: https://docs.rs/syntect/4.6.0/src/syntect/parsing/syntax_set.rs.html#288-291