### PR TITLE
create_highlighted_versions: fix misleading/wrong error message

### DIFF
--- a/tests/syntax-tests/create_highlighted_versions.py
+++ b/tests/syntax-tests/create_highlighted_versions.py
@@ -91,7 +91,7 @@ def create_highlighted_versions(output_basepath):
             p.map(create_highlighted_version, sources)
     except subprocess.CalledProcessError as err:
         print(
-            "=== Error: Could not highlight source file '{}".format(source),
+            "=== Error: Could not highlight source file:\n" + " ".join(err.cmd),
             file=sys.stderr,
         )
         print(


### PR DESCRIPTION
See comment in https://github.com/sharkdp/bat/pull/1843/files/f7fc62123999fe41034d91f2f878b290b88af339#r734944312

I first tried to send back the `source` parameter from the worker thread with a custom Exception, but ran into some "pickling" problems. This is not as pretty as before, but actually contains more information.