### PR TITLE
run-benchmarks.sh: Use `python3` oneliner instead of `jq`

### DIFF
--- a/tests/benchmarks/run-benchmarks.sh
+++ b/tests/benchmarks/run-benchmarks.sh
@@ -9,15 +9,15 @@ if ! command -v hyperfine > /dev/null 2>&1; then
 	exit 1
 fi
 
-# Check that jq is installed.
-if ! command -v jq > /dev/null 2>&1; then
-	echo "'jq' does not seem to be installed."
-	echo "You can get it here: https://stedolan.github.io/jq"
+# Check that python3 is installed.
+if ! command -v python3 > /dev/null 2>&1; then
+	echo "'python3' does not seem to be installed."
+	echo "You can get it here: https://www.python.org/downloads/"
 	exit 1
 fi
 
 get_cargo_target_dir() {
-	cargo metadata --no-deps --format-version 1 | jq -r .target_directory
+	cargo metadata --no-deps --format-version 1 | python3 -c 'import sys, json; print(json.load(sys.stdin)["target_directory"])'
 }
 
 heading() {


### PR DESCRIPTION
I am setting up a new computer and thus are missing a lot of tools. I
noticed we rely on `jq` being installed, which is a bit annoying when it
is not installed yet. That's easy enough to install on Linux, but on a fresh
macOS install it is not trivial to do. Partly because MacOS refuses to run
unsigned software by default.

We can quite easily get rid of this dependency on `jq` by using a simple
`python3` oneliner.

For reference, the dependency on `jq` was added in ea2faf45e4.

If you prefer to keep the `jq` dependency I am fine with that. Personally I
think it's nice to reduce dependencies  on external tools though. Python3 is of course also an external tool, but it is installed by default on both macOS and (practically) all Linux distributions.

(This is the only place we use `jq`)