### PR TITLE
printer.rs: De-duplicate code to highlight long lines

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -445,18 +445,21 @@ impl<'a> Printer for InteractivePrinter<'a> {
                     return Ok(());
                 }
             };
+
             // skip syntax highlighting on long lines
-            if line.len() > 1024 * 16 {
-                let mut empty = highlighter_from_set
-                    .highlighter
-                    .highlight(&"\n", highlighter_from_set.syntax_set);
-                empty[0].1 = line.as_ref();
-                empty
-            } else {
-                highlighter_from_set
-                    .highlighter
-                    .highlight(&line, highlighter_from_set.syntax_set)
+            let too_long = line.len() > 1024 * 16;
+
+            let for_highlighting: &str = if too_long { "\n" } else { &line };
+
+            let mut highlighted_line = highlighter_from_set
+                .highlighter
+                .highlight(for_highlighting, highlighter_from_set.syntax_set);
+
+            if too_long {
+                highlighted_line[0].1 = &line;
             }
+
+            highlighted_line
         };
 
         if out_of_range {


### PR DESCRIPTION
We do this to only have one invocation of `highlighter.highlight(...)`
so we don't need to change to `highlighter.highlight_line(...)` in two
places in #2181.