### PR TITLE
run-benchmarks.sh: Add new test 'Startup time with syntax highlighting'

### DIFF
--- a/tests/benchmarks/run-benchmarks.sh
+++ b/tests/benchmarks/run-benchmarks.sh
@@ -93,6 +93,16 @@ hyperfine \
 cat "$RESULT_DIR/startup-time.md" >> "$REPORT"
 
 
+heading "Startup time with syntax highlighting"
+hyperfine \
+	"$(printf "%q" "$BAT") --no-config --color=always test-src/small-Markdown-file.md" \
+	--command-name "bat … small-Markdown-file.md" \
+	--warmup "$WARMUP_COUNT" \
+    --export-markdown "$RESULT_DIR/startup-time-with-syntax-highlighting.md" \
+    --export-json "$RESULT_DIR/startup-time-with-syntax-highlighting.json"
+cat "$RESULT_DIR/startup-time-with-syntax-highlighting.md" >> "$REPORT"
+
+
 heading "Plain-text speed"
 hyperfine \
 	"$(printf "%q" "$BAT") --no-config --language=txt --style=plain test-src/numpy_test_multiarray.py" \

--- a/tests/benchmarks/test-src/small-Markdown-file.md
+++ b/tests/benchmarks/test-src/small-Markdown-file.md
@@ -1,0 +1,3 @@
+# Keep this file small, we want to measure bat startup time, not speed of Markdown highlighting!
+
+The Markdown syntax definition references ~18 other syntaxes, so without lazy-loading, it will be slow to load.


### PR DESCRIPTION
Performance characteristics of the file used for the test:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat-v0.18.3` | 112.4 ± 1.6 | 109.9 | 116.9 | 3.46 ± 0.16 |
| `bat-minimal_assets.bin` (never managed to solve startup for Markdown files)  | 117.3 ± 1.8 | 114.3 | 120.6 | 3.61 ± 0.16 |
| `bat-syntect-master` (with syntax lazy-loading) | 32.5 ± 1.4 | 30.4 | 38.5 | 1.00 |


Example output of `run-benchmarks.sh`:

## `bat` benchmark results

### Startup time

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat` | 10.8 ± 1.2 | 9.7 | 19.4 | 1.00 |

### Startup time with syntax highlighting

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat … small-Markdown-file.md` | 32.3 ± 2.6 | 29.8 | 46.9 | 1.00 |

...