### PR TITLE
Contribute new 8-bit theme: Ansi 16

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -236,3 +236,6 @@
 [submodule "assets/syntaxes/02_Extra/Dart"]
 	path = assets/syntaxes/02_Extra/Dart
 	url = https://github.com/elMuso/Dartlight.git
+[submodule "assets/themes/ansi16"]
+	path = assets/themes/ansi16
+	url = https://github.com/chtenb/ansi16

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ even when truecolor support is available:
 - `base16-256` is designed for [base16-shell](https://github.com/chriskempson/base16-shell).
   It replaces certain bright colors with 8-bit colors from 16 to 21. **Do not** use this simply
   because you have a 256-color terminal but are not using base16-shell.
+- `terminal-ansi16` looks decent on any terminal. It uses 4-bit colors (3-bit colors plus bright variants) in accordance with the [Ansi 16](https://github.com/chtenb/ansi16) guidelines. If your editor and terminal have the same Ansi 16 color theme, their syntax highlighting will match.
 
 Although these themes are more restricted, they have three advantages over truecolor themes. They:
 

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -39,7 +39,7 @@ fn all_themes_are_present() {
             "material-ansi16",
             "noctis-lux-ansi16",
             "synthwave-material-ansi16",
-            "terminal-ansi16"
+            "terminal-ansi16",
             "zenburn"
         ]
     );

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -36,6 +36,10 @@ fn all_themes_are_present() {
             "base16-256",
             "gruvbox-dark",
             "gruvbox-light",
+            "material-ansi16",
+            "noctis-lux-ansi16",
+            "synthwave-material-ansi16",
+            "terminal-ansi16"
             "zenburn"
         ]
     );


### PR DESCRIPTION
I've been working on an adaptation of [base16](http://chriskempson.com/projects/base16/) to solve a few compatibility issues: [Ansi 16](https://github.com/chtenb/ansi16). 

- In contrast with the base16 highlighting scheme, Ansi 16 will work well with any ANSI terminal color theme and does not require that the bright colors are set to a specific scheme. In fact, the Ansi 16 guidelines encourage that the bright colors be compatible with the non-bright colors.
- In contrast with the pre-included `ansi` theme, Ansi 16 *does* make use of the bright ANSI colors, not just the first 8 base colors.

I've put together a .tmTheme called `terminal-ansi16` that implements the Ansi16 scheme for bat. This is included in this PR. Apart from improving compatibility, the scope assignment rules are also more sophisticated than both the pre-included `ansi` and `base16` themes. You can judge this by comparing https://github.com/chtenb/ansi16/blob/0a16273296bbd5d7f5335d62e7605071743794a9/terminal-ansi16.tmTheme with https://github.com/sharkdp/bat/blob/master/assets/themes/ansi.tmTheme and by looking at the screenshot comparisons below.

After this PR has been merged I intend to release a short tutorial somewhere which explains how to use bat, delta and VSCode to create a development setup where the syntax highlighting is fully equivalent between the editor and the terminal.

To get an idea of what that looks like, you can take a look at screenshots of the [VSCode theme I just released.](https://marketplace.visualstudio.com/items?itemName=ctenbrinke.ansi16) These themes set the integrated terminal theme to the same color palette as their in-editor theme. I've used the .tmTheme included in this PR for the diff views (using delta) in the terminal.