### PR TITLE
Reject additional incomplete syntax definitions

### DIFF
--- a/src/assets/build_assets.rs
+++ b/src/assets/build_assets.rs
@@ -117,7 +117,7 @@ fn print_unlinked_contexts(syntax_set: &SyntaxSet) -> Result<()> {
 
     // Allowed since they already exist
     let mut allowed = std::collections::BTreeSet::<String>::new();
-    for a in [
+    for a in &[
         "Syntax 'Svelte' with scope 'text.html.svelte' has unresolved context reference ByScope { scope: <source.livescript>, sub_context: None }",
         "Syntax 'Svelte' with scope 'text.html.svelte' has unresolved context reference ByScope { scope: <source.postcss>, sub_context: None }",
         "Syntax 'Vue Component' with scope 'text.html.vue' has unresolved context reference ByScope { scope: <source.livescript>, sub_context: None }",


### PR DESCRIPTION
We currently ship two incomplete syntaxes by default, namely `Svelte` and `Vue Component`. This can make bat crash. See #915.

Since we don't want bat to crash, I think we should make sure to not ship any additional incomplete syntaxes. Here is a Draft PR on how we could ensure that.

We might want to make it opt-in (for CI) or opt-out (for users building custom assets), but before we tweak that I would like to hear what you think about the general idea.

I actually don't think it is a viable option to make syntect handle incomplete syntaxes. Even if syntect ignores missing syntaxes, what should it do instead? It seems to me as if the risk is high for follow-up problems if syntect tries to ignores problems like these.
