### PR TITLE
Include git hash in `bat -V` and `bat --version` output if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Add PowerShell completion, see #1826 (@rashil2000)
 - Minimum supported Rust version (MSRV) bumped to 1.46
+- Include git hash in `bat -V` and `bat --version` output if present. See #1921 (@Enselic)
 
 ## Syntaxes
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -2,6 +2,21 @@ use clap::{crate_name, crate_version, App as ClapApp, AppSettings, Arg, ArgGroup
 use std::env;
 use std::path::Path;
 
+lazy_static::lazy_static! {
+    static ref VERSION: String = {
+        #[cfg(feature = "bugreport")]
+        let git_version = bugreport::git_version!(fallback = "");
+        #[cfg(not(feature = "bugreport"))]
+        let git_version = "";
+
+        if git_version.is_empty() {
+            crate_version!().to_string()
+        } else {
+            format!("{} ({})", crate_version!(), git_version)
+        }
+    };
+}
+
 pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
     let clap_color_setting = if interactive_output && env::var_os("NO_COLOR").is_none() {
         AppSettings::ColoredHelp
@@ -10,7 +25,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
     };
 
     let mut app = ClapApp::new(crate_name!())
-        .version(crate_version!())
+        .version(VERSION.as_str())
         .global_setting(clap_color_setting)
         .global_setting(AppSettings::DeriveDisplayOrder)
         .global_setting(AppSettings::UnifiedHelpMessage)


### PR DESCRIPTION
I had to use a `lazy_static` due to the strange clap API that only accepts a reference to a version string. And, in our current code, only a 'static reference to a version string is accepted. Code could of course be refactored, but it would be way more messy.

I have several binaries of `bat` lying around everywhere, and with this PR, I (and anyone else of course) can just do `bat -V` to find out exactly what version of bat is at hand. Right now I have to do `bat --diagnostics | head`, which is too unergonomic for my taste.

I could of course have a local script to avoid repetition, but who wants to local scripts for these kinds of things?

The output looks like this:
```
% cargo run -- -V
bat 0.18.3 (9291a79)

% cargo run -- --version
bat 0.18.3 (9291a79)
```

which is identical to the output format in `--diagnostic`:

```
% cargo run -- --diagnostic | head -n 3
#### Software version

bat 0.18.3 (9291a79)
```

If no git repo is available at build time, the output is the same as before:

```
% touch src/bin/bat/main.rs # force rebuild

% GIT_DIR=/not-present cargo run -- -V
bat 0.18.3

% GIT_DIR=/not-present cargo run -- --version
bat 0.18.3
```