### PR TITLE
Failing silently if syntax is unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Features
 
-- Flag `--fail-if-unsupported` added, allows `bat` to fail silently with a non-zero exit code, see #1709
+- Flag `--fail-if-unsupported` added, allows `bat` to fail silently with a non-zero exit code if
+  no specific syntax highlighting was found for the file, see #1709
 
 ## Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Flag `--fail-if-unsupported` added, allows `bat` to fail silently with a non-zero exit code, see #1709
+
 ## Bugfixes
 
 ## Other

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -166,6 +166,10 @@ prints lines 30 to 40
 .IP
 Display a list of supported languages for syntax highlighting.
 .HP
+\fB\-\-fail\-if\-unsupported\fR
+.IP
+If this flag is enabled, {{PROJECT_EXECUTABLE}} will fail if there's no specific syntax highlighting support for the file, and will return a non zero error code. Useful when using {{[PROJECT_EXECUTABLE}} as a preprocessor.
+.HP
 \fB\-u\fR, \fB\-\-unbuffered\fR
 .IP
 This option exists for POSIX\-compliance reasons ('u' is for 'unbuffered'). The output is

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -168,7 +168,8 @@ Display a list of supported languages for syntax highlighting.
 .HP
 \fB\-\-fail\-if\-unsupported\fR
 .IP
-If this flag is enabled, {{PROJECT_EXECUTABLE}} will fail if there's no specific syntax highlighting support for the file, and will return a non zero error code. Useful when using {{[PROJECT_EXECUTABLE}} as a preprocessor.
+If this flag is enabled, {{PROJECT_EXECUTABLE}} will fail if there's no specific syntax highlighting support for the file, or if the file is
+a binary file, and will return a non zero error code. Useful when using {{[PROJECT_EXECUTABLE}} as a preprocessor.
 .HP
 \fB\-u\fR, \fB\-\-unbuffered\fR
 .IP

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -241,6 +241,7 @@ impl App {
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
             use_custom_assets: !self.matches.is_present("no-custom-assets"),
+            fail_if_unsupported: self.matches.is_present("fail_if_unsupported"),
         })
     }
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -241,7 +241,7 @@ impl App {
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
             use_custom_assets: !self.matches.is_present("no-custom-assets"),
-            fail_if_unsupported: self.matches.is_present("fail_if_unsupported"),
+            fail_if_unsupported: self.matches.is_present("fail-if-unsupported"),
         })
     }
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -526,6 +526,12 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .hidden_short_help(true)
                 .help("Show acknowledgements."),
         )
+        .arg(
+            Arg::with_name("fail-if-unsupported")
+                .long("fail-if-unsupported")
+                .hidden_short_help(true)
+                .help("Fail silently with a non zero exit code if no specific syntax was found for the file")
+        )
         .help_message("Print this help message.")
         .version_message("Show version information.");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,9 @@ pub struct Config<'a> {
     /// Whether or not to allow custom assets. If this is false or if custom assets (a.k.a.
     /// cached assets) are not available, assets from the binary will be used instead.
     pub use_custom_assets: bool,
+
+    /// Whether or not we fail silently with a non zero exit code if the syntax is unsupported
+    pub fail_if_unsupported: bool
 }
 
 #[cfg(all(feature = "minimal-application", feature = "paging"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,7 +88,7 @@ pub struct Config<'a> {
     pub use_custom_assets: bool,
 
     /// Whether or not we fail silently with a non zero exit code if the syntax is unsupported
-    pub fail_if_unsupported: bool
+    pub fail_if_unsupported: bool,
 }
 
 #[cfg(all(feature = "minimal-application", feature = "paging"))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     UnknownStyle(String),
     #[error("Use of bat as a pager is disallowed in order to avoid infinite recursion problems")]
     InvalidPagerValueBat,
+    #[error("")]
+    SilentExit,
     #[error("{0}")]
     Msg(String),
 }
@@ -54,6 +56,9 @@ pub fn default_error_handler(error: &Error, output: &mut dyn Write) {
                 error
             )
             .ok();
+        }
+        Error::SilentExit => { 
+            ::std::process::exit(-1);
         }
         _ => {
             writeln!(output, "{}: {}", Red.paint("[bat error]"), error).ok();

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,7 +57,7 @@ pub fn default_error_handler(error: &Error, output: &mut dyn Write) {
             )
             .ok();
         }
-        Error::SilentExit => { 
+        Error::SilentExit => {
             ::std::process::exit(-1);
         }
         _ => {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -182,7 +182,11 @@ impl<'a> InteractivePrinter<'a> {
             .content_type
             .map_or(false, |c| c.is_binary() && !config.show_nonprintable)
         {
-            None
+            if config.fail_if_unsupported {
+                return Err(Error::SilentExit);
+            } else {
+                None
+            }
         } else {
             // Determine the type of syntax for highlighting
             let syntax_in_set =

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -188,12 +188,14 @@ impl<'a> InteractivePrinter<'a> {
             let syntax_in_set =
                 match assets.get_syntax(config.language, input, &config.syntax_mapping) {
                     Ok(syntax_in_set) => syntax_in_set,
-                    Err(Error::UndetectedSyntax(_))=> {
-                        if config.fail_if_unsupported { return Err(Error::SilentExit) }
+                    Err(Error::UndetectedSyntax(_)) => {
+                        if config.fail_if_unsupported {
+                            return Err(Error::SilentExit);
+                        }
                         assets
-                        .find_syntax_by_name("Plain Text")?
-                        .expect("A plain text syntax is available")
-                    },
+                            .find_syntax_by_name("Plain Text")?
+                            .expect("A plain text syntax is available")
+                    }
                     Err(e) => return Err(e),
                 };
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -188,9 +188,12 @@ impl<'a> InteractivePrinter<'a> {
             let syntax_in_set =
                 match assets.get_syntax(config.language, input, &config.syntax_mapping) {
                     Ok(syntax_in_set) => syntax_in_set,
-                    Err(Error::UndetectedSyntax(_)) => assets
+                    Err(Error::UndetectedSyntax(_))=> {
+                        if config.fail_if_unsupported { return Err(Error::SilentExit) }
+                        assets
                         .find_syntax_by_name("Plain Text")?
-                        .expect("A plain text syntax is available"),
+                        .expect("A plain text syntax is available")
+                    },
                     Err(e) => return Err(e),
                 };
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1312,3 +1312,14 @@ fn acknowledgements() {
         )
         .stderr("");
 }
+
+// Regression test for https://github.com/sharkdp/bat/issues/1709
+#[test]
+fn fail_if_unsupported_supported() {
+    bat()
+        .arg("--fail-if-unsupported")
+        .arg("test.txt")
+        .assert()
+        .success()
+        .stdout("hello world\n");
+}


### PR DESCRIPTION
This is my first commit to a open source project, I decided to tackle this specific issue: #1709 

Added the flag `fail-if-unsupported`, allows `bat` to fail without output and with a non-zero status code, so that it can be used as an input preprocessor

I'm new to rust and to contributing to open source so please give any feedback you have