### PR TITLE
Tweak release-checklist.md

### DIFF
--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -31,7 +31,7 @@
 - [ ] Optional: manually test the new features and command-line options. To do
       this, install the latest `bat` version again (to include the new syntaxes
       and themes).
-- [ ] Run `cargo publish --dry-run --allow-dirty` to make sure that it will
+- [ ] Run `cargo publish --dry-run` to make sure that it will
       succeed later (after creating the GitHub release).
 
 ## Release

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -13,7 +13,7 @@
 
 ## Update syntaxes and themes (build assets)
 
-- [ ] Install the latest master version (`cargo clean && cargo install -f --path .`) and make
+- [ ] Install the latest master version (`cargo clean && cargo install --locked -f --path .`) and make
       sure that it is available on the `PATH` (`bat --version` should show the
       new version).
 - [ ] Run `assets/create.sh` and check in the binary asset files.

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -22,6 +22,7 @@
 
 - [ ] Review `-h`, `--help`, and the `man` page. All of these are shown in
       the output of the CI job called *Documentation*, so look there.
+      The CI workflow corresponding to the tip of the master branch is a good place to look.
 
 ## Pre-release checks
 

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -7,8 +7,8 @@
 - [ ] Find the current min. supported Rust version by running
       `grep '^\s*MIN_SUPPORTED_RUST_VERSION' .github/workflows/CICD.yml`.
 - [ ] Update the version and the min. supported Rust version in `README.md` and
-      `doc/README-*.md`. Check with `git grep -i 'rust.*1\.'` and
-      `git grep -i '1\..*rust'`.
+      `doc/README-*.md`. Check with
+      `git grep -i -e 'rust.*1\.' -e '1\..*rust' | grep README | grep -v tests/`.
 - [ ] Update `CHANGELOG.md`. Introduce a section for the new release.
 
 ## Update syntaxes and themes (build assets)


### PR DESCRIPTION
Using `--allow-dirty` increases the risk of the published code not being versioned properly in git, so stop recommending it.

Recommend `--locked` for `cargo install` so that the command will not fail if you are using the MSRV toolchain and the latest version of a dependency happens to have a higher MSRV than we do. Contrary to e.g. `cargo build`, `cargo install` will not default to versions in `Cargo.lock`, but instead try to use the latest compatible versions of everything, unless `--locked` is passed.

Recommend a single `git grep` command for MSRV that filters out irrelevant hits in `CHANGELOG.md` and `tests/`.

This is in preparation of the v0.21.0 release so that the diff becomes smaller when it is time to make the release for real.