### PR TITLE
Add mapping for Unix mail spool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Mapped clang-format config file (.clang-format) to YAML syntax (@TruncatedDinosour)
 - log syntax: improved handling of escape characters in double quoted strings. See #2123 (@keith-hall)
+- Associate `/var/spool/mail/*` and `/var/mail/*` with the `Email` syntax. See #2156 (@cyqsimon)
 
 ## Themes
 

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -120,6 +120,11 @@ impl<'a> SyntaxMapping<'a> {
             mapping.insert(glob, MappingTarget::MapTo("INI")).unwrap();
         }
 
+        // unix mail spool
+        for glob in &["/var/spool/mail/*", "/var/mail/*"] {
+            mapping.insert(glob, MappingTarget::MapTo("Email")).unwrap()
+        }
+
         // pacman hooks
         mapping
             .insert("*.hook", MappingTarget::MapTo("INI"))


### PR DESCRIPTION
`/var/spool/mail` and `/var/mail` are often symlinked, but not necessarily so (https://serverfault.com/a/351783/549727). So I mapped both.