### PR TITLE
bug_report.md template: Mention some already reported bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,13 @@ Please note that the following bugs have already been reported:
 
 -->
 
-**Describe the bug you encountered:**
+**What steps will reproduce the bug?**
+
+1. step 1
+2. step 2
+3. ...
+
+**What happens?**
 
 ...
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,18 @@ assignees: ''
 
 ---
 
-<!-- Hey there, thank you for creating an issue! -->
+<!--
+
+Hey there, thank you for reporting a bug!
+
+Please note that the following bugs have already been reported:
+
+* dpkg: error processing archive /some/path/some-program.deb (--unpack):
+  trying to overwrite '/usr/.crates2.json'
+
+  See https://github.com/sharkdp/bat/issues/938
+
+-->
 
 **Describe the bug you encountered:**
 


### PR DESCRIPTION
Well, to be fair, only the `/usr/.crates2.json` one at the moment. But we can add more later.

Also explicitly ask for steps on how to reproduce the reported bug.