### PR TITLE
Include contents of custom assets `metadata.yaml` in `--diagnostics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Other
 
+- Include contents of custom assets `metadata.yaml` in `--diagnostics`. See #2107 (@Enselic)
+
 ## Syntaxes
 
 ## Themes

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -230,6 +230,9 @@ fn invoke_bugreport(app: &App) {
     let pager = bat::config::get_pager_executable(app.matches.value_of("pager"))
         .unwrap_or_else(|| "less".to_owned()); // FIXME: Avoid non-canonical path to "less".
 
+    let mut custom_assets_metadata = PROJECT_DIRS.cache_dir().to_path_buf();
+    custom_assets_metadata.push("metadata.yaml");
+
     let mut report = bugreport!()
         .info(SoftwareVersion::default())
         .info(OperatingSystem::default())
@@ -254,6 +257,10 @@ fn invoke_bugreport(app: &App) {
             "MANPAGER",
         ]))
         .info(FileContent::new("Config file", config_file()))
+        .info(FileContent::new(
+            "Custom assets metadata",
+            custom_assets_metadata,
+        ))
         .info(CompileTimeInformation::default());
 
     #[cfg(feature = "paging")]


### PR DESCRIPTION
# Output without custom assets:

#### Custom assets metadata

Could not read contents of '/Users/martin/.cache/bat/metadata.yaml': No such file or directory (os error 2).

# Output with custom assets:

#### Custom assets metadata

```
---
bat_version: 0.20.0
creation_time:
  secs_since_epoch: 1646283165
  nanos_since_epoch: 208676000
```

# Remark

When we have access to https://github.com/sharkdp/bugreport/pull/11 we will be able to get even more info for custom assets, but the metadata is a significant giver of valuable information by itself that we can add already now to `bat`, so let's do that.

This will help slightly with https://github.com/sharkdp/bat/issues/2085