### PR TITLE
better fish completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Other
 
 - Relaxed glibc requirements on amd64, see #2106 and #2194 (@sharkdp)
+- Improved fish completions. See #2275 (@zgracem)
 
 ## Syntaxes
 

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -100,6 +100,14 @@ set -l color_opts '
 set -l decorations_opts $color_opts
 set -l paging_opts $color_opts
 
+# Include some examples so we can indicate the default.
+set -l pager_opts '
+    less\tdefault
+    less\ -FR\t
+    more\t
+    vimpager\t
+'
+
 set -l italic_text_opts '
     always\t
     never\tdefault
@@ -165,7 +173,7 @@ complete -c $bat -s m -l map-syntax -x -a "(__bat_complete_map_syntax)" -d "Map 
 
 complete -c $bat -s n -l number -d "Only show line numbers, no other decorations" -n __bat_no_excl_args
 
-complete -c $bat -l pager -x -a less\tdefault -d "Which pager to use" -n __bat_no_excl_args
+complete -c $bat -l pager -x -a "$pager_opts" -d "Which pager to use" -n __bat_no_excl_args
 
 complete -c $bat -l paging -x -a "$paging_opts" -d "When to use the pager" -n __bat_no_excl_args
 

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -207,3 +207,5 @@ complete -c $bat -l acknowledgements -d "Build acknowledgements.bin" -n __bat_ca
 complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_cache_no_excl
 
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
+
+# vim:ft=fish

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -1,78 +1,209 @@
 # Fish Shell Completions
-# Place or symlink to $XDG_CONFIG_HOME/fish/completions/{{PROJECT_EXECUTABLE}}.fish ($XDG_CONFIG_HOME is usually set to ~/.config)
+# Copy or symlink to $XDG_CONFIG_HOME/fish/completions/{{PROJECT_EXECUTABLE}}.fish
+# ($XDG_CONFIG_HOME is usually set to ~/.config)
 
-# Helper function:
-function __{{PROJECT_EXECUTABLE}}_autocomplete_languages --description "A helper function used by "(status filename)
-	{{PROJECT_EXECUTABLE}} --list-languages | awk -F':' '
-		{
-			lang=$1
-			split($2, exts, ",")
+# `bat` is `batcat` on Debian and Ubuntu
+set bat {{PROJECT_EXECUTABLE}}
 
-			for (i in exts) {
-				ext=exts[i]
-				if (ext !~ /[A-Z].*/ && ext !~ /^\..*rc$/) {
-					print ext"\t"lang
-				}
-			}
-		}
-	' | sort
+# Helper functions:
+
+function __bat_complete_files -a token
+    # Cheat to complete files by calling `complete -C` on a fake command name,
+    # like `__fish_complete_directories` does.
+    set -l fake_command aaabccccdeeeeefffffffffgghhhhhhiiiii
+    complete -C"$fake_command $token"
 end
