### PR TITLE
Updating default theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add PowerShell completion, see #1826 (@rashil2000)
 - Minimum supported Rust version (MSRV) bumped to 1.51, see #1994 (@mdibaiee)
 - Include git hash in `bat -V` and `bat --version` output if present. See #1921 (@Enselic)
+- Updated default theme to be `ansi` by default (@milespossing)
 
 ## Syntaxes
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -69,7 +69,7 @@ impl HighlightingAssets {
     }
 
     pub fn default_theme() -> &'static str {
-        "Monokai Extended"
+        "ansi"
     }
 
     pub fn from_cache(cache_path: &Path) -> Result<Self> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1254,7 +1254,7 @@ fn ignored_suffix_arg() {
         .arg("test.json~")
         .assert()
         .success()
-        .stdout("\u{1b}[38;5;231m{\u{1b}[0m\u{1b}[38;5;208m\"\u{1b}[0m\u{1b}[38;5;208mtest\u{1b}[0m\u{1b}[38;5;208m\"\u{1b}[0m\u{1b}[38;5;231m:\u{1b}[0m\u{1b}[38;5;231m \u{1b}[0m\u{1b}[38;5;186m\"\u{1b}[0m\u{1b}[38;5;186mvalue\u{1b}[0m\u{1b}[38;5;186m\"\u{1b}[0m\u{1b}[38;5;231m}\u{1b}[0m")
+        .stdout("{\u{1b}[32m\"\u{1b}[0m\u{1b}[32mtest\u{1b}[0m\u{1b}[32m\"\u{1b}[0m: \u{1b}[32m\"\u{1b}[0m\u{1b}[32mvalue\u{1b}[0m\u{1b}[32m\"\u{1b}[0m}")
         .stderr("");
 
     bat()
@@ -1264,7 +1264,7 @@ fn ignored_suffix_arg() {
         .arg("test.json.suffix")
         .assert()
         .success()
-        .stdout("\u{1b}[38;5;231m{\u{1b}[0m\u{1b}[38;5;208m\"\u{1b}[0m\u{1b}[38;5;208mtest\u{1b}[0m\u{1b}[38;5;208m\"\u{1b}[0m\u{1b}[38;5;231m:\u{1b}[0m\u{1b}[38;5;231m \u{1b}[0m\u{1b}[38;5;186m\"\u{1b}[0m\u{1b}[38;5;186mvalue\u{1b}[0m\u{1b}[38;5;186m\"\u{1b}[0m\u{1b}[38;5;231m}\u{1b}[0m")
+        .stdout("{\u{1b}[32m\"\u{1b}[0m\u{1b}[32mtest\u{1b}[0m\u{1b}[32m\"\u{1b}[0m: \u{1b}[32m\"\u{1b}[0m\u{1b}[32mvalue\u{1b}[0m\u{1b}[32m\"\u{1b}[0m}")
         .stderr("");
 
     bat()
@@ -1273,7 +1273,7 @@ fn ignored_suffix_arg() {
         .arg("test.json.suffix")
         .assert()
         .success()
-        .stdout("\u{1b}[38;5;231m{\"test\": \"value\"}\u{1b}[0m")
+        .stdout("{\"test\": \"value\"}")
         .stderr("");
 }
 


### PR DESCRIPTION
A potential solution to #1978, if desired.

Updating theme to be `ansi` by default. The current default theme (Monokai Extended) does not work well in light mode:

Light vs Dark w/ Monokai:

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/7330275/147796151-feaa74a0-5ad7-4ae7-9158-1f1f9cca0e94.png">

Light vs Dark w/ ansi:

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/7330275/147796165-4a2fe2f1-405d-481a-bb50-8e32fd2a5393.png">

- Changing theme to ansi by default
- Updating integration tests
- Updating CHANGELOG.md