### PR TITLE
Make `INI` syntax register as handler of `.inf` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Associate `/var/spool/mail/*` and `/var/mail/*` with the `Email` syntax. See #2156 (@cyqsimon)
 - Added cmd-help syntax to scope --help messages. See #2148 (@victor-gp)
 - Slightly adjust Zig syntax. See #2136 (@Enselic)
+- Associate `.inf` files with the `INI` syntax. See #2190 (@Enselic)
 
 ## Themes
 

--- a/assets/syntaxes/02_Extra/INI.sublime-syntax
+++ b/assets/syntaxes/02_Extra/INI.sublime-syntax
@@ -5,8 +5,8 @@ name: INI
 file_extensions:
   - ini
   - INI
-  - inf
-  - INF
+  - "inf"
+  - "INF"
   - reg
   - REG
   - lng

--- a/tests/syntax-tests/highlighted/INI/test.inf
+++ b/tests/syntax-tests/highlighted/INI/test.inf
@@ -1,0 +1,5 @@
+[38;2;248;248;242m[[0m[38;2;166;226;46msection[0m[38;2;248;248;242m][0m
+[38;2;249;38;114mkey[0m[38;2;248;248;242m=[0m[38;2;230;219;116mvalue[0m
+[38;2;117;113;94m#[0m[38;2;117;113;94m This file is just for testing that the INI syntax is registered to handle[0m
+[38;2;117;113;94m#[0m[38;2;117;113;94m the .inf file extension, it is not testing the syntax highlighting capabilities[0m
+[38;2;117;113;94m#[0m[38;2;117;113;94m of the INI syntax itself[0m

--- a/tests/syntax-tests/source/INI/test.inf
+++ b/tests/syntax-tests/source/INI/test.inf
@@ -1,0 +1,5 @@
+[section]
+key=value
+# This file is just for testing that the INI syntax is registered to handle
+# the .inf file extension, it is not testing the syntax highlighting capabilities
+# of the INI syntax itself


### PR DESCRIPTION
I discovered this while debugging an unexpected diff of `assets/syntaxes.bin` for the upcoming v0.21.0 release.

We need to type `inf` and `INF` as strings in `INI.sublime-syntax`,
otherwise `yaml-rust` interprets them as real numbers ("infinity") and
they do not get registered as file extensions:

    /Users/martin/src/yaml-rust # https://github.com/chyh1990/yaml-rust
    % cargo run --example dump_yaml ~/src/bat/assets/syntaxes/02_Extra/INI.sublime-syntax
    ---
    String("name"):
        String("INI")
    String("file_extensions"):
            String("ini")
            String("INI")
            Real("inf")        <--- NOTE: Interpreted as real number
            Real("INF")
    ...

Also add a regression test.