### PR TITLE
Make grep-cli optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ minimal-application = [
     "wild",
 ]
 git = ["git2"] # Support indicating git modifications
-paging = ["shell-words"] # Support applying a pager on the output
+paging = ["shell-words", "grep-cli"] # Support applying a pager on the output
 # Add "syntect/plist-load" when https://github.com/trishume/syntect/pull/345 reaches us
 build-assets = ["syntect/yaml-load", "syntect/dump-create"]
 
@@ -64,7 +64,7 @@ path_abs = { version = "0.5", default-features = false }
 clircle = "0.3"
 bugreport = { version = "0.4", optional = true }
 dirs-next = { version = "2.0.0", optional = true }
-grep-cli = "0.1.6"
+grep-cli = { version = "0.1.6", optional = true }
 
 [dependencies.git2]
 version = "0.13"

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -229,7 +229,7 @@ fn invoke_bugreport(app: &App) {
     let pager = bat::config::get_pager_executable(app.matches.value_of("pager"))
         .unwrap_or_else(|| "less".to_owned()); // FIXME: Avoid non-canonical path to "less".
 
-    let report = bugreport!()
+    let mut report = bugreport!()
         .info(SoftwareVersion::default())
         .info(OperatingSystem::default())
         .info(CommandLine::default())
@@ -255,14 +255,13 @@ fn invoke_bugreport(app: &App) {
         .info(FileContent::new("Config file", config_file()))
         .info(CompileTimeInformation::default());
 
-    let mut report = if let Ok(resolved_path) = grep_cli::resolve_binary(pager) {
-        report.info(CommandOutput::new(
+    #[cfg(feature = "paging")]
+    if let Ok(resolved_path) = grep_cli::resolve_binary(pager) {
+        report = report.info(CommandOutput::new(
             "Less version",
             resolved_path,
             &["--version"],
         ))
-    } else {
-        report
     };
 
     report.print::<Markdown>();


### PR DESCRIPTION
`grep-cli` crate is used for resolving a path of pager command safely. So it is only necessary with `paging` feature. This PR changes it to optional dependency so that installing bat as library with `--no-default-features` can reduce number of dependencies (111 → 108).