### PR TITLE
Make `bat::PrettyPrinter::syntaxes()` iterate over new `bat::Syntax` struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ## `bat` as a library
 
+- Make `bat::PrettyPrinter::syntaxes()` iterate over new `bat::Syntax` struct instead of `&syntect::parsing::SyntaxReference`. See #2222 (@Enselic)
+
 
 # v0.21.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub(crate) mod syntax_mapping;
 mod terminal;
 pub(crate) mod wrapping;
 
-pub use pretty_printer::{Input, PrettyPrinter};
+pub use pretty_printer::{Input, PrettyPrinter, Syntax};
 pub use syntax_mapping::{MappingTarget, SyntaxMapping};
 pub use wrapping::WrappingMode;
 

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -2,7 +2,6 @@ use std::io::Read;
 use std::path::Path;
 
 use console::Term;
-use syntect::parsing::SyntaxReference;
 
 use crate::{
     assets::HighlightingAssets,
@@ -26,6 +25,12 @@ struct ActiveStyleComponents {
     rule: bool,
     line_numbers: bool,
     snip: bool,
+}
+
+#[non_exhaustive]
+pub struct Syntax {
+    pub name: String,
+    pub file_extensions: Vec<String>,
 }
 
 pub struct PrettyPrinter<'a> {
@@ -240,10 +245,18 @@ impl<'a> PrettyPrinter<'a> {
         self.assets.themes()
     }
 
-    pub fn syntaxes(&self) -> impl Iterator<Item = &SyntaxReference> {
+    pub fn syntaxes(&self) -> impl Iterator<Item = Syntax> + '_ {
         // We always use assets from the binary, which are guaranteed to always
         // be valid, so get_syntaxes() can never fail here
-        self.assets.get_syntaxes().unwrap().iter()
+        self.assets
+            .get_syntaxes()
+            .unwrap()
+            .iter()
+            .filter(|s| !s.hidden)
+            .map(|s| Syntax {
+                name: s.name.clone(),
+                file_extensions: s.file_extensions.clone(),
+            })
     }
 
     /// Pretty-print all specified inputs. This method will "use" all stored inputs.

--- a/tests/test_pretty_printer.rs
+++ b/tests/test_pretty_printer.rs
@@ -1,0 +1,16 @@
+use bat::PrettyPrinter;
+
+#[test]
+fn syntaxes() {
+    let printer = PrettyPrinter::new();
+    let syntaxes: Vec<String> = printer.syntaxes().map(|s| s.name).collect();
+
+    // Just do some sanity checking
+    assert!(syntaxes.contains(&"Rust".to_string()));
+    assert!(syntaxes.contains(&"Java".to_string()));
+    assert!(!syntaxes.contains(&"this-language-does-not-exist".to_string()));
+
+    // This language exists but is hidden, so we should not see it; it shall
+    // have been filtered out before getting to us
+    assert!(!syntaxes.contains(&"Git Common".to_string()));
+}


### PR DESCRIPTION
We can't keep `syntect::parsing::SyntaxReference` as part of the public API, because that might prevent us from bumping to syntect 6.0.0 without also bumping bat to v2.0.0.

So introduce a new stripped down struct `Syntax` and return that instead. Let it be fully owned to make the API simple. It is not going to be in a hot code path anyway.

I have looked at all code of our 27 dependents but I can't find a single instance of this method being used, so this change should be safe for v1.0.0. It is only used in our own example code as far as I can tell.

For reference (mostly to my future self), here is the script I used to download the code of all dependents. Then one can grep around in the code of dependents:

```bash
#/usr/bin/env bash

# curl -L 'https://crates.io/api/v1/crates/bat/reverse_dependencies' | jq --raw-output '.versions | map(.crate) | flatten[]'
# curl -L 'https://crates.io/api/v1/crates/bat/reverse_dependencies?page=2' | jq --raw-output '.versions | map(.crate) | flatten[]'
# curl -L 'https://crates.io/api/v1/crates/bat/reverse_dependencies?page=3' | jq --raw-output '.versions | map(.crate) | flatten[]'
bat_dependents="
barberousse
borrowing_exerci
bropages
cargo-expand
download_caretaker
dsconv
dts
etrade
fix-hidden-lifetime-bug-proc_macros
gistit-cli
gistit
git-delta-lib
git-delta
gooseberry
hgrep
longboard
mdn
next-gen-proc_macros
nu_plugin_textview
partiql-rs
piqel
pmis
qcow-cli
raen
riffle
trrs
with_locals-proc_macros
"

for crate in $bat_dependents; do
    echo "Processing $crate"
    mkdir -p "$crate"
    cd "$crate"
    newest_version=$(curl -L https://crates.io/api/v1/crates/$crate | jq --raw-output .crate.newest_version)
    echo "$newest_version"
    curl -L "https://crates.io/api/v1/crates/$crate/$newest_version/download" | tar -zxf -
    cd ..

    sleep 2 # avoid throttling
done
```

Also see #2221