### PR TITLE
release-checklist.md: Update `cargo outdated` section with link and arg

### DIFF
--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -6,9 +6,10 @@ See this page for a good overview: https://deps.rs/repo/github/sharkdp/bat
 
 - [ ] Optional: update dependencies with `cargo update`. This is also done by
       dependabot, so it is not strictly necessary.
-- [ ] Check for outdated dependencies (`cargo outdated`) and decide for each of
-      them whether we want to (manually) upgrade. This will require changes to
-      `Cargo.toml`.
+- [ ] Install [cargo-outdated](https://crates.io/crates/cargo-outdated). Check
+      for outdated dependencies with `cargo outdated --root-deps-only` and
+      decide for each of them whether we want to (manually) upgrade. This will
+      require changes to `Cargo.toml`.
 
 ## Version bump
 


### PR DESCRIPTION
I don't think we can do much about transitive dependencies being out of date? So I think we want to run `cargo outdated --root-deps-only`?