### PR TITLE
assets/create.sh: Reverse patches even if `bat cache` fails or aborts

### DIFF
--- a/assets/create.sh
+++ b/assets/create.sh
@@ -46,6 +46,7 @@ bat cache --clear
 # - Remove the JavaDoc patch once https://github.com/trishume/syntect/issues/222 has been fixed
 # - Remove the C# patch once https://github.com/sublimehq/Packages/pull/2331 has been merged
 
+# Apply patches
 (
     cd "$ASSET_DIR"
     for patch in patches/*.patch; do
@@ -53,11 +54,16 @@ bat cache --clear
     done
 )
 
-bat cache --build --blank --acknowledgements --source="$ASSET_DIR" --target="$ASSET_DIR"
+reverse_patches() {
+    (
+        cd "$ASSET_DIR"
+        for patch in patches/*.patch; do
+            patch --strip=0 --reverse <"$patch"
+        done
+    )
+}
 
-(
-    cd "$ASSET_DIR"
-    for patch in patches/*.patch; do
-        patch --strip=0 --reverse < "$patch"
-    done
-)
+# Make sure to always reverse patches, even if the `bat cache` command fails or aborts
+trap reverse_patches EXIT
+
+bat cache --build --blank --acknowledgements --source="$ASSET_DIR" --target="$ASSET_DIR"


### PR DESCRIPTION
I quite frequently encounter this inconvenience:

**Step-by-step:**
1. Make some changes to how assets are built
2. Rebuild assets with `cargo build && PATH="./target/debug:$PATH" assets/create.sh`
3. While assets are built, realize I made a mistake and abort with Ctrl+C

**Expected result:**
Patches are not applied any longer since `create.sh` was aborted

**Actual result:**
Patches are still applied, causing an error when `create.sh` is invoked next time. I usually run `git submodule update --init --force` to get rid of the patches. But then there are always some `.rej` files lying around I have to clean up manually...

This PR reverses the patches in a trap, so that patches are reversed even if `bat cache` is aborted with Ctrl + C (or fails for other reasons)
