### PR TITLE
Print info about custom assets in --diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Other
 
-- Include contents of custom assets `metadata.yaml` in `--diagnostics`. See #2107 (@Enselic)
+- Include info about custom assets in `--diagnostics` if used. See #2107, #2144 (@Enselic)
 
 ## Syntaxes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "bugreport"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0014b4b2b4f63bfe69c3838470121290cc437fdc79785d408a761a21e8b2404c"
+checksum = "535120b8182547808081a66f1f77a64533c780b23da26763e0ee34dfb94f98c9"
 dependencies = [
  "git-version",
  "shell-escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde_yaml = "0.8"
 semver = "1.0"
 path_abs = { version = "0.5", default-features = false }
 clircle = "0.3"
-bugreport = { version = "0.4", optional = true }
+bugreport = { version = "0.5.0", optional = true }
 dirs-next = { version = "2.0.0", optional = true }
 grep-cli = { version = "0.1.6", optional = true }
 regex = { version = "1.5", optional = true }

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -261,6 +261,10 @@ fn invoke_bugreport(app: &App) {
             "Custom assets metadata",
             custom_assets_metadata,
         ))
+        .info(DirectoryEntries::new(
+            "Custom assets",
+            PROJECT_DIRS.cache_dir(),
+        ))
         .info(CompileTimeInformation::default());
 
     #[cfg(feature = "paging")]


### PR DESCRIPTION
It will look like this:

```
#### Custom assets

- metadata.yaml, 100 bytes
- syntaxes.bin, 726649 bytes
- themes.bin, 40475 bytes
```

or this:

```
#### Custom assets

'/Users/martin/.cache/bat' is empty
```

or this:

```
#### Custom assets

'/Users/martin/.cache/bat' not found
```