### PR TITLE
Deny unsafe code in lib and bin

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_code)]
+
 mod app;
 mod assets;
 mod clap_app;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 //!     .unwrap();
 //! ```
 
+#![deny(unsafe_code)]
+
 mod macros;
 
 pub mod assets;


### PR DESCRIPTION
The deny also applies recursively to submodules.