### PR TITLE
Simplify release-checklist.md by printing `-h`, `--help` and `man` in CI

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -118,6 +118,18 @@ jobs:
         toolchain: stable
         default: true
         profile: minimal
+    - name: Print -h
+      uses: actions-rs/cargo@v1
+      with:
+        command: run
+        args: --locked -- -h
+    - name: Print --help
+      uses: actions-rs/cargo@v1
+      with:
+        command: run
+        args: --locked -- --help
+    - name: Show man page
+      run: man $(find . -name bat.1) | tee
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -129,7 +129,7 @@ jobs:
         command: run
         args: --locked -- --help
     - name: Show man page
-      run: man $(find . -name bat.1) | tee
+      run: man $(find . -name bat.1)
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -20,8 +20,8 @@
 
 ## Documentation
 
-- [ ] Review the `-h` and `--help` texts
-- [ ] Review the `man` page (`man $(fd -HIp target/release/build.*out/assets/manual/bat.1) | tee`)
+- [ ] Review `-h`, `--help`, and the `man` page. All of these are shown in
+      the output of the CI job called *Documentation*, so look there.
 
 ## Pre-release checks
 


### PR DESCRIPTION
Note that we run `find . -name bat.1` before we run anything with
`--all-features`, because `--all-features` is considered a separate
target, and so we will get a different (but identical) `bat.1`. For
example, we might have these:

    ./target/debug/build/bat-218e9538b4996215/out/assets/manual/bat.1
    ./target/debug/build/bat-89d6f56802af023f/out/assets/manual/bat.1

By showing the man page earlier, there is only one `bat.1` to pick from.