### PR TITLE
Add requirements.txt syntax

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -239,3 +239,6 @@
 [submodule "assets/syntaxes/02_Extra/SublimeJQ"]
 	path = assets/syntaxes/02_Extra/SublimeJQ
 	url = https://github.com/zogwarg/SublimeJQ.git
+[submodule "assets/syntaxes/02_Extra/requirementstxt"]
+	path = assets/syntaxes/02_Extra/requirementstxt
+	url = https://github.com/wuub/requirementstxt.git

--- a/assets/patches/requirementstxt.sublime-syntax.patch
+++ b/assets/patches/requirementstxt.sublime-syntax.patch
@@ -1,0 +1,26 @@
+diff --git a/assets/syntaxes/02_Extra/requirementstxt.sublime-syntax b/assets/syntaxes/02_Extra/requirementstxt.sublime-syntax
+index 8419f27..bffb1a6 100644
+--- syntaxes/02_Extra/requirementstxt.sublime-syntax
++++ syntaxes/02_Extra/requirementstxt.sublime-syntax
+@@ -2,6 +2,12 @@
+ ---
+ # http://www.sublimetext.com/docs/syntax.html
+ name: requirements.txt
++file_extensions:
++  - requirements.txt
++  - requirements-dev.txt
++  - requirements-test.txt
++  - dev-requirements.txt
++  - test-requirements.txt
+ scope: source.requirementstxt
+ contexts:
+   main:
+@@ -11,7 +17,7 @@ contexts:
+         1: punctuation.definition.comment.requirementstxt
+     - match: '(?i)^[a-z0-9_\-\.]+'
+       scope: string.package_name.requirementstxt
+-    - match: (?i)==|<|<=|>=|>
++    - match: (?i)==|<|<=|>=|>|~=|!=|===
+       scope: keyword.operator.logical.punctuation.requirementstxt
+     - match: '(?i)\d+\.[\da-z\-_\.]*'
+       scope: constant.numeric.verions.requirementstxt

