### PR TITLE
Underline highlighted lines in ANSI theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - New style component `header-filesize` to show size of the displayed file in the header. See #1988 (@mdibaiee)
+- Use underline for line highlighting on ANSI, see #1730 (@mdibaiee)
 
 ## Bugfixes
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -463,6 +463,10 @@ impl<'a> Printer for InteractivePrinter<'a> {
         let highlight_this_line =
             self.config.highlighted_lines.0.check(line_number) == RangeCheckResult::InRange;
 
+        if highlight_this_line && self.config.theme == "ansi" {
+            self.ansi_style.update("^[4m");
+        }
+
         let background_color = self
             .background_color_highlight
             .filter(|_| highlight_this_line);
@@ -647,6 +651,10 @@ impl<'a> Printer for InteractivePrinter<'a> {
                 )?;
             }
             writeln!(handle)?;
+        }
+
+        if highlight_this_line && self.config.theme == "ansi" {
+            self.ansi_style.update("^[24m");
         }
 
         Ok(())

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -655,6 +655,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
 
         if highlight_this_line && self.config.theme == "ansi" {
             self.ansi_style.update("^[24m");
+            write!(handle, "\x1B[24m")?;
         }
 
         Ok(())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1290,6 +1290,25 @@ fn grid_for_file_without_newline() {
         .stderr("");
 }
 
+// For ANSI theme, use underscore as a highlighter
+#[test]
+fn ansi_highlight_underline() {
+    bat()
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--theme=ansi")
+        .arg("--style=plain")
+        .arg("--highlight-line=1")
+        .write_stdin("Ansi Underscore Test\nAnother Line")
+        .assert()
+        .success()
+        .stdout("\x1B[4mAnsi Underscore Test\n\x1B[24mAnother Line")
+        .stderr("");
+}
+
 // Ensure that ANSI passthrough is emitted properly for both wrapping and non-wrapping printer.
 #[test]
 fn ansi_passthrough_emit() {


### PR DESCRIPTION
Hey 👋 
I have attempted to fix this in two ways: the [first commit](https://github.com/sharkdp/bat/pull/1985/commits/129210e9fa181c06409d5ad085a0b0744cc5fb1d) is a simple, ANSI-specific condition.
The [second commit](https://github.com/sharkdp/bat/pull/1985/commits/31404f6a172c74936481189fec58e0ec05975efd) is using a custom scope to allow each theme to customise how the highlighted line's font style is set.

Let me know what you think and I can squash to a single final commit.

Fixes #1730 