### PR TITLE
Speed up binary file read

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -15,6 +15,7 @@ use crate::paging::PagingMode;
 use crate::printer::{InteractivePrinter, Printer, SimplePrinter};
 
 use clircle::{Clircle, Identifier};
+use content_inspector::ContentType;
 
 pub struct Controller<'a> {
     config: &'a Config<'a>,
@@ -171,6 +172,11 @@ impl<'b> Controller<'b> {
     ) -> Result<()> {
         if !input.reader.first_line.is_empty() || self.config.style_components.header() {
             printer.print_header(writer, input, add_header_padding)?;
+        }
+
+        if !self.config.show_nonprintable && input.reader.content_type == Some(ContentType::BINARY)
+        {
+            return Ok(());
         }
 
         if !input.reader.first_line.is_empty() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -272,7 +272,7 @@ impl<'a> InputReader<'a> {
 
         if content_type == Some(ContentType::UTF_16LE) {
             reader.read_until(0x00, &mut first_line).ok();
-        } else if content_type != Some(ContentType::BINARY) {
+        } else if content_type != Some(ContentType::BINARY) && first_line.last() != Some(&b'\n') {
             reader.read_until(b'\n', &mut first_line).ok();
         }
 


### PR DESCRIPTION
Test setup:
```
$ truncate -s 10G example_file
```

Before change:
```
$ time bat example_file
───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: example_file   <BINARY>
───────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

real	0m12.840s
user	0m3.923s
sys	0m8.911s
```
After update
```
$ time bat example_file
───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: example_file   <BINARY>
───────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

real	0m0.037s
user	0m0.036s
sys	0m0.002s
```