### PR TITLE
Add `bat::PrettyPrinter::clear_highlights`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ## `bat` as a library
 
 - Make `bat::PrettyPrinter::syntaxes()` iterate over new `bat::Syntax` struct instead of `&syntect::parsing::SyntaxReference`. See #2222 (@Enselic)
+- Clear highlights after printing, see #1919 and #1920 (@rhysd)
 
 
 # v0.21.0

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -229,6 +229,14 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Clear highlighted lines added by [`PrettyPrinter::highlight`] and
+    /// [`PrettyPrinter::highlight_range`]. This is useful when reusing a
+    /// `PrettyPrinter` instance for multiple different ranges.
+    pub fn clear_highlights(&mut self) -> &mut Self {
+        self.highlighted_lines.clear();
+        self
+    }
+
     /// Specify the highlighting theme
     pub fn theme(&mut self, theme: impl AsRef<str>) -> &mut Self {
         self.config.theme = theme.as_ref().to_owned();

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -229,14 +229,6 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
-    /// Clear highlighted lines added by [`PrettyPrinter::highlight`] and
-    /// [`PrettyPrinter::highlight_range`]. This is useful when reusing a
-    /// `PrettyPrinter` instance for multiple different ranges.
-    pub fn clear_highlights(&mut self) -> &mut Self {
-        self.highlighted_lines.clear();
-        self
-    }
-
     /// Specify the highlighting theme
     pub fn theme(&mut self, theme: impl AsRef<str>) -> &mut Self {
         self.config.theme = theme.as_ref().to_owned();
@@ -271,8 +263,8 @@ impl<'a> PrettyPrinter<'a> {
     /// If you want to call 'print' multiple times, you have to call the appropriate
     /// input_* methods again.
     pub fn print(&mut self) -> Result<bool> {
-        self.config.highlighted_lines =
-            HighlightedLineRanges(LineRanges::from(self.highlighted_lines.clone()));
+        let highlight_lines = std::mem::take(&mut self.highlighted_lines);
+        self.config.highlighted_lines = HighlightedLineRanges(LineRanges::from(highlight_lines));
         self.config.term_width = self
             .term_width
             .unwrap_or_else(|| Term::stdout().size().1 as usize);


### PR DESCRIPTION
Fixes #1919

With this API, the code written in #1919 can be improved as follows:

```rust
use bat::PrettyPrinter;

let targets: (PathBuf, Vec<(usize, usize)>) = vec![];

let mut pp = PrettyPrinter::new();
for (path, ranges) in targets.iter() {
    pp.input_file(path);
    for (start, end) in ranges.iter() {
        pp.highlight_range(*start, *end);
    }

    pp.print().unwrap();
    // Clear highlights for next iteration
    pp.clear_highlights();
}
```