### PR TITLE
run-benchmarks.sh: Add third 'Startup time' variant

### DIFF
--- a/tests/benchmarks/run-benchmarks.sh
+++ b/tests/benchmarks/run-benchmarks.sh
@@ -95,12 +95,22 @@ cat "$RESULT_DIR/startup-time.md" >> "$REPORT"
 
 heading "Startup time with syntax highlighting"
 hyperfine \
-	"$(printf "%q" "$BAT") --no-config --color=always test-src/small-Markdown-file.md" \
-	--command-name "bat … small-Markdown-file.md" \
+	"$(printf "%q" "$BAT") --no-config --color=always test-src/small-CpuInfo-file.cpuinfo" \
+	--command-name "bat … small-CpuInfo-file.cpuinfo" \
 	--warmup "$WARMUP_COUNT" \
     --export-markdown "$RESULT_DIR/startup-time-with-syntax-highlighting.md" \
     --export-json "$RESULT_DIR/startup-time-with-syntax-highlighting.json"
 cat "$RESULT_DIR/startup-time-with-syntax-highlighting.md" >> "$REPORT"
+
+
+heading "Startup time with syntax with dependencies"
+hyperfine \
+	"$(printf "%q" "$BAT") --no-config --color=always test-src/small-Markdown-file.md" \
+	--command-name "bat … small-Markdown-file.md" \
+	--warmup "$WARMUP_COUNT" \
+    --export-markdown "$RESULT_DIR/startup-time-with-syntax-with-dependencies.md" \
+    --export-json "$RESULT_DIR/startup-time-with-syntax-with-dependencies.json"
+cat "$RESULT_DIR/startup-time-with-syntax-with-dependencies.md" >> "$REPORT"
 
 
 heading "Plain-text speed"

--- a/tests/benchmarks/test-src/small-CpuInfo-file.cpuinfo
+++ b/tests/benchmarks/test-src/small-CpuInfo-file.cpuinfo
@@ -1,0 +1,1 @@
+OneColor : AnotherColor


### PR DESCRIPTION
Using Markdown for a startup test is useful since it has so many dependencies on
other syntaxes. So such a test makes sure that lazy-loading of syntaxes work.

It is however also useful to measure the startup time of bat when the time to
load a syntax is very small, and the measured startup time has mostly non-syntax
related causes. Such as:
 * Parsing arguments
 * Setting up syntax mappings
 * Loading themes

This commit adds such a test. It uses the CpuInfo syntax which is very small.
Only 14 lines, compared to the 1581 lines that Markdown is (not including the
size of its included syntaxes).

This command can be used to get an approximation of the size of syntaxes, and
thus how expensive they are to lazy-load:

    find -name *.sublime-syntax -print0 | xargs --null wc -l | sort -n -r

Example output from `run-benchmarks.sh`:

## `bat` benchmark results

### Startup time

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat` | 10.9 ± 1.0 | 9.6 | 14.0 | 1.00 |

### Startup time with syntax highlighting

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat … small-CpuInfo-file.cpuinfo` | 19.2 ± 0.9 | 17.7 | 22.3 | 1.00 |

### Startup time with syntax with dependencies

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bat … small-Markdown-file.md` | 32.0 ± 1.3 | 30.1 | 37.2 | 1.00 |

### Plain-text speed

...

From this we can deduce that it takes ~10 ms purely to lazy-load the Markdown syntax (without dependencies). (The above test using a build of bat with lazy-loading of syntaxes.)