### PR TITLE
Blend alpha value of gutter foreground color

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -29,7 +29,7 @@ use crate::error::*;
 use crate::input::OpenedInput;
 use crate::line_range::RangeCheckResult;
 use crate::preprocessor::{expand_tabs, replace_nonprintable};
-use crate::terminal::{as_terminal_escaped, to_ansi_color};
+use crate::terminal::{as_terminal_escaped, blend_foreground_alpha, to_ansi_color};
 use crate::wrapping::WrappingMode;
 
 pub(crate) trait Printer {
@@ -647,7 +647,12 @@ impl Colors {
                 // Note: It might be the special value #00000001, in which case
                 // to_ansi_color returns None and we use an empty Style
                 // (resulting in the terminal's default foreground color).
-                Some(c) => to_ansi_color(c, true_color),
+                Some(mut fg) => {
+                    if let Some(bg) = theme.settings.background {
+                        fg = blend_foreground_alpha(fg, bg)
+                    }
+                    to_ansi_color(fg, true_color)
+                }
                 // Otherwise, use a specific fallback color.
                 None => Some(Fixed(DEFAULT_GUTTER_COLOR)),
             },

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -101,3 +101,55 @@ pub fn as_terminal_escaped(
     style.background = background_color.and_then(|c| to_ansi_color(c, true_color));
     style.paint(text).to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syntect::highlighting::Color;
+
+    #[test]
+    fn test_blend_foreground_alpha() {
+        let bg = Color {
+            r: 255,
+            g: 255,
+            b: 255,
+            a: 255,
+        };
+        let fg = Color {
+            r: 30,
+            g: 40,
+            b: 50,
+            a: 128,
+        };
+        let c = blend_foreground_alpha(fg, bg);
+        assert_eq!(
+            c,
+            Color {
+                r: 142,
+                g: 147,
+                b: 152,
+                a: 255,
+            },
+        );
+
+        // Special cases
+
+        let pass_through = Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 1,
+        };
+        let c = blend_foreground_alpha(pass_through, bg);
+        assert_eq!(c, pass_through);
+
+        let ansi_16_color = Color {
+            r: 1,
+            g: 0,
+            b: 0,
+            a: 0,
+        };
+        let c = blend_foreground_alpha(ansi_16_color, bg);
+        assert_eq!(c, ansi_16_color);
+    }
+}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -3,6 +3,27 @@ use ansi_term::{self, Style};
 
 use syntect::highlighting::{self, FontStyle};
 
+pub fn blend_foreground_alpha(
+    fg: highlighting::Color,
+    bg: highlighting::Color,
+) -> highlighting::Color {
+    if fg.a == 255 || fg.a == 0 || fg.a == 1 {
+        return fg;
+    }
+
+    let ratio = fg.a as u32;
+    let r = (fg.r as u32 * ratio + bg.r as u32 * (255 - ratio)) / 255;
+    let g = (fg.g as u32 * ratio + bg.g as u32 * (255 - ratio)) / 255;
+    let b = (fg.b as u32 * ratio + bg.b as u32 * (255 - ratio)) / 255;
+
+    highlighting::Color {
+        r: r as u8,
+        g: g as u8,
+        b: b as u8,
+        a: 255,
+    }
+}
+
 pub fn to_ansi_color(color: highlighting::Color, true_color: bool) -> Option<ansi_term::Color> {
     if color.a == 0 {
         // Themes can specify one of the user-configurable terminal colors by


### PR DESCRIPTION
Currently bat ignores an alpha value of gutter foreground color. This breaks gutter colors of some color themes. Here is the example with `Nord` theme:

- Current master branch

<img width="521" alt="before" src="https://user-images.githubusercontent.com/823277/141673768-898786ea-f68d-4b55-a693-a0110e4a3eaa.png">

- This PR

<img width="521" alt="after" src="https://user-images.githubusercontent.com/823277/141673772-2e0a02e5-0030-4613-bb6f-679c6e2a45ac.png">

As you see, gutter color of `Nord` theme is very light on current master branch. This is because the gutter color has actually an alpha value smaller than 255, which makes the color darker.

With this PR, the alpha value is correctly considered by blending the foreground color and the background color on initializing a printer instance.
