### PR TITLE
Improve message on cache file is not existing

### DIFF
--- a/src/bin/bat/assets.rs
+++ b/src/bin/bat/assets.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fs;
+use std::io;
 
 use clap::crate_version;
 
@@ -52,6 +53,14 @@ pub fn assets_from_cache_or_binary(use_custom_assets: bool) -> Result<Highlighti
 
 fn clear_asset(filename: &str, description: &str) {
     print!("Clearing {} ... ", description);
-    fs::remove_file(PROJECT_DIRS.cache_dir().join(filename)).ok();
-    println!("okay");
+    let path = PROJECT_DIRS.cache_dir().join(filename);
+    match fs::remove_file(&path) {
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            println!("skipped (not present)");
+        }
+        Err(err) => {
+            println!("could not remove the cache file {:?}: {}", &path, err);
+        }
+        Ok(_) => println!("okay"),
+    }
 }


### PR DESCRIPTION
As you know [`Result::ok`](https://doc.rust-lang.org/std/result/enum.Result.html#method.ok) is a method to convert `Result<T, E>` to `Option<T>`. Using it without substituting the result to other place has not effect.

I thought those misusage aimed to check  no error happened basically. In the case `Result::unwrap` should be used. This PR fixes the `Result::ok` with `Result::unwrap` to ensure no error happened.

In the case of removing assets cache, an error is expected (when a cache does not exist). I added a better output in the case (rather than just saying 'okay').