### PR TITLE
Add `--relative` to `batdiff` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can combine `bat` with `git diff` to view lines around code changes with pro
 highlighting:
 ```bash
 batdiff() {
-    git diff --name-only --line-prefix=`git rev-parse --show-toplevel`/ --diff-filter=d | xargs bat --diff
+    git diff --name-only --relative --diff-filter=d | xargs bat --diff
 }
 ```
 If you prefer to use this as a separate tool, check out `batdiff` in [`bat-extras`](https://github.com/eth-p/bat-extras).

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can combine `bat` with `git diff` to view lines around code changes with pro
 highlighting:
 ```bash
 batdiff() {
-    git diff --name-only --diff-filter=d | xargs bat --diff
+    git diff --name-only --line-prefix=`git rev-parse --show-toplevel`/ --diff-filter=d | xargs bat --diff
 }
 ```
 If you prefer to use this as a separate tool, check out `batdiff` in [`bat-extras`](https://github.com/eth-p/bat-extras).


### PR DESCRIPTION
The change emits the absolute path from root for changed files so one does not need to be in the repo root for `batdiff` to work, anywhere within the repo is fine.

```
$ git diff --name-only --diff-filter=d
gcp/terraform/apps/platform/sum/main.tf
gcp/terraform/apps/platform/sum/prd.tfvars
```
vs
```
$ git diff --name-only --relative --diff-filter=d 
main.tf
uat.tfvars
```