### PR TITLE
Relax glibc requirements on x86_64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -154,7 +154,7 @@ jobs:
           - { target: x86_64-apple-darwin         , os: macos-10.15                   }
           - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                  }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
     steps:
     - name: Checkout source code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Other
 
+- Relaxed glibc requirements on amd64, see #2106 and #2194 (@sharkdp)
+
 ## Syntaxes
 
 ## Themes


### PR DESCRIPTION
The Docker images used by `cross` use very old versions of glibc, so we can simply "cross" compile to fix #2106.

Before (binary from a recent master build):
```
▶ objdump -T bat|rg 'GLIBC_2.[0-9][0-9]'      
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.29) log
0000000000000000  w   DF *UND*	0000000000000000 (GLIBC_2.18) __cxa_thread_atexit_impl
0000000000000000  w   DF *UND*	0000000000000000 (GLIBC_2.25) getrandom
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.15) posix_spawnp
0000000000000000  w   DF *UND*	0000000000000000 (GLIBC_2.28) statx
0000000000000000  w   DF *UND*	0000000000000000 (GLIBC_2.29) posix_spawn_file_actions_addchdir_np
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.17) clock_gettime
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.14) memcpy
```

This PR:
```
▶ objdump -T bat|rg 'GLIBC_2.[0-9][0-9]'      
0000000000000000  w   DF *UND*	0000000000000000 (GLIBC_2.18) __cxa_thread_atexit_impl
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.14) memcpy
0000000000000000      DF *UND*	0000000000000000 (GLIBC_2.15) posix_spawnp
```


closes #2106