### PR TITLE
Proof of concept: Lua plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "path_abs",
  "predicates",
  "regex",
+ "rlua",
  "semver",
  "serde",
  "serde_yaml",
@@ -914,6 +915,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a374af9a0e5fdcdd98c1c7b64f05004f9ea2555b6c75f211daa81268a3c50f1"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "rlua"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "627ae78424400009e889c43b0c188d0b7af3fe7301b68c03d9cfacb29115408a"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "libc",
+ "num-traits",
+ "rlua-lua54-sys",
+]
+
+[[package]]
+name = "rlua-lua54-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e1fdfc6a5f7acfa1b1fe26c5076b54f5ebd6818b5982460c39844c8b859370"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ minimal-application = [
     "paging",
     "regex-onig",
     "wild",
+    "rlua"
 ]
 git = ["git2"] # Support indicating git modifications
 paging = ["shell-words", "grep-cli"] # Support applying a pager on the output
@@ -65,6 +66,7 @@ grep-cli = { version = "0.1.6", optional = true }
 regex = { version = "1.5.5", optional = true }
 walkdir = { version = "2.0", optional = true }
 bytesize = { version = "1.1.0" }
+rlua = { version = "0.19", optional = true }
 
 [dependencies.git2]
 version = "0.14"

--- a/plugins/curl.lua
+++ b/plugins/curl.lua
@@ -1,0 +1,21 @@
+function tempdir()
+    local stream = assert(io.popen('mktemp --directory'))
+    local output = stream:read('*all')
+    stream:close()
+    return string.gsub(output, "\n", "")
+end
+
+function preprocess(path_or_url)
+    filename_from_url = string.match(path_or_url, '^https?://.*/(.*)$')
+    if filename_from_url then
+        local temp_directory = tempdir()
+        local new_path = temp_directory .. "/" .. filename_from_url
+
+        -- TODO: how to prevent shell injection bugs?
+        os.execute("curl --silent '" .. path_or_url .. "' --output '" .. new_path .. "'")
+
+        return new_path
+    else
+        return path_or_url
+    end
+end

--- a/plugins/directories.lua
+++ b/plugins/directories.lua
@@ -1,0 +1,17 @@
+-- https://stackoverflow.com/a/3254007/704831
+function is_dir(path)
+    local f = io.open(path, "r")
+    local ok, err, code = f:read(1)
+    f:close()
+    return code == 21
+end
+
+function preprocess(path)
+    if is_dir(path) then
+        tmpfile = os.tmpname()
+        os.execute("ls -alh --color=always '" .. path .. "' > '" .. tmpfile .. "'")
+        return tmpfile
+    else
+        return path
+    end
+end

--- a/plugins/hexyl.lua
+++ b/plugins/hexyl.lua
@@ -1,0 +1,21 @@
+-- Note: this plugin depends on the existence of 'inspect' [1] and 'hexyl' [2]
+--
+-- [1] https://github.com/sharkdp/content_inspector
+-- [2] https://github.com/sharkdp/hexyl
+
+function is_binary(path)
+    local stream = assert(io.popen("inspect '" .. path .. "'"))
+    local output = stream:read('*all')
+    stream:close()
+    return string.find(output, ": binary\n")
+end
+
+function preprocess(path)
+    if is_binary(path) then
+        tmpfile = os.tmpname()
+        os.execute("hexyl --length 1024 --no-position --border=none --no-squeezing '" .. path .. "' > '" .. tmpfile .. "'")
+        return tmpfile
+    else
+        return path
+    end
+end

