### PR TITLE
pipe separated values

### DIFF
--- a/assets/syntaxes/02_Extra/CSV.sublime-syntax
+++ b/assets/syntaxes/02_Extra/CSV.sublime-syntax
@@ -7,7 +7,7 @@ file_extensions:
   - tsv
 scope: text.csv
 variables:
-  field_separator: (?:[,;\t])
+  field_separator: (?:[|,;\t])
   record_separator: (?:$\n?)
 contexts:
   prototype:


### PR DESCRIPTION
hi,
may adding the pipe character in fields separator ?
`column --table --separator $'\t' --output-separator ' | ' myfile.tsv | bat --plain --language tsv` will give a nice aligned and colored table ;-)
regards, lacsaP.