### PR TITLE
Disable completion of `cache` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Other
 
 - Various bash completion improvements, see #2310 (@scop)
+- Disable completion of `cache` subcommand, see #2399 (@cyqsimon)
 
 ## Syntaxes
 

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -68,9 +68,8 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print this help message.')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Show version information.')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Show version information.')
-            ## Completion of the 'cache' command itself is disabled for better UX
+            ## Completion of the 'cache' command itself is removed for better UX
             ## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
-            #[CompletionResult]::new('cache', 'cache', [CompletionResultType]::ParameterValue, 'Modify the syntax-definition and theme cache')
             break
         }
         '{{PROJECT_EXECUTABLE}};cache' {

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -68,7 +68,9 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print this help message.')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Show version information.')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Show version information.')
-            [CompletionResult]::new('cache', 'cache', [CompletionResultType]::ParameterValue, 'Modify the syntax-definition and theme cache')
+            ## Completion of the 'cache' command itself is disabled for better UX
+            ## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
+            #[CompletionResult]::new('cache', 'cache', [CompletionResultType]::ParameterValue, 'Modify the syntax-definition and theme cache')
             break
         }
         '{{PROJECT_EXECUTABLE}};cache' {

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -185,8 +185,6 @@ _bat() {
 
 	_filedir
 	
-	## Completion of the 'cache' command itself is disabled for better UX
+	## Completion of the 'cache' command itself is removed for better UX
 	## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
-	#((cword == 1)) && COMPREPLY+=($(compgen -W cache -- "$cur"))
-
 } && complete -F _bat {{PROJECT_EXECUTABLE}}

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -184,6 +184,9 @@ _bat() {
 	fi
 
 	_filedir
-	((cword == 1)) && COMPREPLY+=($(compgen -W cache -- "$cur"))
+	
+	## Completion of the 'cache' command itself is disabled for better UX
+	## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
+	#((cword == 1)) && COMPREPLY+=($(compgen -W cache -- "$cur"))
 
 } && complete -F _bat {{PROJECT_EXECUTABLE}}

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -198,9 +198,8 @@ complete -c $bat -s V -l version -f -d "Show version information" -n __fish_is_f
 complete -c $bat -l wrap -x -a "$wrap_opts" -d "Text-wrapping mode" -n __bat_no_excl_args
 
 # Sub-command 'cache' completions
-## Completion of the 'cache' command itself is disabled for better UX
+## Completion of the 'cache' command itself is removed for better UX
 ## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
-#complete -c $bat -a cache -d "Modify the syntax/language definition cache" -n __fish_use_subcommand
 
 complete -c $bat -l build -f -d "Parse new definitions into cache" -n __bat_cache_no_excl
 

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -198,7 +198,9 @@ complete -c $bat -s V -l version -f -d "Show version information" -n __fish_is_f
 complete -c $bat -l wrap -x -a "$wrap_opts" -d "Text-wrapping mode" -n __bat_no_excl_args
 
 # Sub-command 'cache' completions
-complete -c $bat -a cache -d "Modify the syntax/language definition cache" -n __fish_use_subcommand
+## Completion of the 'cache' command itself is disabled for better UX
+## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
+#complete -c $bat -a cache -d "Modify the syntax/language definition cache" -n __fish_use_subcommand
 
 complete -c $bat -l build -f -d "Parse new definitions into cache" -n __bat_cache_no_excl
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -82,9 +82,12 @@ _{{PROJECT_EXECUTABLE}}_main() {
 
 # first positional argument
 if (( ${#words} == 2 )); then
-    local -a subcommands
-    subcommands=('cache:Modify the syntax-definition and theme cache')
-    _describe subcommand subcommands
+    ## Completion of the 'cache' command itself is disabled for better UX
+    ## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
+    #local -a subcommands
+    #subcommands=('cache:Modify the syntax-definition and theme cache')
+    #_describe subcommand subcommands
+    
     _{{PROJECT_EXECUTABLE}}_main
 else
     case $words[2] in

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -80,23 +80,14 @@ _{{PROJECT_EXECUTABLE}}_main() {
     esac
 }
 
-# first positional argument
-if (( ${#words} == 2 )); then
-    ## Completion of the 'cache' command itself is disabled for better UX
-    ## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
-    #local -a subcommands
-    #subcommands=('cache:Modify the syntax-definition and theme cache')
-    #_describe subcommand subcommands
-    
-    _{{PROJECT_EXECUTABLE}}_main
-else
-    case $words[2] in
-        cache)
-            _{{PROJECT_EXECUTABLE}}_cache_subcommand
-        ;;
+case $words[2] in
+    cache)
+        ## Completion of the 'cache' command itself is removed for better UX
+        ## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
+        _{{PROJECT_EXECUTABLE}}_cache_subcommand
+    ;;
 
-        *)
-            _{{PROJECT_EXECUTABLE}}_main
-        ;;
-    esac
-fi
+    *)
+        _{{PROJECT_EXECUTABLE}}_main
+    ;;
+esac


### PR DESCRIPTION
See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802.

TLDR: autocompleting the `cache` subcommand causes usability issues. This PR disables it.

I am not terribly familiar with completion scripts TBH. If you are more competent please help check my edits, thanks.