### PR TITLE
Make `PrettyPrinter::header` an alias for `header_filename`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 ## `bat` as a library
 
+- `PrettyPrinter::header` correctly displays a header with the filename, see #2378 and #2406 (@cstyles)
+
 
 # v0.22.1
 

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -19,7 +19,7 @@ use crate::paging::PagingMode;
 
 #[derive(Default)]
 struct ActiveStyleComponents {
-    header: bool,
+    header_filename: bool,
     #[cfg(feature = "git")]
     vcs_modification_markers: bool,
     grid: bool,
@@ -140,7 +140,7 @@ impl<'a> PrettyPrinter<'a> {
 
     /// Whether to show a header with the file name
     pub fn header(&mut self, yes: bool) -> &mut Self {
-        self.active_style_components.header = yes;
+        self.active_style_components.header_filename = yes;
         self
     }
 
@@ -277,8 +277,10 @@ impl<'a> PrettyPrinter<'a> {
         if self.active_style_components.rule {
             self.config.style_components.insert(StyleComponent::Rule);
         }
-        if self.active_style_components.header {
-            self.config.style_components.insert(StyleComponent::Header);
+        if self.active_style_components.header_filename {
+            self.config
+                .style_components
+                .insert(StyleComponent::HeaderFilename);
         }
         if self.active_style_components.line_numbers {
             self.config


### PR DESCRIPTION
Fixes #2378