### PR TITLE
fix Bash completion on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bugfixes
 
+- Fix bash completion on macOS. See #2066 (@joshpencheon)
+
 ## Other
 
 ## Syntaxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bugfixes
 
-- Fix bash completion on macOS. See #2066 (@joshpencheon)
+- Fix bash completion on bash 3.x and bash-completion 1.x. See #2066 (@joshpencheon)
 
 ## Other
 

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -16,9 +16,8 @@ _bat() {
 		_init_completion -s || return 0
 	else
 		__bat_init_completion -n "=" || return 0
+		_split_longopt && split=true
 	fi
-
-	_split_longopt && split=true
 
 	if [[ ${words[1]-} == cache ]]; then
 		case $prev in

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -2,9 +2,23 @@
 
 # Requires https://github.com/scop/bash-completion
 
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+__bat_init_completion()
+{
+	COMPREPLY=()
+	_get_comp_words_by_ref "$@" cur prev words cword
+}
+
 _bat() {
-	local cur prev words cword split
-	_init_completion -s || return 0
+	local cur prev words cword split=false
+	if declare -F _init_completion >/dev/null 2>&1; then
+		_init_completion -s || return 0
+	else
+		__bat_init_completion -n "=" || return 0
+	fi
+
+	_split_longopt && split=true
 
 	if [[ ${words[1]-} == cache ]]; then
 		case $prev in


### PR DESCRIPTION
Issue #2066 reports that bash completion is broken on macOS. This is because the version of `bash-completion` that's often packed on macOS via Home-brew is v1.3, which doesn't include the missing `_init_completion` function.

This PR adopts a pattern seen across many other projects (e.g. `tmux`/ `gh` / `kubectl` /  `helm`, some of which use the Cobra Go library to [autogenerate their completion](https://github.com/spf13/cobra/blob/master/bash_completionsV2.go#L32-L38)) to add a shim function with the minimal required functionality.

Completion now works for me on both macOS 10.15.7 and Ubuntu 22.04.

