### PR TITLE
Mark `MappingTarget` as `#[non_exhaustive]` for increased semver flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 - Deprecate `HighlightingAssets::syntaxes()` and `HighlightingAssets::syntax_for_file_name()`. Use `HighlightingAssets::get_syntaxes()` and `HighlightingAssets::get_syntax_for_path()` instead. They return a `Result` which is needed for upcoming lazy-loading work to improve startup performance. They also return which `SyntaxSet` the returned `SyntaxReference` belongs to. See #1747, #1755, #1776, #1862 (@Enselic)
 - Remove `HighlightingAssets::from_files` and `HighlightingAssets::save_to_cache`. Instead of calling the former and then the latter you now make a single call to `bat::assets::build`. See #1802, #1971 (@Enselic)
 - Replace  the `error::Error(error::ErrorKind, _)` struct and enum with an `error::Error` enum. `Error(ErrorKind::UnknownSyntax, _)` becomes `Error::UnknownSyntax`, etc. Also remove the `error::ResultExt` trait. These changes stem from replacing `error-chain` with `thiserror`. See #1820 (@Enselic)
-- Add new `MappingTarget` enum variant `MapExtensionToUnknown`. Refer to its docummentation for more information. Clients are adviced to treat `MapExtensionToUnknown` the same as `MapToUnknown` in exhaustive matches. See #1703 (@cbolgiano)
+- Add new `MappingTarget` enum variant `MapExtensionToUnknown`. Refer to its documentation for more information. Also mark `MappingTarget` as `#[non_exhaustive]` since more enum variants might be added in the future. See #1703 (@cbolgiano), #2012 (@Enselic)
 
 
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -74,13 +74,9 @@ fn get_syntax_mapping_to_paths<'a>(
 ) -> HashMap<&'a str, Vec<String>> {
     let mut map = HashMap::new();
     for mapping in mappings {
-        match mapping {
-            (_, MappingTarget::MapToUnknown) => {}
-            (_, MappingTarget::MapExtensionToUnknown) => {}
-            (matcher, MappingTarget::MapTo(s)) => {
-                let globs = map.entry(*s).or_insert_with(Vec::new);
-                globs.push(matcher.glob().glob().into());
-            }
+        if let (matcher, MappingTarget::MapTo(s)) = mapping {
+            let globs = map.entry(*s).or_insert_with(Vec::new);
+            globs.push(matcher.glob().glob().into());
         }
     }
     map

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -8,6 +8,7 @@ use globset::{Candidate, GlobBuilder, GlobMatcher};
 pub mod ignored_suffixes;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum MappingTarget<'a> {
     /// For mapping a path to a specific syntax.
     MapTo(&'a str),


### PR DESCRIPTION
This will allow us to add new enum variants in the future without breaking
semver compatibility. See
https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute

Since we already added an enum variant since v0.18.3, now is a good time to mark
it as `#[non_exhaustive]`. Even if we currently always bump major version (since we are on 0.x.x) there will come a time when we don't, and then it's nice to have this prepared.