### PR TITLE
Add `rustfmt.toml`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Defaults are used


### PR DESCRIPTION
Having an empty `rustfmt.toml` in the repository causes rustfmt to ignore users' global settings and ensures formatting consistency. See https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#configuring-rustfmt