### PR TITLE
CICD: Make the 'cargo fmt' check a toplevel job

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -14,6 +14,13 @@ on:
       - '*'
 
 jobs:
+  ensure_cargo_fmt:
+    name: Ensure 'cargo fmt' has been run
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: cargo fmt -- --check
+
   min_version:
     name: Minimum supported rust version
     runs-on: ubuntu-20.04
@@ -27,12 +34,7 @@ jobs:
         toolchain: ${{ env.MIN_SUPPORTED_RUST_VERSION }}
         default: true
         profile: minimal # minimal component installation (ie, no documentation)
-        components: clippy, rustfmt
-    - name: Ensure `cargo fmt` has been run
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
+        components: clippy
     - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -18,6 +18,12 @@ jobs:
     name: Ensure 'cargo fmt' has been run
     runs-on: ubuntu-20.04
     steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+        profile: minimal
+        components: rustfmt
     - uses: actions/checkout@v2
     - run: cargo fmt -- --check
 


### PR DESCRIPTION
Mainly to make it easier to see what went wrong when CI fails.

If this ever gets of out sync with a particular Rust version, we can most likely
save the situation by introducing a `rustfmt.toml` file.

Note that I choose to make the config minimal (e.g. without `name`). I think it does not make things harder to understand. In fact, I think it makes things easier to understand and maintain. I also use the default Rust installation instead of installing our own. That's just unnecessary to do in this case.