+
+function __bat_complete_one_language -a comp
+    command $bat --list-languages | string split -f1 : | string match -e "$comp"
+end
+
+function __bat_complete_list_languages
+    for spec in (command $bat --list-languages)
+        set -l name (string split -f1 : $spec)
+        for ext in (string split -f2 : $spec | string split ,)
+            test -n "$ext"; or continue
+            string match -rq '[/*]' $ext; and continue
+            printf "%s\t%s\n" $ext $name
+        end
+        printf "%s\t\n" $name
+    end
+end
+
+function __bat_complete_map_syntax
+    set -l token (commandline -ct)
+
+    if string match -qr '(?<glob>.+):(?<syntax>.*)' -- $token
+        # If token ends with a colon, complete with the list of language names.
+        set -f comps $glob:(__bat_complete_one_language $syntax)
+    else if string match -qr '\*' -- $token
+        # If token contains a globbing character (`*`), complete only possible
+        # globs in the current directory
+        set -f comps (__bat_complete_files $token | string match -er '[*]'):
+    else
+        # Complete files (and globs).
+        set -f comps (__bat_complete_files $token | string match -erv '/$'):
+    end
+
+    if set -q comps[1]
+        printf "%s\t\n" $comps
+    end
+end
+
+function __bat_cache_subcommand
+    __fish_seen_subcommand_from cache
+end
+
+# Returns true if no exclusive arguments seen.
+function __bat_no_excl_args
+    not __bat_cache_subcommand; and not __fish_seen_argument \
+        -s h -l help \
+        -s V -l version \
+        -l acknowledgements \
+        -l config-dir -l config-file \
+        -l diagnostic \
+        -l list-languages -l list-themes
+end
+
+# Returns true if the 'cache' subcommand is seen without any exclusive arguments.
+function __bat_cache_no_excl
+    __bat_cache_subcommand; and not __fish_seen_argument \
+        -s h -l help \
+        -l acknowledgements -l build -l clear
+end
+
+function __bat_style_opts
+    set -l style_opts \
+        "default,recommended components" \
+        "auto,same as 'default' unless piped" \
+        "full,all components" \
+        "plain,no components" \
+        "changes,Git change markers" \
+        "header,alias for header-filename" \
+        "header-filename,filename above content" \
+        "header-filesize,filesize above content" \
+        "grid,lines b/w sidebar/header/content" \
+        "numbers,line numbers in sidebar" \
+        "rule,separate files" \
+        "snip,separate ranges"
+
+    string replace , \t $style_opts
+end
+
+# Use option argument descriptions to indicate which is the default, saving
+# horizontal space and making sure the option description isn't truncated.
+set -l color_opts '
+    auto\tdefault
+    never\t
+    always\t
+'
+set -l decorations_opts $color_opts
+set -l paging_opts $color_opts
+
+set -l italic_text_opts '
+    always\t
+    never\tdefault
+'
+
+set -l wrap_opts '
+    auto\tdefault
+    never\t
+    character\t
+'
+
+# While --tabs theoretically takes any number, most people should be OK with these.
+# Specifying a list lets us explain what 0 does.
+set -l tabs_opts '
+    0\tpass\ tabs\ through\ directly
+    1\t
+    2\t
+    4\t
+    8\t
+'
 
 # Completions:
 
-complete -c {{PROJECT_EXECUTABLE}} -l color -xka "auto never always" -d "Specify when to use colored output (default: auto)" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l acknowledgements -d "Print acknowledgements" -n __fish_is_first_arg
 
-complete -c {{PROJECT_EXECUTABLE}} -l config-dir -d "Display location of '{{PROJECT_EXECUTABLE}}' configuration directory" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l color -x -a "$color_opts" -d "When to use colored output" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -l config-file -d "Display location of '{{PROJECT_EXECUTABLE}}' configuration file" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l config-dir -f -d "Display location of configuration directory" -n __fish_is_first_arg
 
-complete -c {{PROJECT_EXECUTABLE}} -l decorations -xka "auto never always" -d "Specify when to use the decorations specified with '--style' (default: auto)" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l config-file -f -d "Display location of configuration file" -n __fish_is_first_arg
 
-complete -c {{PROJECT_EXECUTABLE}} -s h -l help -d "Print help message" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l decorations -x -a "$decorations_opts" -d "When to use --style decorations" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -s H -l highlight-line -x -d "<N> Highlight the N-th line with a different background color" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l diagnostic -d "Print diagnostic info for bug reports" -n __fish_is_first_arg
 
-complete -c {{PROJECT_EXECUTABLE}} -l italic-text -xka "always never" -d "Specify when to use ANSI sequences for italic text (default: never)" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s d -l diff -d "Only show lines with Git changes" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -s l -l language -d "Set the language for syntax highlighting" -n "not __fish_seen_subcommand_from cache" -xa "(__{{PROJECT_EXECUTABLE}}_autocomplete_languages)"
+complete -c $bat -l diff-context -x -d "Show N context lines around Git changes" -n "__fish_seen_argument -s d -l diff"
 
