### PR TITLE
Run `cargo clippy --fix --all-targets --all-features` with Rust 1.60

### DIFF
--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -91,7 +91,7 @@ pub fn get_args_from_config_file() -> Result<Vec<OsString>, shell_words::ParseEr
         .ok()
         .map(|content| get_args_from_str(&content))
         .transpose()?
-        .unwrap_or_else(Vec::new))
+        .unwrap_or_default())
 }
 
 pub fn get_args_from_env_var() -> Option<Result<Vec<OsString>, shell_words::ParseError>> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -118,7 +118,7 @@ impl OpenedInput<'_> {
         self.metadata
             .user_provided_name
             .as_ref()
-            .or_else(|| match self.kind {
+            .or(match self.kind {
                 OpenedInputKind::OrdinaryFile(ref path) => Some(path),
                 _ => None,
             })


### PR DESCRIPTION
Clippy in the newly released Rust 1.60 found some new lints.
Conveniently, all of them were fixable with `--fix`.

By fixing these lints it becomes easier for us and others to see when
new lints are introduced.