--- a/assets/syntaxes/02_Extra/requirementstxt.sublime-syntax
+++ b/assets/syntaxes/02_Extra/requirementstxt.sublime-syntax
@@ -1,0 +1,17 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+name: requirements.txt
+scope: source.requirementstxt
+contexts:
+  main:
+    - match: (#).*$\n?
+      scope: comment.line.requirementstxt
+      captures:
+        1: punctuation.definition.comment.requirementstxt
+    - match: '(?i)^[a-z0-9_\-\.]+'
+      scope: string.package_name.requirementstxt
+    - match: (?i)==|<|<=|>=|>
+      scope: keyword.operator.logical.punctuation.requirementstxt
+    - match: '(?i)\d+\.[\da-z\-_\.]*'
+      scope: constant.numeric.verions.requirementstxt

--- a/tests/syntax-tests/highlighted/requirementstxt/requirements.txt
+++ b/tests/syntax-tests/highlighted/requirementstxt/requirements.txt
@@ -1,0 +1,30 @@
+[38;2;117;113;94m#[0m[38;2;117;113;94m Example from https://pip.pypa.io/en/stable/reference/requirements-file-format/#example for pip v22.0.3[0m
+
+[38;2;117;113;94m#[0m[38;2;117;113;94m##### Requirements without Version Specifiers ######[0m
+[38;2;230;219;116mpytest[0m
+[38;2;230;219;116mpytest-cov[0m
+[38;2;230;219;116mbeautifulsoup4[0m
+
+[38;2;117;113;94m#[0m[38;2;117;113;94m##### Requirements with Version Specifiers ######[0m
+[38;2;117;113;94m#[0m[38;2;117;113;94m   See https://www.python.org/dev/peps/pep-0440/#version-specifiers[0m
+[38;2;230;219;116mdocopt[0m[38;2;248;248;242m [0m[38;2;249;38;114m==[0m[38;2;248;248;242m [0m[38;2;190;132;255m0.6.1[0m[38;2;248;248;242m             [0m[38;2;117;113;94m#[0m[38;2;117;113;94m Version Matching. Must be version 0.6.1[0m
+[38;2;230;219;116mkeyring[0m[38;2;248;248;242m [0m[38;2;249;38;114m>=[0m[38;2;248;248;242m [0m[38;2;190;132;255m4.1.1[0m[38;2;248;248;242m            [0m[38;2;117;113;94m#[0m[38;2;117;113;94m Minimum version 4.1.1[0m
+[38;2;230;219;116mcoverage[0m[38;2;248;248;242m [0m[38;2;249;38;114m!=[0m[38;2;248;248;242m [0m[38;2;190;132;255m3.5[0m[38;2;248;248;242m             [0m[38;2;117;113;94m#[0m[38;2;117;113;94m Version Exclusion. Anything except version 3.5[0m
+[38;2;230;219;116mMopidy-Dirble[0m[38;2;248;248;242m [0m[38;2;249;38;114m~=[0m[38;2;248;248;242m [0m[38;2;190;132;255m1.1[0m[38;2;248;248;242m        [0m[38;2;117;113;94m#[0m[38;2;117;113;94m Compatible release. Same as >= 1.1, == 1.*[0m
+
+[38;2;117;113;94m#[0m[38;2;117;113;94m##### Refer to other requirements files ######[0m
+[38;2;230;219;116m-r[0m[38;2;248;248;242m other-requirements.txt[0m
+
+[38;2;117;113;94m#[0m[38;2;117;113;94m##### A particular file ######[0m
+[38;2;230;219;116m.[0m[38;2;248;248;242m/downloads/numpy-[0m[38;2;190;132;255m1.9.2-cp34-none-win32.whl[0m
+[38;2;230;219;116mhttp[0m[38;2;248;248;242m://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-[0m[38;2;190;132;255m3.0.3.dev1820[0m[38;2;248;248;242m+49a8884-cp34-none-win_amd[0m[38;2;190;132;255m64.whl[0m
+
+[38;2;117;113;94m#[0m[38;2;117;113;94m##### Additional Requirements without Version Specifiers ######[0m
+[38;2;117;113;94m#[0m[38;2;117;113;94m   Same as 1st section, just here to show that you can put things in any order.[0m
+[38;2;230;219;116mrejected[0m
+[38;2;230;219;116mgreen[0m
+
+[38;2;117;113;94m#[0m[38;2;117;113;94m Additional examples from https://www.python.org/dev/peps/pep-0508/#examples[0m
+
+[38;2;230;219;116mrequests[0m[38;2;248;248;242m [security,tests] [0m[38;2;249;38;114m>=[0m[38;2;248;248;242m [0m[38;2;190;132;255m2.8.1[0m[38;2;248;248;242m, [0m[38;2;249;38;114m==[0m[38;2;248;248;242m [0m[38;2;190;132;255m2.8.[0m[38;2;248;248;242m* ; python_version [0m[38;2;249;38;114m<[0m[38;2;248;248;242m "[0m[38;2;190;132;255m2.7[0m[38;2;248;248;242m"[0m
+[38;2;230;219;116mpip[0m[38;2;248;248;242m @ https://github.com/pypa/pip/archive/[0m[38;2;190;132;255m1.3.1.zip[0m[38;2;117;113;94m#[0m[38;2;117;113;94msha1=da9234ee9982d4bbb3c72346a6de940a148ea686[0m

--- a/tests/syntax-tests/source/requirementstxt/requirements.txt
+++ b/tests/syntax-tests/source/requirementstxt/requirements.txt
@@ -1,0 +1,30 @@
+# Example from https://pip.pypa.io/en/stable/reference/requirements-file-format/#example for pip v22.0.3
+
+###### Requirements without Version Specifiers ######
+pytest
+pytest-cov
+beautifulsoup4
+
+###### Requirements with Version Specifiers ######
+#   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
+docopt == 0.6.1             # Version Matching. Must be version 0.6.1
+keyring >= 4.1.1            # Minimum version 4.1.1
+coverage != 3.5             # Version Exclusion. Anything except version 3.5
+Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.*
+
+###### Refer to other requirements files ######
+-r other-requirements.txt
+
+###### A particular file ######
+./downloads/numpy-1.9.2-cp34-none-win32.whl
+http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
+
+###### Additional Requirements without Version Specifiers ######
+#   Same as 1st section, just here to show that you can put things in any order.
+rejected
+green
+
+# Additional examples from https://www.python.org/dev/peps/pep-0508/#examples
+
+requests [security,tests] >= 2.8.1, == 2.8.* ; python_version < "2.7"
+pip @ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686


### PR DESCRIPTION
requirementstxt.sublime-syntax converted from `.tmLanguage`, patched to add `file_extensions`, and additional version specifiers from https://www.python.org/dev/peps/pep-0440/#version-specifiers

61k downloads at the moment at https://packagecontrol.io/packages/requirementstxt