### PR TITLE
Lock regex crate at min 1.5.5 for CVE-2022-24713

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bugfixes
 
+- Bump `regex` dependency from 1.5.4 to 1.5.5 to fix [CVE-2022-24713](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html), see #2145, #2139 (@Enselic)
+
 ## Other
 
 - Include contents of custom assets `metadata.yaml` in `--diagnostics`. See #2107 (@Enselic)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ clircle = "0.3"
 bugreport = { version = "0.4", optional = true }
 dirs-next = { version = "2.0.0", optional = true }
 grep-cli = { version = "0.1.6", optional = true }
-regex = { version = "1.5", optional = true }
+regex = { version = "1.5.5", optional = true }
 walkdir = { version = "2.0", optional = true }
 bytesize = { version = "1.1.0" }
 


### PR DESCRIPTION
Cargo.lock already specifies 1.5.5, but we should also do it in Cargo.toml.

I forgot that in #2139.

For #2125