### PR TITLE
Allow configuring show_nonprintable from PrettyPrinter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## `bat` as a library
 
-- Allow crates using `bat` as a library to configure `show_nonprintable` with `PrettyPrinter`, see #2142
+- Allow configuration of `show_nonprintable` with `PrettyPrinter`, see #2142
 
 # v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ## `bat` as a library
 
+- Allow crates using `bat` as a library to configure `show_nonprintable` with `PrettyPrinter`, see #2142
 
 # v0.20.0
 

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -164,6 +164,12 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Whether to print binary content or nonprintable characters (default: no)
+    pub fn show_nonprintable(&mut self, yes: bool) -> &mut Self {
+        self.config.show_nonprintable = yes;
+        self
+    }
+
     /// Whether to show "snip" markers between visible line ranges (default: no)
     pub fn snip(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.snip = yes;


### PR DESCRIPTION
This PR allows crates using `bat` as a library to configure the `show_nonprintable` setting via the `PrettyPrinter` API.

Note that it is possible to use `bat` as a lib and configure this, but the workaround requires using `bat`'s "inner" API which is discouraged by `bat`'s documentation.

Current workaround:

```rs
let mut config = bat::config::Config::default();
config.show_nonprintable = true;
let assets = bat::assets::HighlightingAssets::from_binary();
let ctrl = bat::controller::Controller::new(&config, &assets);
let inp = bat::input::Input::from(bat::Input::from_bytes(&output));
ctrl.run(vec![inp]).unwrap();
```

Once this PR is merged, consumers will be able to do this:

```rs
bat::PrettyPrinter::new()
    .input_from_bytes(&output)
    .show_nonprintable(true)
    .print()
    .expect("Failed to print to STDOUT");
```

---

**Something else noteworthy**: if using `bat` as a library, if binary content is detected then the `PrettyPrinter` will print:

```
[bat warning]: Binary content from READER will not be printed to the terminal (but will be present if the output of 'bat' is piped). You can use 'bat -A' to show the binary file contents.
```

I'm not sure if this has been discussed previously, but I imagine it could cause some surprise for crates which depend on `bat` since the `-A` flag obviously isn't available, etc.