### PR TITLE
Run `cargo clippy --fix --all-targets --all-features` with Rust 1.57

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -195,7 +195,7 @@ impl HighlightingAssets {
                     bat_warning!("Unknown theme '{}', using default.", theme)
                 }
                 self.get_theme_set()
-                    .get(self.fallback_theme.unwrap_or_else(|| Self::default_theme()))
+                    .get(self.fallback_theme.unwrap_or_else(Self::default_theme))
                     .expect("something is very wrong if the default theme is missing")
             }
         }

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -307,7 +307,7 @@ impl App {
                     .map(|style_str| {
                         style_str
                             .split(',')
-                            .map(|x| StyleComponent::from_str(x))
+                            .map(StyleComponent::from_str)
                             .collect::<Result<Vec<StyleComponent>>>()
                     })
                     .transpose()?;

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -104,7 +104,7 @@ fn get_args_from_str(content: &str) -> Result<Vec<OsString>, shell_words::ParseE
         .map(|line| line.trim())
         .filter(|line| !line.is_empty())
         .filter(|line| !line.starts_with('#'))
-        .map(|line| shell_words::split(line))
+        .map(shell_words::split)
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(args_per_line


### PR DESCRIPTION
Clippy in the newly released Rust 1.57 found some new lints. Conveniently, all
of them were fixable with `--fix`.