-complete -c {{PROJECT_EXECUTABLE}} -s r -l line-range -x -d "<N:M> Only print the specified range of lines for each file" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l file-name -x -d "Specify the display name" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -l list-languages -d "Display list of supported languages for syntax highlighting" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s f -l force-colorization -d "Force color and decorations" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -l list-themes -d "Display a list of supported themes for syntax highlighting" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s h -d "Print a concise overview" -n __fish_is_first_arg
 
-complete -c {{PROJECT_EXECUTABLE}} -s m -l map-syntax -x -d "<from:to> Map a file extension or file name to an existing syntax" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l help -f -d "Print all help information" -n __fish_is_first_arg
 
-complete -c {{PROJECT_EXECUTABLE}} -s n -l number -d "Only show line numbers, no other decorations. Alias for '--style=numbers'" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s H -l highlight-line -x -d "Highlight line(s) N[:M]" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -l pager -x -d "<command> Specify which pager program to use (default: less)" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l ignored-suffix -x -d "Ignore extension" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -l paging -xka "auto never always" -d "Specify when to use the pager (default: auto)" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l italic-text -x -a "$italic_text_opts" -d "When to use italic text in the output" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -s p -l plain -d "Only show plain style, no decorations. Alias for '--style=plain'" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s l -l language -x -k -a "(__bat_complete_list_languages)" -d "Set the syntax highlighting language" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -s P -d "Disable paging. Alias for '--paging=never'" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s r -l line-range -x -d "Only print lines [M]:[N] (either optional)" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -s A -l show-all -d "Show non-printable characters like space/tab/newline" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l list-languages -f -d "List syntax highlighting languages" -n __fish_is_first_arg
 
-complete -c {{PROJECT_EXECUTABLE}} -l style -xka "default auto full plain changes header header-filename header-filesize grid rule numbers snip" -d "Comma-separated list of style elements or presets to display with file contents" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l list-themes -f -d "List syntax highlighting themes" -n __fish_is_first_arg
 
-complete -c {{PROJECT_EXECUTABLE}} -l tabs -x -d "<T> Set the tab width to T spaces (width of 0 passes tabs through directly)" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s m -l map-syntax -x -a "(__bat_complete_map_syntax)" -d "Map <glob pattern>:<language syntax>" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -l terminal-width -x -d "<width> Explicitly set terminal width; Prefix with '+' or '-' to offset (default width is auto determined)" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s n -l number -d "Only show line numbers, no other decorations" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -l theme -xka "({{PROJECT_EXECUTABLE}} --list-themes | cat)" -d "Set the theme for syntax highlighting" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l pager -x -a less\tdefault -d "Which pager to use" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -s u -l unbuffered -d "POSIX-compliant unbuffered output. Option is ignored" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -l paging -x -a "$paging_opts" -d "When to use the pager" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -s V -l version -d "Show version information" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -s p -l plain -d "Disable decorations" -n __bat_no_excl_args
 
-complete -c {{PROJECT_EXECUTABLE}} -l wrap -xka "auto never character" -d "<mode> Specify the text-wrapping mode (default: auto)" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -o pp -d "Disable decorations and paging" -n __bat_no_excl_args
+
+complete -c $bat -s P -d "Disable paging" -n __bat_no_excl_args
+
+complete -c $bat -s A -l show-all -d "Show non-printable characters" -n __bat_no_excl_args
+
+complete -c $bat -l style -x -k -a "(__fish_complete_list , __bat_style_opts)" -d "Specify which non-content elements to display" -n __bat_no_excl_args
+
+complete -c $bat -l tabs -x -a "$tabs_opts" -d "Set tab width" -n __bat_no_excl_args
+
+complete -c $bat -l terminal-width -x -d "Set terminal <width>, +<offset>, or -<offset>" -n __bat_no_excl_args
+
+complete -c $bat -l theme -x -a "(command $bat --list-themes | command cat)" -d "Set the syntax highlighting theme" -n __bat_no_excl_args
+
+complete -c $bat -s V -l version -f -d "Show version information" -n __fish_is_first_arg
+
+complete -c $bat -l wrap -x -a "$wrap_opts" -d "Text-wrapping mode" -n __bat_no_excl_args
 
 # Sub-command 'cache' completions
