### PR TITLE
Make `--no-paging`/`-P` override `--paging=...` if passed as a later arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bugfixes
 
 - Prevent fork nightmare with `PAGER=batcat`. See #2235 (@johnmatthiggins)
+- Make `--no-paging`/`-P` override `--paging=...` if passed as a later arg, see #2201 (@themkat)
 
 ## Other
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -293,6 +293,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             Arg::with_name("paging")
                 .long("paging")
                 .overrides_with("paging")
+                .overrides_with("no-paging")
                 .takes_value(true)
                 .value_name("when")
                 .possible_values(&["auto", "never", "always"])

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -696,6 +696,18 @@ fn alias_pager_disable_long_overrides_short() {
 }
 
 #[test]
+fn disable_pager_if_disable_paging_flag_comes_after_paging() {
+    bat()
+        .env("PAGER", "echo pager-output")
+        .arg("--paging=always")
+        .arg("-P")
+        .arg("test.txt")
+        .assert()
+        .success()
+        .stdout(predicate::eq("hello world\n").normalize());
+}
+
+#[test]
 fn pager_failed_to_parse() {
     bat()
         .env("BAT_PAGER", "mismatched-quotes 'a")


### PR DESCRIPTION
Part of fix for #2128 

Makes the -P ~and -pp~ option take precedence over --paging when given. See issue for more details 🙂  Had to change one test, as it assumed the opposite of what the issue is explaining. 