### PR TITLE
CICD: Add check for accidental inclusion of GPL:ed code

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -27,6 +27,15 @@ jobs:
     - uses: actions/checkout@v2
     - run: cargo fmt -- --check
 
+  license_checks:
+    name: License checks
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true # we especially want to perform license checks on submodules
+    - run: tests/scripts/license-checks.sh
+
   min_version:
     name: Minimum supported rust version
     runs-on: ubuntu-20.04

--- a/tests/scripts/license-checks.sh
+++ b/tests/scripts/license-checks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+# Make sure that we don't accidentally include GPL licenced files
+gpl_term="General Public License"
+gpl_excludes=(
+    # Snippet expands to GPL, but is not under GPL
+    ":(exclude)assets/syntaxes/01_Packages/Matlab/Snippets/Octave-function.sublime-snippet"
+
+    # 'gpl_term' matches itself :D
+    ":(exclude)tests/scripts/license-checks.sh"
+
+    # Contains a reference to GPL, but is not under GPL
+    ":(exclude)tests/syntax-tests/source/Java Server Page (JSP)/LICENSE.md"
+)
+gpl_occurances=$(git grep --recurse-submodules "${gpl_term}" -- "${gpl_excludes[@]}" || true)
+
+if [ -z "${gpl_occurances}" ]; then
+    echo "PASS: No files under GPL were found"
+else
+    echo "FAIL: GPL:ed code is not compatible with bat, but occurances of '${gpl_term}' were found:"
+    echo "${gpl_occurances}"
+    exit 1
+fi


### PR DESCRIPTION
I have confirmed that the script catches the problem that #1960 fixes.