--- a/plugins/uncompress.lua
+++ b/plugins/uncompress.lua
@@ -1,0 +1,21 @@
+function tempdir()
+    local stream = assert(io.popen('mktemp --directory'))
+    local output = stream:read('*all')
+    stream:close()
+    return string.gsub(output, "\n", "")
+end
+
+function preprocess(path)
+    prefix = string.match(path, '^(.*)%.gz$')
+    if prefix then
+        local temp_directory = tempdir()
+        local new_path = temp_directory .. "/" .. prefix
+
+        -- TODO: how to prevent shell injection bugs?
+        os.execute("gunzip < '" .. path .. "' > '" .. new_path .. "'")
+
+        return new_path
+    else
+        return path
+    end
+end

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -241,6 +241,11 @@ impl App {
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
             use_custom_assets: !self.matches.is_present("no-custom-assets"),
+            plugins: self
+                .matches
+                .values_of_os("load-plugin")
+                .unwrap_or_default()
+                .collect(),
         })
     }
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -475,6 +475,14 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .long_help("Display a list of supported languages for syntax highlighting."),
         )
         .arg(
+            Arg::with_name("load-plugin")
+            .long("load-plugin")
+            .takes_value(true)
+            .value_name("name")
+            .help("Load plugin with specified name.")
+            .hidden_short_help(true)
+        )
+        .arg(
             Arg::with_name("unbuffered")
                 .short("u")
                 .long("unbuffered")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -477,7 +477,9 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("load-plugin")
             .long("load-plugin")
+            .multiple(true)
             .takes_value(true)
+            .number_of_values(1)
             .value_name("name")
             .help("Load plugin with specified name.")
             .hidden_short_help(true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use crate::style::StyleComponents;
 use crate::syntax_mapping::SyntaxMapping;
 use crate::wrapping::WrappingMode;
 
+use std::ffi::OsStr;
+
 #[derive(Debug, Clone)]
 pub enum VisibleLines {
     /// Show all lines which are included in the line ranges
@@ -86,6 +88,9 @@ pub struct Config<'a> {
     /// Whether or not to allow custom assets. If this is false or if custom assets (a.k.a.
     /// cached assets) are not available, assets from the binary will be used instead.
     pub use_custom_assets: bool,
+
+    /// List of bat plugins to be loaded
+    pub plugins: Vec<&'a OsStr>,
 }
 
 #[cfg(all(feature = "minimal-application", feature = "paging"))]

--- a/src/input.rs
+++ b/src/input.rs
@@ -69,7 +69,8 @@ impl InputDescription {
     }
 }
 
-pub(crate) enum InputKind<'a> {
+pub enum InputKind<'a> {
+    // TODO
     OrdinaryFile(PathBuf),
     StdIn,
     CustomReader(Box<dyn Read + 'a>),
@@ -86,14 +87,15 @@ impl<'a> InputKind<'a> {
 }
 
 #[derive(Clone, Default)]
-pub(crate) struct InputMetadata {
-    pub(crate) user_provided_name: Option<PathBuf>,
+pub struct InputMetadata {
+    // TODO
+    pub user_provided_name: Option<PathBuf>,
     pub(crate) size: Option<u64>,
 }
 
 pub struct Input<'a> {
-    pub(crate) kind: InputKind<'a>,
-    pub(crate) metadata: InputMetadata,
+    pub kind: InputKind<'a>,     // TODO
+    pub metadata: InputMetadata, // TODO
     pub(crate) description: InputDescription,
 }
 


### PR DESCRIPTION
This is a proof-of-concept implementation of something that we discussed amongst the maintainers recently: a **plugin mechanism for bat**. The idea of this PR is to get the discussion started. And to answer a few questions. Most importantly: do we really want/need this?

This whole idea came up because there are a lot of feature requests that keep popping up on `bat`s issue tracker that we previously always declined, mostly because we wanted to keep `bat` focused on its core functionality. And because of the additional maintenance overhead:
- **gzip support** (#237, #642, #748, #2188)
- **CURL support** (#4, #2070)
- **`bat <directory>` support** (#427, #971, #1156, #1940)
- **View binary files as hex dump** (#619, #800, #1554)
- **Pretty printing** (#565, #1592, #2191)

On the other hand, most of these functionalities *are* actually quite useful! A lot of workarounds have been suggested. Lots of people wrote their own wrapper functions. And with [bat-extras](https://github.com/eth-p/bat-extras), we even have a dedicated project working on extending `bat`s functionality. The "problem" with all of these solutions is that they are not directly included in `bat`, so you need to remember the name of the wrapper scripts. And you need to install them separately.

Here, we try to follow a different approach: instead of forcing users to wrap `bat`, we enable users to *add functionality to bat* by providing a plugin mechanism. We could still maintain those plugins here in this repository. But (1) we could easily argue that those plugins are not part of `bat`s core functionality, especially if all of them would be opt-in (2) it would be easier to maintain this functionality... or to throw it out again. And (3), users could easily customize those plugins or write their own.

In this PoC, plugins can be enabled by adding lines like the following to your `bat` config file:
```bash
--load-plugin "uncompress.lua"
--load-plugin "curl.lua"
--load-plugin "directories.lua"
```
Plugins are written in Lua. For now, there is just one type of plugin: a "preprocess" plugin that can modify the input to `bat`. These plugins have to provide a `preprocess` function that will be called for every input path to `bat`. The plugins then have the option to *return a different path* instead. This can be used to hand back paths to temporary files with the output of the preprocessing. For example, `directories.lua` looks like this:
```lua
function preprocess(path)
    if is_dir(path) then
        tmpfile = os.tmpname()
        os.execute("ls -alh --color=always '" .. path .. "' > '" .. tmpfile .. "'")
        return tmpfile
    else
        return path
    end
end
```
Obviously, *this is not a great plugin architecture*. It's extremely restrictive. And the interface between `bat` and the plugins is very limited. I could easily imagine a lot of different things that we would like to expose to the plugins. Or functionality that we would like to provide (e.g. to add new command-line options to `bat`). But it's somewhat surprising that this simple interface is (up to a few limitations) powerful enough to handle four of the five feature requests listed above:

## Showcase

**gzip support**:
![image](https://user-images.githubusercontent.com/4209276/170888511-a79a390b-a404-496c-b51b-5a58387a60b7.png)

**CURL support**:
![image](https://user-images.githubusercontent.com/4209276/170888466-0907f53e-c85e-4b66-af09-d3684708a33f.png)

**`bat <directory>` support**
![image](https://user-images.githubusercontent.com/4209276/170888478-54a982bc-08b5-480c-8573-af97250df523.png)

**Preview binary files**

![image](https://user-images.githubusercontent.com/4209276/170890957-51b2f3be-99e6-4955-b33c-b609588d4f0a.png)


## Executable size, Benchmarks

I chose Lua because I heard that it is cheap to embed it into existing applications. And also fast. I have never programmed in Lua until today, so I would have probably have preferred another scripting language personally. But I don't think we want to ship a Python interpreter with `bat`.

But obviously, this still comes with some overhead in terms of binary size:
```
bat-master: 4.69 MB (4,685,824 bytes)
bat-2203:   5.05 MB (5,050,368 bytes)
```

Concerning startup time: the overhead here seems to be pretty much negligible. With three plugins activated and executed (but in the trivial "don't touch this path" mode) and 22 input files passed to `bat` (i.e. 3 x 22 = 66 Lua function invocations), we get a slowdown of less than a millisecond:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./bat-master src/*.rs` | 5.2 ± 0.4 | 4.5 | 7.4 | 1.00 |
| `./bat-2203 src/*.rs` | 5.6 ± 0.4 | 4.9 | 7.9 | 1.08 ± 0.12 |
