### PR TITLE
Fix clippy suggestions

### DIFF
--- a/src/assets/assets_metadata.rs
+++ b/src/assets/assets_metadata.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::*;
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct AssetsMetadata {
     bat_version: Option<String>,
     creation_time: Option<SystemTime>,

--- a/src/assets/build_assets/acknowledgements.rs
+++ b/src/assets/build_assets/acknowledgements.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
@@ -124,7 +125,7 @@ fn append_to_acknowledgements(
     relative_path: &str,
     license_text: &str,
 ) {
-    acknowledgements.push_str(&format!("## {}\n\n{}", relative_path, license_text));
+    write!(acknowledgements, "## {}\n\n{}", relative_path, license_text).ok();
 
     // Make sure the last char is a newline to not mess up formatting later
     if acknowledgements

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -8,6 +8,7 @@ mod directories;
 mod input;
 
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
 use std::io;
 use std::io::{BufReader, Write};
 use std::path::Path;
@@ -125,7 +126,7 @@ pub fn get_languages(config: &Config) -> Result<String> {
 
     if config.loop_through {
         for lang in languages {
-            result += &format!("{}:{}\n", lang.name, lang.file_extensions.join(","));
+            writeln!(result, "{}:{}", lang.name, lang.file_extensions.join(",")).ok();
         }
     } else {
         let longest = languages
@@ -146,7 +147,7 @@ pub fn get_languages(config: &Config) -> Result<String> {
         };
 
         for lang in languages {
-            result += &format!("{:width$}{}", lang.name, separator, width = longest);
+            write!(result, "{:width$}{}", lang.name, separator, width = longest).ok();
 
             // Number of characters on this line so far, wrap before `desired_width`
             let mut num_chars = 0;
@@ -157,11 +158,11 @@ pub fn get_languages(config: &Config) -> Result<String> {
                 let new_chars = word.len() + comma_separator.len();
                 if num_chars + new_chars >= desired_width {
                     num_chars = 0;
-                    result += &format!("\n{:width$}{}", "", separator, width = longest);
+                    write!(result, "\n{:width$}{}", "", separator, width = longest).ok();
                 }
 
                 num_chars += new_chars;
-                result += &format!("{}", style.paint(&word[..]));
+                write!(result, "{}", style.paint(&word[..])).ok();
                 if extension.peek().is_some() {
                     result += comma_separator;
                 }

--- a/src/less.rs
+++ b/src/less.rs
@@ -3,7 +3,7 @@
 use std::ffi::OsStr;
 use std::process::Command;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum LessVersion {
     Less(usize),
     BusyBox,

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -168,7 +168,7 @@ fn test_parse_minus_fail() {
     assert!(range.is_err());
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RangeCheckResult {
     // Within one of the given ranges
     InRange,

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PagingMode {
     Always,
     QuitIfOneScreen,

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+
 /// Expand tabs like an ANSI-enabled expand(1).
 pub fn expand_tabs(mut text: &str, width: usize, cursor: &mut usize) -> String {
     let mut buffer = String::with_capacity(text.len() * 2);
@@ -92,7 +94,7 @@ pub fn replace_nonprintable(input: &[u8], tab_width: usize) -> String {
                 c => output.push_str(&c.escape_unicode().collect::<String>()),
             }
         } else {
-            output.push_str(&format!("\\x{:02X}", input[idx]));
+            write!(output, "\\x{:02X}", input[idx]).ok();
             idx += 1;
         }
     }

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -7,7 +7,7 @@ use globset::{Candidate, GlobBuilder, GlobMatcher};
 
 pub mod ignored_suffixes;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum MappingTarget<'a> {
     /// For mapping a path to a specific syntax.


### PR DESCRIPTION
For rationale on the `s.push_str(&format!(…))` => `write!(s, …)` changes, see https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string (TLDR: it saves one allocation). This leads to a ~15% performance improvements for `bat -A` in cases where there are a lot of non-ASCII characters:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./bat-master --no-config -A ./bat-master` | 259.8 ± 1.1 | 258.4 | 261.7 | 1.15 ± 0.01 |
| `./bat-2301 --no-config -A ./bat-master` | 225.6 ± 1.8 | 224.0 | 229.5 | 1.00 |