-complete -c {{PROJECT_EXECUTABLE}} -a "cache" -d "Modify the syntax/language definition cache" -n "not __fish_seen_subcommand_from cache"
+complete -c $bat -a cache -d "Modify the syntax/language definition cache" -n __fish_use_subcommand
 
-complete -c {{PROJECT_EXECUTABLE}} -l build -f -d "Parse syntaxes/language definitions into cache" -n "__fish_seen_subcommand_from cache"
+complete -c $bat -l build -f -d "Parse new definitions into cache" -n __bat_cache_no_excl
 
-complete -c {{PROJECT_EXECUTABLE}} -l clear -f -d "Reset syntaxes/language definitions to default settings" -n "__fish_seen_subcommand_from cache"
+complete -c $bat -l clear -f -d "Reset definitions to defaults" -n __bat_cache_no_excl
+
+complete -c $bat -l blank -f -d "Create new data instead of appending" -n "__bat_cache_subcommand; and not __fish_seen_argument -l clear"
+
+complete -c $bat -l source -x -a "(__fish_complete_directories)" -d "Load syntaxes and themes from DIR" -n "__bat_cache_subcommand; and not __fish_seen_argument -l clear"
+
+complete -c $bat -l target -x -a "(__fish_complete_directories)" -d "Store cache in DIR" -n __bat_cache_subcommand
+
+complete -c $bat -l acknowledgements -d "Build acknowledgements.bin" -n __bat_cache_no_excl
+
+complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_cache_no_excl
+
+complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl


### PR DESCRIPTION
Back in 2020, the command-line completions for bat that had been shipping with fish were removed in favour of the completions file that currently ships with bat (see discussion in #651). Unfortunately, the [deprecated fish completions](https://github.com/fish-shell/fish-shell/blob/ea8a2b2/share/completions/bat.fish) had some nifty features that weren't carried over. This PR restores those features and expands upon them.

Improvements vs. the current completions:

- Less verbose descriptions → better columned layout.
  - Notably, default options (e.g. `always`, `auto`) are indicated in the option-completion text, not the description of the option itself.
- Supports all documented options, including those for `bat cache`.
- Fully (!) supports completing `bat --map-syntax <glob pattern>:<language syntax>`.
- Supports multiple comma-separated arguments to `bat --style`.
- Regular output options (e.g. `--style`) won't be suggested if a previous option (e.g. `--help`) overrides regular output/behaviour.
- The `{{PROJECT_EXECUTABLE}}` placeholders have been place-held by the locally-scoped `$bat`, for ease of reading and editing.
  - The names of the support functions (e.g. `__bat_complete_map_syntax`) are no longer parameterized, but "the other bat" [doesn't include shell completions](https://packages.debian.org/sid/x32/bacula-console-qt/filelist) as far as I can tell, so there shouldn't be any collisions.

Please let me know if you have any questions!

***

Before:

<img width="1064" alt="bat-before" src="https://user-images.githubusercontent.com/1896569/184782838-3f74805d-327c-4ac7-96d5-6aad59b65ea7.png">

After:

<img width="1064" alt="bat-after" src="https://user-images.githubusercontent.com/1896569/184782849-2fe41732-26c0-493f-b605-98e556628454.png">

`bat --italic-text=` before:

<img width="1064" alt="bat-italic-before" src="https://user-images.githubusercontent.com/1896569/184782879-b6b6f3cb-dc1e-4cb6-9c36-604bc28710f3.png">

`bat --italic-text=` after:

<img width="1064" alt="bat-italic-after" src="https://user-images.githubusercontent.com/1896569/184782883-7d7a959e-e905-4d3c-bb95-951b30373f2e.png">

`bat --style=` before:

<img width="1064" alt="bat-style-before" src="https://user-images.githubusercontent.com/1896569/184782902-16743e27-cd55-4f8e-970b-1200695cf5aa.png">

`bat --style=` after:

<img width="1064" alt="bat-style-after" src="https://user-images.githubusercontent.com/1896569/184782910-0ceb7f0e-5ea4-47e3-9f68-39d640e85e54.png">
