### PR TITLE
release-checklist.md: Remove '## Dependencies'

### DIFF
--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -1,16 +1,5 @@
 # Release checklist
 
-## Dependencies
-
-See this page for a good overview: https://deps.rs/repo/github/sharkdp/bat
-
-- [ ] Optional: update dependencies with `cargo update`. This is also done by
-      dependabot, so it is not strictly necessary.
-- [ ] Install [cargo-outdated](https://crates.io/crates/cargo-outdated). Check
-      for outdated dependencies with `cargo outdated --root-deps-only` and
-      decide for each of them whether we want to (manually) upgrade. This will
-      require changes to `Cargo.toml`.
-
 ## Version bump
 
 - [ ] Update version in `Cargo.toml`. Run `cargo build` to update `Cargo.lock`.


### PR DESCRIPTION
I would like us to discuss removing the section in the release checklist that encourages (by merely being in the checklist) bumping of dependencies.

Bumping dependencies right before a release might not be the best strategy, because

* Bumping deps comes with a risk of introducing regressions (that are not caught by our regression tests). Letting bumps sit in git master for a few weeks or so increases the chances of that kind of regressions being found before we make a release.

* Dependabot regularly bumps dependencies anyway (which is also pointed out in the removed text)

* Ideally, it should be pleasant and easy to make a bat release. The fewer steps, the easier. Even if we mark steps as "optional", it is easy to get a bad conscious if you skip the steps, and thus even optional steps have some amount of "slow down".