### PR TITLE
Allow the license used by GraphQL

### DIFF
--- a/src/assets/build_assets/acknowledgements.rs
+++ b/src/assets/build_assets/acknowledgements.rs
@@ -104,6 +104,9 @@ fn license_not_needed_in_acknowledgements(license_text: &str) -> bool {
         // Public domain
         "This is free and unencumbered software released into the public domain.",
 
+        // Public domain with stronger wording than above
+        "DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE",
+
         // Special license of assets/syntaxes/01_Packages/LICENSE
         "Permission to copy, use, modify, sell and distribute this software is granted. This software is provided \"as is\" without express or implied warranty, and with no claim as to its suitability for any purpose."
     ];


### PR DESCRIPTION
This license is apparently common enough that GitHub recognizes it. See
https://github.com/dncrews/GraphQL-SublimeText3/blob/master/LICENSE.

This will fix the CI failure in #2000

Just to clarify: the license text will not be part of the acknowledgments output (same as the other public domain license)