### PR TITLE
refactor: Migrate to clap 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,18 +193,28 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
- "term_size",
+ "termcolor",
+ "terminal_size",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -716,6 +726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,9 +1061,9 @@ checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1109,16 +1125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,12 +1151,11 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
- "term_size",
- "unicode-width",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1242,12 +1247,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,10 @@ default-features = false
 features = ["parsing"]
 
 [dependencies.clap]
-version = "2.34"
+version = "3.2.20"
 optional = true
 default-features = false
-features = ["suggestions", "color", "wrap_help"]
+features = ["std", "suggestions", "color", "wrap_help", "cargo"]
 
 [dev-dependencies]
 assert_cmd = "2.0.4"
@@ -93,7 +93,7 @@ tempfile = "3.3.0"
 nix = { version = "0.24.2", default-features = false, features = ["term"] }
 
 [build-dependencies]
-clap = { version = "2.34", optional = true }
+clap = { version = "3.2.20", optional = true }
 
 [profile.release]
 lto = true

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -84,7 +84,7 @@ impl App {
             Some("never") => PagingMode::Never,
             Some("auto") | None => {
                 // If we have -pp as an option when in auto mode, the pager should be disabled.
-                let extra_plain = self.matches.occurrences_of("plain") > 1;
+                let extra_plain = self.matches.get_count("plain") > 1;
                 if extra_plain || self.matches.is_present("no-paging") {
                     PagingMode::Never
                 } else if inputs.iter().any(Input::is_stdin) {
@@ -297,7 +297,7 @@ impl App {
                 HashSet::new()
             } else if matches.is_present("number") {
                 [StyleComponent::LineNumbers].iter().cloned().collect()
-            } else if matches.is_present("plain") {
+            } else if 0 < matches.get_count("plain") {
                 [StyleComponent::Plain].iter().cloned().collect()
             } else {
                 let env_style_components: Option<Vec<StyleComponent>> = env::var("BAT_STYLE")

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -85,7 +85,7 @@ impl App {
             Some("auto") | None => {
                 // If we have -pp as an option when in auto mode, the pager should be disabled.
                 let extra_plain = self.matches.get_count("plain") > 1;
-                if extra_plain || self.matches.is_present("no-paging") {
+                if extra_plain || self.matches.get_flag("no-paging") {
                     PagingMode::Never
                 } else if inputs.iter().any(Input::is_stdin) {
                     // If we are reading from stdin, only enable paging if we write to an
@@ -153,13 +153,13 @@ impl App {
                 .get_one::<String>("language")
                 .map(|s| s.as_str())
                 .or_else(|| {
-                    if self.matches.is_present("show-all") {
+                    if self.matches.get_flag("show-all") {
                         Some("show-nonprintable")
                     } else {
                         None
                     }
                 }),
-            show_nonprintable: self.matches.is_present("show-all"),
+            show_nonprintable: self.matches.get_flag("show-all"),
             wrapping_mode: if self.interactive_output || maybe_term_width.is_some() {
                 match self.matches.get_one::<String>("wrap").map(|s| s.as_str()) {
                     Some("character") => WrappingMode::Character,
@@ -178,7 +178,7 @@ impl App {
                 // There's no point in wrapping when this is the case.
                 WrappingMode::NoWrapping(false)
             },
-            colored_output: self.matches.is_present("force-colorization")
+            colored_output: self.matches.get_flag("force-colorization")
                 || match self.matches.get_one::<String>("color").map(|s| s.as_str()) {
                     Some("always") => true,
                     Some("never") => false,
@@ -194,7 +194,7 @@ impl App {
                     .get_one::<String>("decorations")
                     .map(|s| s.as_str())
                     == Some("always")
-                || self.matches.is_present("force-colorization")),
+                || self.matches.get_flag("force-colorization")),
             tab_width: self
                 .matches
                 .get_one::<String>("tabs")
@@ -221,7 +221,7 @@ impl App {
                     }
                 })
                 .unwrap_or_else(|| String::from(HighlightingAssets::default_theme())),
-            visible_lines: match self.matches.is_present("diff") {
+            visible_lines: match self.matches.contains_id("diff") && self.matches.get_flag("diff") {
                 #[cfg(feature = "git")]
                 true => VisibleLines::DiffContext(
                     self.matches
@@ -255,7 +255,7 @@ impl App {
                 .map(LineRanges::from)
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
-            use_custom_assets: !self.matches.is_present("no-custom-assets"),
+            use_custom_assets: !self.matches.get_flag("no-custom-assets"),
         })
     }
 
@@ -310,7 +310,7 @@ impl App {
         let mut styled_components = StyleComponents(
             if matches.get_one::<String>("decorations").map(|s| s.as_str()) == Some("never") {
                 HashSet::new()
-            } else if matches.is_present("number") {
+            } else if matches.get_flag("number") {
                 [StyleComponent::LineNumbers].iter().cloned().collect()
             } else if 0 < matches.get_count("plain") {
                 [StyleComponent::Plain].iter().cloned().collect()

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -32,7 +32,7 @@ fn is_truecolor_terminal() -> bool {
 }
 
 pub struct App {
-    pub matches: ArgMatches<'static>,
+    pub matches: ArgMatches,
     interactive_output: bool,
 }
 
@@ -49,7 +49,7 @@ impl App {
         })
     }
 
-    fn matches(interactive_output: bool) -> Result<ArgMatches<'static>> {
+    fn matches(interactive_output: bool) -> Result<ArgMatches> {
         let args = if wild::args_os().nth(1) == Some("cache".into())
             || wild::args_os().any(|arg| arg == "--no-config")
         {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -16,7 +16,7 @@ static VERSION: Lazy<String> = Lazy::new(|| {
     }
 });
 
-pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
+pub fn build_app(interactive_output: bool) -> ClapApp<'static> {
     let clap_color_setting = if interactive_output && env::var_os("NO_COLOR").is_none() {
         AppSettings::ColoredHelp
     } else {
@@ -32,7 +32,6 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .setting(AppSettings::ArgsNegateSubcommands)
         .setting(AppSettings::AllowExternalSubcommands)
         .setting(AppSettings::DisableHelpSubcommand)
-        .setting(AppSettings::VersionlessSubcommands)
         .max_term_width(100)
         .about(
             "A cat(1) clone with wings.\n\n\
@@ -50,14 +49,16 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                     "File(s) to print / concatenate. Use a dash ('-') or no argument at all \
                      to read from standard input.",
                 )
+                .takes_value(true)
                 .multiple(true)
-                .empty_values(false),
+                .empty_values(false)
+                .allow_invalid_utf8(true),
         )
         .arg(
             Arg::with_name("show-all")
                 .long("show-all")
                 .alias("show-nonprintable")
-                .short("A")
+                .short('A')
                 .conflicts_with("language")
                 .help("Show non-printable characters (space, tab, newline, ..).")
                 .long_help(
@@ -70,9 +71,9 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             Arg::with_name("plain")
                 .overrides_with("plain")
                 .overrides_with("number")
-                .short("p")
+                .short('p')
                 .long("plain")
-                .multiple(true)
+                .multiple_occurrences(true)
                 .help("Show plain style (alias for '--style=plain').")
                 .long_help(
                     "Only show plain style, no decorations. This is an alias for \
@@ -82,7 +83,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         )
         .arg(
             Arg::with_name("language")
-                .short("l")
+                .short('l')
                 .long("language")
                 .overrides_with("language")
                 .help("Set the language for syntax highlighting.")
@@ -97,7 +98,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("highlight-line")
                 .long("highlight-line")
-                .short("H")
+                .short('H')
                 .takes_value(true)
                 .number_of_values(1)
                 .multiple(true)
@@ -120,6 +121,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .number_of_values(1)
                 .multiple(true)
                 .value_name("name")
+                .allow_invalid_utf8(true)
                 .help("Specify the name to display for a file.")
                 .long_help(
                     "Specify the name to display for a file. Useful when piping \
@@ -135,7 +137,8 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .arg(
                     Arg::with_name("diff")
                         .long("diff")
-                        .short("d")
+                        .short('d')
+                        .conflicts_with("line-range")
                         .help("Only show lines that have been added/removed/modified.")
                         .long_help(
                             "Only show lines that have been added/removed/modified with respect \
@@ -226,7 +229,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
             Arg::with_name("number")
                 .long("number")
                 .overrides_with("number")
-                .short("n")
+                .short('n')
                 .help("Show line numbers (alias for '--style=numbers').")
                 .long_help(
                     "Only show line numbers, no other decorations. This is an alias for \
@@ -280,7 +283,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("force-colorization")
                 .long("force-colorization")
-                .short("f")
+                .short('f')
                 .conflicts_with("color")
                 .conflicts_with("decorations")
                 .overrides_with("force-colorization")
@@ -309,7 +312,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         )
         .arg(
             Arg::with_name("no-paging")
-                .short("P")
+                .short('P')
                 .long("no-paging")
                 .alias("no-pager")
                 .overrides_with("no-paging")
@@ -334,7 +337,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         )
         .arg(
             Arg::with_name("map-syntax")
-                .short("m")
+                .short('m')
                 .long("map-syntax")
                 .multiple(true)
                 .takes_value(true)
@@ -450,12 +453,11 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("line-range")
                 .long("line-range")
-                .short("r")
+                .short('r')
                 .multiple(true)
                 .takes_value(true)
                 .number_of_values(1)
                 .value_name("N:M")
-                .conflicts_with("diff")
                 .help("Only print the lines from N to M.")
                 .long_help(
                     "Only print the specified range of lines for each file. \
@@ -470,14 +472,14 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
         .arg(
             Arg::with_name("list-languages")
                 .long("list-languages")
-                .short("L")
+                .short('L')
                 .conflicts_with("list-themes")
                 .help("Display all supported languages.")
                 .long_help("Display a list of supported languages for syntax highlighting."),
         )
         .arg(
             Arg::with_name("unbuffered")
-                .short("u")
+                .short('u')
                 .long("unbuffered")
                 .hidden_short_help(true)
                 .long_help(
@@ -539,8 +541,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .hidden_short_help(true)
                 .help("Show acknowledgements."),
         )
-        .help_message("Print this help message.")
-        .version_message("Show version information.");
+        .help_message("Print this help message.");
 
     // Check if the current directory contains a file name cache. Otherwise,
     // enable the 'bat cache' subcommand.
@@ -553,7 +554,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .arg(
                     Arg::with_name("build")
                         .long("build")
-                        .short("b")
+                        .short('b')
                         .help("Initialize (or update) the syntax/theme cache.")
                         .long_help(
                             "Initialize (or update) the syntax/theme cache by loading from \
@@ -563,7 +564,7 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 .arg(
                     Arg::with_name("clear")
                         .long("clear")
-                        .short("c")
+                        .short('c')
                         .help("Remove the cached syntax definitions and themes."),
                 )
                 .group(
@@ -606,4 +607,9 @@ pub fn build_app(interactive_output: bool) -> ClapApp<'static, 'static> {
                 ),
         )
     }
+}
+
+#[test]
+fn verify_app() {
+    build_app(false).debug_assert();
 }

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -60,6 +60,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 .long("show-all")
                 .alias("show-nonprintable")
                 .short('A')
+                .action(ArgAction::SetTrue)
                 .conflicts_with("language")
                 .help("Show non-printable characters (space, tab, newline, ..).")
                 .long_help(
@@ -137,6 +138,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                     Arg::new("diff")
                         .long("diff")
                         .short('d')
+                        .action(ArgAction::SetTrue)
                         .conflicts_with("line-range")
                         .help("Only show lines that have been added/removed/modified.")
                         .long_help(
@@ -229,6 +231,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 .long("number")
                 .overrides_with("number")
                 .short('n')
+                .action(ArgAction::SetTrue)
                 .help("Show line numbers (alias for '--style=numbers').")
                 .long_help(
                     "Only show line numbers, no other decorations. This is an alias for \
@@ -283,6 +286,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
             Arg::new("force-colorization")
                 .long("force-colorization")
                 .short('f')
+                .action(ArgAction::SetTrue)
                 .conflicts_with("color")
                 .conflicts_with("decorations")
                 .overrides_with("force-colorization")
@@ -314,6 +318,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 .short('P')
                 .long("no-paging")
                 .alias("no-pager")
+                .action(ArgAction::SetTrue)
                 .overrides_with("no-paging")
                 .hide(true)
                 .hide_short_help(true)
@@ -379,6 +384,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
         .arg(
             Arg::new("list-themes")
                 .long("list-themes")
+                .action(ArgAction::SetTrue)
                 .help("Display all supported highlighting themes.")
                 .long_help("Display a list of supported themes for syntax highlighting."),
         )
@@ -469,6 +475,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
             Arg::new("list-languages")
                 .long("list-languages")
                 .short('L')
+                .action(ArgAction::SetTrue)
                 .conflicts_with("list-themes")
                 .help("Display all supported languages.")
                 .long_help("Display a list of supported languages for syntax highlighting."),
@@ -493,12 +500,14 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
         .arg(
             Arg::new("no-custom-assets")
                 .long("no-custom-assets")
+                .action(ArgAction::SetTrue)
                 .hide(true)
                 .help("Do not load custom assets"),
         )
         .arg(
             Arg::new("config-file")
                 .long("config-file")
+                .action(ArgAction::SetTrue)
                 .conflicts_with("list-languages")
                 .conflicts_with("list-themes")
                 .hide(true)
@@ -507,6 +516,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
         .arg(
             Arg::new("generate-config-file")
                 .long("generate-config-file")
+                .action(ArgAction::SetTrue)
                 .conflicts_with("list-languages")
                 .conflicts_with("list-themes")
                 .hide(true)
@@ -515,12 +525,14 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
         .arg(
             Arg::new("config-dir")
                 .long("config-dir")
+                .action(ArgAction::SetTrue)
                 .hide(true)
                 .help("Show bat's configuration directory."),
         )
         .arg(
             Arg::new("cache-dir")
                 .long("cache-dir")
+                .action(ArgAction::SetTrue)
                 .hide(true)
                 .help("Show bat's cache directory."),
         )
@@ -528,12 +540,14 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
             Arg::new("diagnostic")
                 .long("diagnostic")
                 .alias("diagnostics")
+                .action(ArgAction::SetTrue)
                 .hide_short_help(true)
                 .help("Show diagnostic information for bug reports.")
         )
         .arg(
             Arg::new("acknowledgements")
                 .long("acknowledgements")
+                .action(ArgAction::SetTrue)
                 .hide_short_help(true)
                 .help("Show acknowledgements."),
         )
@@ -551,6 +565,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                     Arg::new("build")
                         .long("build")
                         .short('b')
+                        .action(ArgAction::SetTrue)
                         .help("Initialize (or update) the syntax/theme cache.")
                         .long_help(
                             "Initialize (or update) the syntax/theme cache by loading from \
@@ -561,6 +576,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                     Arg::new("clear")
                         .long("clear")
                         .short('c')
+                        .action(ArgAction::SetTrue)
                         .help("Remove the cached syntax definitions and themes."),
                 )
                 .group(
@@ -586,13 +602,20 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                             "Use a different directory to store the cached syntax and theme set.",
                         ),
                 )
-                .arg(Arg::new("blank").long("blank").requires("build").help(
-                    "Create completely new syntax and theme sets \
+                .arg(
+                    Arg::new("blank")
+                        .long("blank")
+                        .action(ArgAction::SetTrue)
+                        .requires("build")
+                        .help(
+                            "Create completely new syntax and theme sets \
                              (instead of appending to the default sets).",
-                ))
+                        ),
+                )
                 .arg(
                     Arg::new("acknowledgements")
                         .long("acknowledgements")
+                        .action(ArgAction::SetTrue)
                         .requires("build")
                         .help("Build acknowledgements.bin."),
                 ),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -1,5 +1,6 @@
 use clap::{
-    crate_name, crate_version, value_parser, AppSettings, Arg, ArgGroup, ColorChoice, Command,
+    crate_name, crate_version, value_parser, AppSettings, Arg, ArgAction, ArgGroup, ColorChoice,
+    Command,
 };
 use once_cell::sync::Lazy;
 use std::env;
@@ -73,7 +74,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 .overrides_with("number")
                 .short('p')
                 .long("plain")
-                .multiple_occurrences(true)
+                .action(ArgAction::Count)
                 .help("Show plain style (alias for '--style=plain').")
                 .long_help(
                     "Only show plain style, no decorations. This is an alias for \
@@ -100,7 +101,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 .long("highlight-line")
                 .short('H')
                 .takes_value(true)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .value_name("N:M")
                 .help("Highlight lines N through M.")
                 .long_help(
@@ -117,7 +118,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
             Arg::new("file-name")
                 .long("file-name")
                 .takes_value(true)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .value_name("name")
                 .value_parser(value_parser!(PathBuf))
                 .help("Specify the name to display for a file.")
@@ -337,7 +338,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
             Arg::new("map-syntax")
                 .short('m')
                 .long("map-syntax")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .takes_value(true)
                 .value_name("glob:syntax")
                 .help("Use the specified syntax for files matching the glob pattern ('*.cpp:C++').")
@@ -352,7 +353,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
         )
         .arg(
             Arg::new("ignored-suffix")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .takes_value(true)
                 .long("ignored-suffix")
                 .hide_short_help(true)
@@ -450,7 +451,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
             Arg::new("line-range")
                 .long("line-range")
                 .short('r')
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .takes_value(true)
                 .value_name("N:M")
                 .help("Only print the lines from N to M.")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -152,11 +152,11 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                         .overrides_with("diff-context")
                         .takes_value(true)
                         .value_name("N")
-                        .validator(
-                            |n| {
+                        .value_parser(
+                            |n: &str| {
                                 n.parse::<usize>()
                                     .map_err(|_| "must be a number")
-                                    .map(|_| ()) // Convert to Result<(), &str>
+                                    .map(|_| n.to_owned()) // Convert to Result<String, &str>
                                     .map_err(|e| e.to_string())
                             }, // Convert to Result<(), String>
                         )
@@ -173,11 +173,11 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
             .overrides_with("tabs")
             .takes_value(true)
             .value_name("T")
-            .validator(
-                |t| {
+            .value_parser(
+                |t: &str| {
                     t.parse::<u32>()
                         .map_err(|_t| "must be a number")
-                        .map(|_t| ()) // Convert to Result<(), &str>
+                        .map(|_t| t.to_owned()) // Convert to Result<String, &str>
                         .map_err(|e| e.to_string())
                 }, // Convert to Result<(), String>
             )
@@ -208,15 +208,15 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 .value_name("width")
                 .hide_short_help(true)
                 .allow_hyphen_values(true)
-                .validator(
-                    |t| {
+                .value_parser(
+                    |t: &str| {
                         let is_offset = t.starts_with('+') || t.starts_with('-');
                         t.parse::<i32>()
                             .map_err(|_e| "must be an offset or number")
                             .and_then(|v| if v == 0 && !is_offset {
                                 Err("terminal width cannot be zero")
                             } else {
-                                Ok(())
+                                Ok(t.to_owned())
                             })
                             .map_err(|e| e.to_string())
                     })
@@ -400,7 +400,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 .overrides_with("plain")
                 .overrides_with("number")
                 // Cannot use claps built in validation because we have to turn off clap's delimiters
-                .validator(|val| {
+                .value_parser(|val: &str| {
                     let mut invalid_vals = val.split(',').filter(|style| {
                         !&[
                             "auto",
@@ -422,7 +422,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                     if let Some(invalid) = invalid_vals.next() {
                         Err(format!("Unknown style, '{}'", invalid))
                     } else {
-                        Ok(())
+                        Ok(val.to_owned())
                     }
                 })
                 .help(

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -1,7 +1,9 @@
-use clap::{crate_name, crate_version, AppSettings, Arg, ArgGroup, ColorChoice, Command};
+use clap::{
+    crate_name, crate_version, value_parser, AppSettings, Arg, ArgGroup, ColorChoice, Command,
+};
 use once_cell::sync::Lazy;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 static VERSION: Lazy<String> = Lazy::new(|| {
     #[cfg(feature = "bugreport")]
@@ -50,7 +52,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 )
                 .takes_value(true)
                 .multiple_values(true)
-                .allow_invalid_utf8(true),
+                .value_parser(value_parser!(PathBuf)),
         )
         .arg(
             Arg::new("show-all")
@@ -117,7 +119,7 @@ pub fn build_app(interactive_output: bool) -> Command<'static> {
                 .takes_value(true)
                 .multiple_occurrences(true)
                 .value_name("name")
-                .allow_invalid_utf8(true)
+                .value_parser(value_parser!(PathBuf))
                 .help("Specify the name to display for a file.")
                 .long_help(
                     "Specify the name to display for a file. Useful when piping \

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -39,11 +39,11 @@ const THEME_PREVIEW_DATA: &[u8] = include_bytes!("../../../assets/theme_preview.
 #[cfg(feature = "build-assets")]
 fn build_assets(matches: &clap::ArgMatches) -> Result<()> {
     let source_dir = matches
-        .value_of("source")
+        .get_one::<String>("source")
         .map(Path::new)
         .unwrap_or_else(|| PROJECT_DIRS.config_dir());
     let target_dir = matches
-        .value_of("target")
+        .get_one::<String>("target")
         .map(Path::new)
         .unwrap_or_else(|| PROJECT_DIRS.cache_dir());
 
@@ -227,8 +227,10 @@ fn run_controller(inputs: Vec<Input>, config: &Config) -> Result<bool> {
 #[cfg(feature = "bugreport")]
 fn invoke_bugreport(app: &App) {
     use bugreport::{bugreport, collector::*, format::Markdown};
-    let pager = bat::config::get_pager_executable(app.matches.value_of("pager"))
-        .unwrap_or_else(|| "less".to_owned()); // FIXME: Avoid non-canonical path to "less".
+    let pager = bat::config::get_pager_executable(
+        app.matches.get_one::<String>("pager").map(|s| s.as_str()),
+    )
+    .unwrap_or_else(|| "less".to_owned()); // FIXME: Avoid non-canonical path to "less".
 
     let mut custom_assets_metadata = PROJECT_DIRS.cache_dir().to_path_buf();
     custom_assets_metadata.push("metadata.yaml");

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -293,11 +293,11 @@ fn run() -> Result<bool> {
     }
 
     match app.matches.subcommand() {
-        ("cache", Some(cache_matches)) => {
+        Some(("cache", cache_matches)) => {
             // If there is a file named 'cache' in the current working directory,
             // arguments for subcommand 'cache' are not mandatory.
             // If there are non-zero arguments, execute the subcommand cache, else, open the file cache.
-            if !cache_matches.args.is_empty() {
+            if cache_matches.args_present() {
                 run_cache_subcommand(cache_matches)?;
                 Ok(true)
             } else {

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -49,20 +49,20 @@ fn build_assets(matches: &clap::ArgMatches) -> Result<()> {
 
     bat::assets::build(
         source_dir,
-        !matches.is_present("blank"),
-        matches.is_present("acknowledgements"),
+        !matches.get_flag("blank"),
+        matches.get_flag("acknowledgements"),
         target_dir,
         clap::crate_version!(),
     )
 }
 
 fn run_cache_subcommand(matches: &clap::ArgMatches) -> Result<()> {
-    if matches.is_present("build") {
+    if matches.get_flag("build") {
         #[cfg(feature = "build-assets")]
         build_assets(matches)?;
         #[cfg(not(feature = "build-assets"))]
         println!("bat has been built without the 'build-assets' feature. The 'cache --build' option is not available.");
-    } else if matches.is_present("clear") {
+    } else if matches.get_flag("clear") {
         clear_assets();
     }
 
@@ -286,7 +286,7 @@ fn invoke_bugreport(app: &App) {
 fn run() -> Result<bool> {
     let app = App::new()?;
 
-    if app.matches.is_present("diagnostic") {
+    if app.matches.get_flag("diagnostic") {
         #[cfg(feature = "bugreport")]
         invoke_bugreport(&app);
         #[cfg(not(feature = "bugreport"))]
@@ -313,7 +313,7 @@ fn run() -> Result<bool> {
             let inputs = app.inputs()?;
             let config = app.config(&inputs)?;
 
-            if app.matches.is_present("list-languages") {
+            if app.matches.get_flag("list-languages") {
                 let languages: String = get_languages(&config)?;
                 let inputs: Vec<Input> = vec![Input::from_reader(Box::new(languages.as_bytes()))];
                 let plain_config = Config {
@@ -322,22 +322,22 @@ fn run() -> Result<bool> {
                     ..Default::default()
                 };
                 run_controller(inputs, &plain_config)
-            } else if app.matches.is_present("list-themes") {
+            } else if app.matches.get_flag("list-themes") {
                 list_themes(&config)?;
                 Ok(true)
-            } else if app.matches.is_present("config-file") {
+            } else if app.matches.get_flag("config-file") {
                 println!("{}", config_file().to_string_lossy());
                 Ok(true)
-            } else if app.matches.is_present("generate-config-file") {
+            } else if app.matches.get_flag("generate-config-file") {
                 generate_config_file()?;
                 Ok(true)
-            } else if app.matches.is_present("config-dir") {
+            } else if app.matches.get_flag("config-dir") {
                 writeln!(io::stdout(), "{}", config_dir())?;
                 Ok(true)
-            } else if app.matches.is_present("cache-dir") {
+            } else if app.matches.get_flag("cache-dir") {
                 writeln!(io::stdout(), "{}", cache_dir())?;
                 Ok(true)
-            } else if app.matches.is_present("acknowledgements") {
+            } else if app.matches.get_flag("acknowledgements") {
                 writeln!(io::stdout(), "{}", bat::assets::get_acknowledgements())?;
                 Ok(true)
             } else {


### PR DESCRIPTION
This updates to clap v3 and resolves all deprecations as of right now.

I mostly relied on the tests.

Help output has two main changes that I noticed
- The sections are no "Args", "Options", "Subcommands"
- The text for `--version` is slightly different

I was confused as to why external subcommand support was enabled but I left it.

Some potential further changes
- Preserve parsed values (like numbers) rather than using strings
- Switch lists of possible values to implementing or deriving the `ValueEnum` trait on enums
- Switching to the derive

Fixes #2056