### PR TITLE
Custom highlight range color support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "bugreport",
  "clap",
  "clircle",
+ "colors-transform",
  "console",
  "content_inspector",
  "dirs-next",
@@ -229,6 +230,12 @@ dependencies = [
  "serde",
  "winapi",
 ]
+
+[[package]]
+name = "colors-transform"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9226dbc05df4fb986f48d730b001532580883c4c06c5d1c213f4b34c1c157178"
 
 [[package]]
 name = "console"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ clircle = "0.3"
 bugreport = { version = "0.4", optional = true }
 dirs-next = { version = "2.0.0", optional = true }
 grep-cli = "0.1.6"
+colors-transform = "0.2.11"
 
 [dependencies.git2]
 version = "0.13"

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -8,7 +8,7 @@ fn main() {
         .line_numbers(true)
         .use_italics(true)
         // The following line will be highlighted in the output:
-        .highlight(line!() as usize)
+        .highlight(line!() as usize, None)
         .theme("1337")
         .wrapping_mode(WrappingMode::Character)
         .paging_mode(PagingMode::QuitIfOneScreen)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -20,7 +20,7 @@ use bat::{
     config::{Config, VisibleLines},
     error::*,
     input::Input,
-    line_range::{HighlightedLineRanges, LineRange, LineRanges},
+    line_range::{BasicLineRange, HighlightedLineRanges, LineRanges},
     style::{StyleComponent, StyleComponents},
     MappingTarget, PagingMode, SyntaxMapping, WrappingMode,
 };
@@ -216,7 +216,7 @@ impl App {
                 _ => VisibleLines::Ranges(
                     self.matches
                         .values_of("line-range")
-                        .map(|vs| vs.map(LineRange::from).collect())
+                        .map(|vs| vs.map(BasicLineRange::from).collect())
                         .transpose()?
                         .map(LineRanges::from)
                         .unwrap_or_default(),
@@ -229,7 +229,7 @@ impl App {
             highlighted_lines: self
                 .matches
                 .values_of("highlight-line")
-                .map(|ws| ws.map(LineRange::from).collect())
+                .map(|ws| ws.map(BasicLineRange::from).collect())
                 .transpose()?
                 .map(LineRanges::from)
                 .map(HighlightedLineRanges)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -96,7 +96,9 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                      '--highlight-line 30:40' highlights lines 30 to 40\n  \
                      '--highlight-line :40' highlights lines 1 to 40\n  \
                      '--highlight-line 40:' highlights lines 40 to the end of the file\n  \
-                     '--highlight-line 30:+10' highlights lines 30 to 40",
+                     '--highlight-line 30:+10' highlights lines 30 to 40\n  \
+                     '--highlight-line 40#ff0' highlights line 40 with yellow background color\n  \
+                     '--highlight-line 30:40#FF0000' highlights line 30 to 40 with white background color",
                 ),
         )
         .arg(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::line_range::{HighlightedLineRanges, LineRanges};
+use crate::line_range::{ColoredLineRange, HighlightedLineRanges, LineRange, LineRanges};
 #[cfg(feature = "paging")]
 use crate::paging::PagingMode;
 use crate::style::StyleComponents;
@@ -8,7 +8,7 @@ use crate::wrapping::WrappingMode;
 #[derive(Debug, Clone)]
 pub enum VisibleLines {
     /// Show all lines which are included in the line ranges
-    Ranges(LineRanges),
+    Ranges(LineRanges<LineRange>),
 
     #[cfg(feature = "git")]
     /// Only show lines surrounding added/deleted/modified lines
@@ -81,7 +81,7 @@ pub struct Config<'a> {
     pub use_italic_text: bool,
 
     /// Ranges of lines which should be highlighted with a special background color
-    pub highlighted_lines: HighlightedLineRanges,
+    pub highlighted_lines: HighlightedLineRanges<ColoredLineRange>,
 
     /// Whether or not to allow custom assets. If this is false or if custom assets (a.k.a.
     /// cached assets) are not available, assets from the binary will be used instead.
@@ -100,7 +100,10 @@ pub fn get_pager_executable(config_pager: Option<&str>) -> Option<String> {
 fn default_config_should_include_all_lines() {
     use crate::line_range::RangeCheckResult;
 
-    assert_eq!(LineRanges::default().check(17), RangeCheckResult::InRange);
+    assert_eq!(
+        LineRanges::<LineRange>::default().check(17),
+        RangeCheckResult::InRange(None)
+    );
 }
 
 #[test]
@@ -109,6 +112,6 @@ fn default_config_should_highlight_no_lines() {
 
     assert_ne!(
         Config::default().highlighted_lines.0.check(17),
-        RangeCheckResult::InRange
+        RangeCheckResult::InRange(None)
     );
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -197,7 +197,7 @@ impl<'b> Controller<'b> {
         printer: &mut dyn Printer,
         writer: &mut dyn Write,
         reader: &mut InputReader,
-        line_ranges: &LineRanges,
+        line_ranges: &LineRanges<crate::line_range::LineRange>,
     ) -> Result<()> {
         let mut line_buffer = Vec::new();
         let mut line_number: usize = 1;
@@ -216,7 +216,7 @@ impl<'b> Controller<'b> {
                     mid_range = false;
                 }
 
-                RangeCheckResult::InRange => {
+                RangeCheckResult::InRange(_) => {
                     if style_snip {
                         if first_range {
                             first_range = false;

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -1,4 +1,26 @@
+use std::fmt::Debug;
+
+use colors_transform::{Color as RgbColor, Rgb};
+use syntect::highlighting::Color;
+
 use crate::error::*;
+
+pub trait BasicLineRange: Default + Debug {
+    fn parse_range(range_raw: &str) -> Result<Self>
+    where
+        Self: Sized;
+    fn from(range_raw: &str) -> Result<Self>
+    where
+        Self: Sized;
+    fn get_lower(&self) -> usize;
+    fn get_upper(&self) -> usize;
+    fn is_inside(&self, line: usize) -> bool {
+        line >= self.get_lower() && line <= self.get_upper()
+    }
+    fn get_color(&self) -> Option<Color> {
+        None
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct LineRange {
@@ -6,27 +28,33 @@ pub struct LineRange {
     upper: usize,
 }
 
+#[derive(Debug, Clone)]
+pub struct ColoredLineRange {
+    lower: usize,
+    upper: usize,
+    color: Option<Color>,
+}
+
 impl Default for LineRange {
-    fn default() -> LineRange {
-        LineRange {
+    fn default() -> Self {
+        Self {
             lower: usize::min_value(),
             upper: usize::max_value(),
         }
     }
 }
 
-impl LineRange {
-    pub fn new(from: usize, to: usize) -> Self {
-        LineRange {
-            lower: from,
-            upper: to,
+impl Default for ColoredLineRange {
+    fn default() -> Self {
+        Self {
+            lower: usize::min_value(),
+            upper: usize::max_value(),
+            color: None,
         }
     }
+}
 
-    pub fn from(range_raw: &str) -> Result<LineRange> {
-        LineRange::parse_range(range_raw)
-    }
-
+impl BasicLineRange for LineRange {
     fn parse_range(range_raw: &str) -> Result<LineRange> {
         let mut new_range = LineRange::default();
 
@@ -66,70 +94,231 @@ impl LineRange {
         }
     }
 
-    pub(crate) fn is_inside(&self, line: usize) -> bool {
-        line >= self.lower && line <= self.upper
+    fn from(range_raw: &str) -> Result<Self> {
+        Self::parse_range(range_raw)
+    }
+
+    fn get_lower(&self) -> usize {
+        self.lower
+    }
+
+    fn get_upper(&self) -> usize {
+        self.upper
+    }
+}
+
+impl BasicLineRange for ColoredLineRange {
+    fn parse_range(range_raw: &str) -> Result<Self> {
+        let mut new_range = Self::default();
+        let parsing_error_msg = "Invalid range string";
+        let mut range_raw_parts = range_raw.split('#');
+        let range_raw = range_raw_parts.next().ok_or(parsing_error_msg)?;
+
+        if let Some(color) = range_raw_parts.next() {
+            let rgb_color = Rgb::from_hex_str(color).or(Err("Invalid range color"))?;
+            new_range.color = Some(Color {
+                r: rgb_color.get_red() as u8,
+                g: rgb_color.get_green() as u8,
+                b: rgb_color.get_blue() as u8,
+                a: 0xFF,
+            });
+        }
+
+        if range_raw.bytes().next().ok_or("Empty line range")? == b':' {
+            new_range.upper = range_raw[1..].parse().or(Err(parsing_error_msg))?;
+            return Ok(new_range);
+        } else if range_raw.bytes().last().ok_or("Empty line range")? == b':' {
+            new_range.lower = range_raw[..range_raw.len() - 1]
+                .parse()
+                .or(Err(parsing_error_msg))?;
+            return Ok(new_range);
+        }
+
+        let line_numbers: Vec<&str> = range_raw.split(':').collect();
+        match line_numbers.len() {
+            1 => {
+                new_range.lower = line_numbers[0].parse()?;
+                new_range.upper = new_range.lower;
+                Ok(new_range)
+            }
+            2 => {
+                new_range.lower = line_numbers[0].parse()?;
+
+                new_range.upper = if line_numbers[1].bytes().next() == Some(b'+') {
+                    let more_lines = &line_numbers[1][1..]
+                        .parse()
+                        .map_err(|_| "Invalid character after +")?;
+                    new_range.lower + more_lines
+                } else {
+                    line_numbers[1].parse()?
+                };
+
+                Ok(new_range)
+            }
+            _ => Err(
+                "Line range contained more than one ':' character. Expected format: 'N' or 'N:M'"
+                    .into(),
+            ),
+        }
+    }
+
+    fn from(range_raw: &str) -> Result<Self> {
+        Self::parse_range(range_raw)
+    }
+
+    fn get_lower(&self) -> usize {
+        self.lower
+    }
+
+    fn get_upper(&self) -> usize {
+        self.upper
+    }
+
+    fn get_color(&self) -> Option<Color> {
+        self.color
+    }
+}
+
+impl LineRange {
+    pub fn new(from: usize, to: usize) -> Self {
+        LineRange {
+            lower: from,
+            upper: to,
+        }
+    }
+}
+
+impl ColoredLineRange {
+    pub fn new(from: usize, to: usize, color: Option<Color>) -> Self {
+        Self {
+            lower: from,
+            upper: to,
+            color,
+        }
     }
 }
 
 #[test]
 fn test_parse_full() {
-    let range = LineRange::from("40:50").expect("Shouldn't fail on test!");
+    let range: LineRange = BasicLineRange::from("40:50").expect("Shouldn't fail on test!");
     assert_eq!(40, range.lower);
     assert_eq!(50, range.upper);
 }
 
 #[test]
 fn test_parse_partial_min() {
-    let range = LineRange::from(":50").expect("Shouldn't fail on test!");
+    let range: LineRange = BasicLineRange::from(":50").expect("Shouldn't fail on test!");
     assert_eq!(usize::min_value(), range.lower);
     assert_eq!(50, range.upper);
 }
 
 #[test]
 fn test_parse_partial_max() {
-    let range = LineRange::from("40:").expect("Shouldn't fail on test!");
+    let range: LineRange = BasicLineRange::from("40:").expect("Shouldn't fail on test!");
     assert_eq!(40, range.lower);
     assert_eq!(usize::max_value(), range.upper);
 }
 
 #[test]
 fn test_parse_single() {
-    let range = LineRange::from("40").expect("Shouldn't fail on test!");
+    let range: LineRange = BasicLineRange::from("40").expect("Shouldn't fail on test!");
     assert_eq!(40, range.lower);
     assert_eq!(40, range.upper);
 }
 
 #[test]
 fn test_parse_fail() {
-    let range = LineRange::from("40:50:80");
+    let range: Result<LineRange> = BasicLineRange::from("40:50:80");
     assert!(range.is_err());
-    let range = LineRange::from("40::80");
+    let range: Result<LineRange> = BasicLineRange::from("40::80");
     assert!(range.is_err());
-    let range = LineRange::from(":40:");
+    let range: Result<LineRange> = BasicLineRange::from(":40:");
     assert!(range.is_err());
 }
 
 #[test]
 fn test_parse_plus() {
-    let range = LineRange::from("40:+10").expect("Shouldn't fail on test!");
+    let range: LineRange = BasicLineRange::from("40:+10").expect("Shouldn't fail on test!");
     assert_eq!(40, range.lower);
     assert_eq!(50, range.upper);
 }
 
 #[test]
 fn test_parse_plus_fail() {
-    let range = LineRange::from("40:+z");
+    let range: Result<LineRange> = BasicLineRange::from("40:+z");
     assert!(range.is_err());
-    let range = LineRange::from("40:+-10");
+    let range: Result<LineRange> = BasicLineRange::from("40:+-10");
     assert!(range.is_err());
-    let range = LineRange::from("40:+");
+    let range: Result<LineRange> = BasicLineRange::from("40:+");
     assert!(range.is_err());
+}
+
+#[test]
+fn test_parse_colored_white() {
+    let range: ColoredLineRange =
+        BasicLineRange::from("40:50#fff").expect("Shouldn't fail on test!");
+    assert_eq!(40, range.lower);
+    assert_eq!(50, range.upper);
+    assert!(range.color.is_some());
+    assert_eq!(Color::WHITE, range.color.unwrap());
+}
+
+#[test]
+fn test_parse_colored_black_long() {
+    let range: ColoredLineRange =
+        BasicLineRange::from("40:50#000000").expect("Shouldn't fail on test!");
+    assert_eq!(40, range.lower);
+    assert_eq!(50, range.upper);
+    assert!(range.color.is_some());
+    assert_eq!(Color::BLACK, range.color.unwrap());
+}
+
+#[test]
+fn test_parse_invalid_colored_value() {
+    let range: Result<ColoredLineRange> = BasicLineRange::from("40:50#00");
+    assert!(range.is_err());
+    let range: Result<ColoredLineRange> = BasicLineRange::from("40:50#0000");
+    assert!(range.is_err());
+    assert_eq!(range.unwrap_err().to_string(), "Invalid range color");
+}
+
+#[test]
+fn test_parse_single_colored_line() {
+    let range: ColoredLineRange = BasicLineRange::from("40#fff").expect("Shouldn't fail on test!");
+    assert_eq!(Color::WHITE, range.color.unwrap());
+}
+
+#[test]
+fn test_parse_colored_plus() {
+    let range: ColoredLineRange =
+        BasicLineRange::from("40:+5#000000").expect("Shouldn't fail on test!");
+    assert_eq!(40, range.lower);
+    assert_eq!(45, range.upper);
+    assert!(range.color.is_some());
+    assert_eq!(Color::BLACK, range.color.unwrap());
+}
+
+#[test]
+fn test_parse_colored_second_only() {
+    let range: ColoredLineRange =
+        BasicLineRange::from(":40#000000").expect("Shouldn't fail on test!");
+    assert_eq!(0, range.lower);
+    assert_eq!(40, range.upper);
+    assert!(range.color.is_some());
+    assert_eq!(Color::BLACK, range.color.unwrap());
+}
+
+#[test]
+fn test_parse_colored_uppercase() {
+    let range: ColoredLineRange = BasicLineRange::from("40#FFF").expect("Shouldn't fail on test!");
+    assert!(range.color.is_some());
+    assert_eq!(Color::WHITE, range.color.unwrap());
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum RangeCheckResult {
     // Within one of the given ranges
-    InRange,
+    InRange(Option<Color>),
 
     // Before the first range or within two ranges
     BeforeOrBetweenRanges,
@@ -139,24 +328,24 @@ pub enum RangeCheckResult {
 }
 
 #[derive(Debug, Clone)]
-pub struct LineRanges {
-    ranges: Vec<LineRange>,
+pub struct LineRanges<T: BasicLineRange> {
+    ranges: Vec<T>,
     largest_upper_bound: usize,
 }
 
-impl LineRanges {
-    pub fn none() -> LineRanges {
+impl<T: BasicLineRange> LineRanges<T> {
+    pub fn none() -> LineRanges<T> {
         LineRanges::from(vec![])
     }
 
-    pub fn all() -> LineRanges {
-        LineRanges::from(vec![LineRange::default()])
+    pub fn all() -> LineRanges<T> {
+        LineRanges::from(vec![T::default()])
     }
 
-    pub fn from(ranges: Vec<LineRange>) -> LineRanges {
-        let largest_upper_bound = ranges
+    pub fn from(ranges: Vec<T>) -> LineRanges<T> {
+        let largest_upper_bound: usize = ranges
             .iter()
-            .map(|r| r.upper)
+            .map(|r| r.get_upper())
             .max()
             .unwrap_or(usize::max_value());
         LineRanges {
@@ -166,8 +355,9 @@ impl LineRanges {
     }
 
     pub(crate) fn check(&self, line: usize) -> RangeCheckResult {
-        if self.ranges.iter().any(|r| r.is_inside(line)) {
-            RangeCheckResult::InRange
+        let matching_line_range = self.ranges.iter().find(|r| r.is_inside(line));
+        if let Some(line_range) = matching_line_range {
+            RangeCheckResult::InRange(line_range.get_color())
         } else if line < self.largest_upper_bound {
             RangeCheckResult::BeforeOrBetweenRanges
         } else {
@@ -176,78 +366,82 @@ impl LineRanges {
     }
 }
 
-impl Default for LineRanges {
+impl<T: BasicLineRange> Default for LineRanges<T> {
     fn default() -> Self {
         Self::all()
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct HighlightedLineRanges(pub LineRanges);
+pub struct HighlightedLineRanges<T: BasicLineRange>(pub LineRanges<T>);
 
-impl Default for HighlightedLineRanges {
+impl<T: BasicLineRange> Default for HighlightedLineRanges<T> {
     fn default() -> Self {
         HighlightedLineRanges(LineRanges::none())
     }
 }
 
 #[cfg(test)]
-fn ranges(rs: &[&str]) -> LineRanges {
-    LineRanges::from(rs.iter().map(|r| LineRange::from(r).unwrap()).collect())
+fn ranges<T: BasicLineRange>(rs: &[&str]) -> LineRanges<T> {
+    LineRanges::from(
+        rs.iter()
+            .map(|r| BasicLineRange::from(r).unwrap())
+            .collect(),
+    )
 }
 
 #[test]
 fn test_ranges_simple() {
-    let ranges = ranges(&["3:8"]);
+    let ranges: LineRanges<LineRange> = ranges(&["3:8"]);
 
     assert_eq!(RangeCheckResult::BeforeOrBetweenRanges, ranges.check(2));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(5));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(5));
     assert_eq!(RangeCheckResult::AfterLastRange, ranges.check(9));
 }
 
 #[test]
 fn test_ranges_advanced() {
-    let ranges = ranges(&["3:8", "11:20", "25:30"]);
+    let ranges: LineRanges<LineRange> = ranges(&["3:8", "11:20", "25:30"]);
 
     assert_eq!(RangeCheckResult::BeforeOrBetweenRanges, ranges.check(2));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(5));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(5));
     assert_eq!(RangeCheckResult::BeforeOrBetweenRanges, ranges.check(9));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(11));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(11));
     assert_eq!(RangeCheckResult::BeforeOrBetweenRanges, ranges.check(22));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(28));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(28));
     assert_eq!(RangeCheckResult::AfterLastRange, ranges.check(31));
 }
 
 #[test]
 fn test_ranges_open_low() {
-    let ranges = ranges(&["3:8", ":5"]);
+    let ranges: LineRanges<LineRange> = ranges(&["3:8", ":5"]);
 
-    assert_eq!(RangeCheckResult::InRange, ranges.check(1));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(3));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(7));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(1));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(3));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(7));
     assert_eq!(RangeCheckResult::AfterLastRange, ranges.check(9));
 }
 
 #[test]
 fn test_ranges_open_high() {
-    let ranges = ranges(&["3:", "2:5"]);
+    let ranges: LineRanges<LineRange> = ranges(&["3:", "2:5"]);
 
     assert_eq!(RangeCheckResult::BeforeOrBetweenRanges, ranges.check(1));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(3));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(5));
-    assert_eq!(RangeCheckResult::InRange, ranges.check(9));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(3));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(5));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(9));
 }
 
 #[test]
 fn test_ranges_all() {
-    let ranges = LineRanges::all();
+    let ranges: LineRanges<LineRange> = LineRanges::all();
 
-    assert_eq!(RangeCheckResult::InRange, ranges.check(1));
+    assert_eq!(RangeCheckResult::InRange(None), ranges.check(1));
 }
 
 #[test]
 fn test_ranges_none() {
-    let ranges = LineRanges::none();
+    let ranges: LineRanges<LineRange> = LineRanges::none();
 
-    assert_ne!(RangeCheckResult::InRange, ranges.check(1));
+    assert_ne!(RangeCheckResult::InRange(None), ranges.check(1));
 }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::path::Path;
 
 use console::Term;
-use syntect::parsing::SyntaxReference;
+use syntect::{highlighting::Color, parsing::SyntaxReference};
 
 use crate::{
     assets::HighlightingAssets,
@@ -10,7 +10,7 @@ use crate::{
     controller::Controller,
     error::Result,
     input,
-    line_range::{HighlightedLineRanges, LineRange, LineRanges},
+    line_range::{ColoredLineRange, HighlightedLineRanges, LineRange, LineRanges},
     style::{StyleComponent, StyleComponents},
     SyntaxMapping, WrappingMode,
 };
@@ -33,7 +33,7 @@ pub struct PrettyPrinter<'a> {
     config: Config<'a>,
     assets: HighlightingAssets,
 
-    highlighted_lines: Vec<LineRange>,
+    highlighted_lines: Vec<ColoredLineRange>,
     term_width: Option<usize>,
     active_style_components: ActiveStyleComponents,
 }
@@ -197,7 +197,7 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     /// Specify the lines that should be printed (default: all)
-    pub fn line_ranges(&mut self, ranges: LineRanges) -> &mut Self {
+    pub fn line_ranges(&mut self, ranges: LineRanges<LineRange>) -> &mut Self {
         self.config.visible_lines = VisibleLines::Ranges(ranges);
         self
     }
@@ -205,16 +205,18 @@ impl<'a> PrettyPrinter<'a> {
     /// Specify a line that should be highlighted (default: none).
     /// This can be called multiple times to highlight more than one
     /// line. See also: highlight_range.
-    pub fn highlight(&mut self, line: usize) -> &mut Self {
-        self.highlighted_lines.push(LineRange::new(line, line));
+    pub fn highlight(&mut self, line: usize, color: Option<Color>) -> &mut Self {
+        self.highlighted_lines
+            .push(ColoredLineRange::new(line, line, color));
         self
     }
 
     /// Specify a range of lines that should be highlighted (default: none).
     /// This can be called multiple times to highlight more than one range
     /// of lines.
-    pub fn highlight_range(&mut self, from: usize, to: usize) -> &mut Self {
-        self.highlighted_lines.push(LineRange::new(from, to));
+    pub fn highlight_range(&mut self, from: usize, to: usize, color: Option<Color>) -> &mut Self {
+        self.highlighted_lines
+            .push(ColoredLineRange::new(from, to, color));
         self
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -416,13 +416,10 @@ impl<'a> Printer for InteractivePrinter<'a> {
         let mut cursor_total: usize = 0;
         let mut panel_wrap: Option<String> = None;
 
-        // Line highlighting
-        let highlight_this_line =
-            self.config.highlighted_lines.0.check(line_number) == RangeCheckResult::InRange;
-
-        let background_color = self
-            .background_color_highlight
-            .filter(|_| highlight_this_line);
+        let background_color = match self.config.highlighted_lines.0.check(line_number) {
+            RangeCheckResult::InRange(color) => color.or(self.background_color_highlight),
+            _ => None,
+        };
 
         // Line decorations.
         if self.panel_width > 0 {


### PR DESCRIPTION
Implements https://github.com/sharkdp/bat/issues/1699, and related to https://github.com/sharkdp/bat/issues/339

Basically, adds support for css hex color in line range - i.e. `30:40#ff0`.

Please take this PR with a grain of salt. Note that it might not be going in the right direction that maintainers would like. I started working on https://github.com/sharkdp/bat/issues/1699, and the change grew substantially, but then I saw that https://github.com/sharkdp/bat/issues/339 is the preferred way to solve the issue.

This is just my idea how we could implement this, and maybe a place for further discussion. Please feel free to request changes or even completely discard this PR if you think this is not the way `bat` should evolve.
