### PR TITLE
Limit nix features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,15 +662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,7 +679,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ wait-timeout = "0.2.0"
 tempfile = "3.3.0"
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = "0.24.1"
+nix = { version = "0.24.1", default-features = false, features = ["term"] }
 
 [build-dependencies]
 clap = { version = "2.34", optional = true }


### PR DESCRIPTION
This removes memoffset as an indirect dependency, and should slightly decrease build times.