### PR TITLE
Correct doc comment for `list_syntaxes_and_themes` example

### DIFF
--- a/examples/list_syntaxes_and_themes.rs
+++ b/examples/list_syntaxes_and_themes.rs
@@ -1,4 +1,4 @@
-/// A simple program that prints its own source code using the bat library
+/// A simple program that lists all supported syntaxes and themes.
 use bat::PrettyPrinter;
 
 fn main() {


### PR DESCRIPTION
[`examples/list_syntaxes_and_themes.rs`](https://github.com/sharkdp/bat/blob/113276a62bb5c1658ef9e26954e9b3e0a2543bad/examples/list_syntaxes_and_themes.rs) currently says:
```rust
/// A simple program that prints its own source code using the bat library
```
but it does not do that ([`examples/simple.rs`](https://github.com/sharkdp/bat/blob/113276a62bb5c1658ef9e26954e9b3e0a2543bad/examples/simple.rs) does, I assume it was copied accidentally). I corrected the comment to say:
```rust
/// A simple program that lists all supported syntaxes and themes.
```
