### PR TITLE
Add a --style=default option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Correctly render tab stops in --show-all, see #2038 (@Synthetica9)
+- Add a --style=default option, less verbose than =full, see #2061 (@IsaacHorvath)
 
 ## Bugfixes
 

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -37,7 +37,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
             [CompletionResult]::new('--map-syntax', 'map-syntax', [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
             [CompletionResult]::new('--theme', 'theme', [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
-            [CompletionResult]::new('--style', 'style', [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*auto*, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+            [CompletionResult]::new('--style', 'style', [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
             [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('--line-range', 'line-range', [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('-A', 'A', [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -56,7 +56,7 @@ complete -c {{PROJECT_EXECUTABLE}} -s P -d "Disable paging. Alias for '--paging=
 
 complete -c {{PROJECT_EXECUTABLE}} -s A -l show-all -d "Show non-printable characters like space/tab/newline" -n "not __fish_seen_subcommand_from cache"
 
-complete -c {{PROJECT_EXECUTABLE}} -l style -xka "auto full plain changes header header-filename header-filesize grid rule numbers snip" -d "Comma-separated list of style elements or presets to display with file contents" -n "not __fish_seen_subcommand_from cache"
+complete -c {{PROJECT_EXECUTABLE}} -l style -xka "default auto full plain changes header header-filename header-filesize grid rule numbers snip" -d "Comma-separated list of style elements or presets to display with file contents" -n "not __fish_seen_subcommand_from cache"
 
 complete -c {{PROJECT_EXECUTABLE}} -l tabs -x -d "<T> Set the tab width to T spaces (width of 0 passes tabs through directly)" -n "not __fish_seen_subcommand_from cache"
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -75,7 +75,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         ;;
 
         style)
-            _values -s , 'style' auto full plain changes header header-filename header-filesize grid rule numbers snip
+            _values -s , 'style' default auto full plain changes header header-filename header-filesize grid rule numbers snip
         ;;
     esac
 }

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -146,7 +146,7 @@ Configure which elements (line numbers, file headers, grid borders, Git modifica
 of components to display (e.g. 'numbers,changes,grid') or a pre\-defined style ('full').
 To set a default style, add the '\-\-style=".."' option to the configuration file or
 export the BAT_STYLE environment variable (e.g.: export BAT_STYLE=".."). Possible
-values: *full*, auto, plain, changes, header, header-filename, header-filesize, grid,
+values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
 rule, numbers, snip.
 .HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -398,6 +398,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                         !&[
                             "auto",
                             "full",
+                            "default",
                             "plain",
                             "header",
                             "header-filename",

--- a/src/style.rs
+++ b/src/style.rs
@@ -17,6 +17,7 @@ pub enum StyleComponent {
     LineNumbers,
     Snip,
     Full,
+    Default,
     Plain,
 }
 
@@ -25,7 +26,7 @@ impl StyleComponent {
         match self {
             StyleComponent::Auto => {
                 if interactive_terminal {
-                    StyleComponent::Full.components(interactive_terminal)
+                    StyleComponent::Default.components(interactive_terminal)
                 } else {
                     StyleComponent::Plain.components(interactive_terminal)
                 }
@@ -45,6 +46,14 @@ impl StyleComponent {
                 StyleComponent::Grid,
                 StyleComponent::HeaderFilename,
                 StyleComponent::HeaderFilesize,
+                StyleComponent::LineNumbers,
+                StyleComponent::Snip,
+            ],
+            StyleComponent::Default => &[
+                #[cfg(feature = "git")]
+                StyleComponent::Changes,
+                StyleComponent::Grid,
+                StyleComponent::HeaderFilename,
                 StyleComponent::LineNumbers,
                 StyleComponent::Snip,
             ],
@@ -69,6 +78,7 @@ impl FromStr for StyleComponent {
             "numbers" => Ok(StyleComponent::LineNumbers),
             "snip" => Ok(StyleComponent::Snip),
             "full" => Ok(StyleComponent::Full),
+            "default" => Ok(StyleComponent::Default),
             "plain" => Ok(StyleComponent::Plain),
             _ => Err(format!("Unknown style '{}'", s).into()),
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -975,6 +975,30 @@ fn header_full_binary() {
 }
 
 #[test]
+fn header_default() {
+    bat()
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=default")
+        .arg("single-line.txt")
+        .assert()
+        .success()
+        .stdout(
+            "\
+───────┬────────────────────────────────────────────────────────────────────────
+       │ File: single-line.txt
+───────┼────────────────────────────────────────────────────────────────────────
+   1   │ Single Line
+───────┴────────────────────────────────────────────────────────────────────────
+",
+        )
+        .stderr("");
+}
+
+#[test]
 fn filename_stdin() {
     bat()
         .arg("--decorations=always")


### PR DESCRIPTION
Hello, this is my first contribution, meant to resolve #2061. I added a new --style=default option that is effectively a carbon copy of --style=full, only I've taken out the file size in the header. I expect there to be more differences going forward, e.g. after implementing some of #1701.

I added a simple integration test that seems to pass okay, and updated the shell completions (though I only use bash so I haven't tested them).

I am brand spanking new to Rust, so apologies if I'm way out of line here. I'm hoping to try my hand at contributing a bit here and there to bat help practice.