### PR TITLE
Improve Manpage.sublime-syntax, Fix #2353

### DIFF
--- a/assets/syntaxes/02_Extra/Manpage.sublime-syntax
+++ b/assets/syntaxes/02_Extra/Manpage.sublime-syntax
@@ -75,7 +75,7 @@ contexts:
 
   options:
     # command-line options like --option=value, --some-flag, or -x
-    - match: '^[ ]{7}(?=-)'
+    - match: '^[ ]{7}(?=-|\+)'
       push: expect-command-line-option
     - match: '(?:[^a-zA-Z0-9_-]|^|\s){{command_line_option}}'
       captures:
@@ -96,7 +96,7 @@ contexts:
     - include: env-var
 
   expect-command-line-option:
-    - match: '[A-Za-z0-9-]+'
+    - match: '[A-Za-z0-9-\.\?:#\$\+]+'
       scope: entity.name.command-line-option.man
     - match: '(\[)(=)'
       captures:
@@ -122,7 +122,7 @@ contexts:
       pop: true
 
   expect-parameter:
-    - match: '[A-Za-z0-9-]+'
+    - match: '[A-Za-z0-9-_]+'
       scope: variable.parameter.man
     - match: (?=\s+\|)
       pop: true


### PR DESCRIPTION
![Screenshot from 2022-10-09 13-56-09](https://user-images.githubusercontent.com/32936898/194740596-cedb80c1-f97c-4fa4-a76d-4e4d1b6f0dd0.png)

It still exists many problems, such as `man fzf`

![Screenshot from 2022-10-09 14-00-35](https://user-images.githubusercontent.com/32936898/194740645-77d76e4c-17af-4458-9db1-551fc9785511.png)

Should we highlight `+x` before `or`? `Case-XXX` should be highlighted, right?

![Screenshot from 2022-10-09 14-01-43](https://user-images.githubusercontent.com/32936898/194740683-98ac9f06-4952-43ce-a2b9-db4d9fd13e8b.png)

Wrong `N[,...]`.

How to distinguish the followings `-.`?

![Screenshot from 2022-10-09 14-02-42](https://user-images.githubusercontent.com/32936898/194740745-21393bac-037c-4304-ba53-fad4cd14df9a.png)
![Screenshot from 2022-10-09 14-03-12](https://user-images.githubusercontent.com/32936898/194740748-63b693b2-5bee-428d-bf36-3eccf202363a.png)
