### PR TITLE
Bump cmd-help syntax to 9b25682

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added a new VimHelp syntax, see #2366 (@Freed-Wu)
 - Associate `pdm.lock` with `TOML` syntax, see #2410
 - `Todo.txt`: Fix highlighting of contexts and projects at beginning of done.txt, see #2411
+- `cmd-help`: overhaul scope names (colors) to improve theme support; misc syntax improvements. See #2419 (@victor-gp)
 
 ## Themes
 

--- a/tests/syntax-tests/highlighted/cmd-help/test.cmd-help
+++ b/tests/syntax-tests/highlighted/cmd-help/test.cmd-help
@@ -1,54 +1,43 @@
-[38;2;248;248;242mbat 0.20.0 (e735562-modified)[0m
-[38;2;248;248;242mA cat(1) clone with syntax highlighting and Git integration.[0m
+[38;2;248;248;242mbat 0.22.1[0m
+[38;2;248;248;242mA cat(1) clone with wings.[0m
 
-[38;2;253;151;31mUSAGE:[0m
+[38;2;248;248;242mUse '--help' instead of '-h' to see a more detailed version of the help text.[0m
+
+[38;2;246;170;17mUSAGE:[0m
 [38;2;248;248;242m    bat [OPTIONS] [FILE]...[0m
 [38;2;248;248;242m    bat <SUBCOMMAND>[0m
 
-[38;2;253;151;31mOPTIONS:[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-A[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--show-all[0m
-[38;2;248;248;242m            Show non-printable characters (space, tab, newline, ..).[0m
+[38;2;246;170;17mARGS:[0m
+[38;2;248;248;242m    [0m[38;2;249;38;114m<FILE>...[0m[38;2;248;248;242m    File(s) to print / concatenate. Use '-' for standard input.[0m
 
-[38;2;248;248;242m    [0m[38;2;166;226;46m-p[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--plain[0m[38;2;248;248;242m                          Show plain style (alias for '--style=plain').[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-l[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--language[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<language>[0m[38;2;248;248;242m            Set the language for syntax highlighting.[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-H[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--highlight-line[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<N:M>[0m[3;38;2;253;151;31m...[0m[38;2;248;248;242m        Highlight lines N through M.[0m
-[38;2;248;248;242m        [0m[38;2;166;226;46m--file-name[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<name>[0m[3;38;2;253;151;31m...[0m[38;2;248;248;242m            Specify the name to display for a file.[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-d[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--diff[0m
-[38;2;248;248;242m            Only show lines that have been added/removed/modified.[0m
+[38;2;246;170;17mOPTIONS:[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-A[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--show-all[0m[38;2;248;248;242m                    Show non-printable characters (space, tab, newline, ..).[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-p[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--plain[0m[38;2;248;248;242m                       Show plain style (alias for '--style=plain').[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-l[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--language[0m[38;2;248;248;242m [0m[38;2;249;38;114m<language>[0m[38;2;248;248;242m         Set the language for syntax highlighting.[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-H[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--highlight-line[0m[38;2;248;248;242m [0m[38;2;249;38;114m<N:M>[0m[38;2;248;248;242m        Highlight lines N through M.[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--file-name[0m[38;2;248;248;242m [0m[38;2;249;38;114m<name>[0m[38;2;248;248;242m            Specify the name to display for a file.[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-d[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--diff[0m[38;2;248;248;242m                        Only show lines that have been added/removed/modified.[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--tabs[0m[38;2;248;248;242m [0m[38;2;249;38;114m<T>[0m[38;2;248;248;242m                    Set the tab width to T spaces.[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--wrap[0m[38;2;248;248;242m [0m[38;2;249;38;114m<mode>[0m[38;2;248;248;242m                 Specify the text-wrapping mode (*auto*, never, character).[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-n[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--number[0m[38;2;248;248;242m                      Show line numbers (alias for '--style=numbers').[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--color[0m[38;2;248;248;242m [0m[38;2;249;38;114m<when>[0m[38;2;248;248;242m                When to use colors (*auto*, never, always).[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--italic-text[0m[38;2;248;248;242m [0m[38;2;249;38;114m<when>[0m[38;2;248;248;242m          Use italics in output (always, *never*)[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--decorations[0m[38;2;248;248;242m [0m[38;2;249;38;114m<when>[0m[38;2;248;248;242m          When to show the decorations (*auto*, never, always).[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--paging[0m[38;2;248;248;242m [0m[38;2;249;38;114m<when>[0m[38;2;248;248;242m               Specify when to use the pager, or use `-P` to disable (*auto*,[0m
+[38;2;248;248;242m                                      never, always).[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-m[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--map-syntax[0m[38;2;248;248;242m [0m[38;2;249;38;114m<glob:syntax>[0m[38;2;248;248;242m    Use the specified syntax for files matching the glob pattern[0m
+[38;2;248;248;242m                                      ('*.cpp:C++').[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--theme[0m[38;2;248;248;242m [0m[38;2;249;38;114m<theme>[0m[38;2;248;248;242m               Set the color theme for syntax highlighting.[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--list-themes[0m[38;2;248;248;242m                 Display all supported highlighting themes.[0m
+[38;2;248;248;242m        [0m[38;2;166;226;46m--style[0m[38;2;248;248;242m [0m[38;2;249;38;114m<components>[0m[38;2;248;248;242m          Comma-separated list of style elements to display (*default*,[0m
+[38;2;248;248;242m                                      auto, full, plain, changes, header, header-filename,[0m
+[38;2;248;248;242m                                      header-filesize, grid, rule, numbers, snip).[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-r[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--line-range[0m[38;2;248;248;242m [0m[38;2;249;38;114m<N:M>[0m[38;2;248;248;242m            Only print the lines from N to M.[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-L[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--list-languages[0m[38;2;248;248;242m              Display all supported languages.[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-h[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--help[0m[38;2;248;248;242m                        Print this help message.[0m
+[38;2;248;248;242m    [0m[38;2;166;226;46m-V[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--version[0m[38;2;248;248;242m                     Print version information[0m
 
-[38;2;248;248;242m        [0m[38;2;166;226;46m--tabs[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<T>[0m[38;2;248;248;242m                       Set the tab width to T spaces.[0m
-[38;2;248;248;242m        [0m[38;2;166;226;46m--wrap[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<mode>[0m
-[38;2;248;248;242m            Specify the text-wrapping mode (*auto*, never, character).[0m
+[38;2;246;170;17mSUBCOMMANDS:[0m
+[38;2;248;248;242m    [0m[38;2;190;132;255mcache[0m[38;2;248;248;242m    Modify the syntax-definition and theme cache[0m
 
-[38;2;248;248;242m    [0m[38;2;166;226;46m-n[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--number[0m
-[38;2;248;248;242m            Show line numbers (alias for '--style=numbers').[0m
-
-[38;2;248;248;242m        [0m[38;2;166;226;46m--color[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<when>[0m[38;2;248;248;242m                   When to use colors (*auto*, never, always).[0m
-[38;2;248;248;242m        [0m[38;2;166;226;46m--italic-text[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<when>[0m[38;2;248;248;242m             Use italics in output (always, *never*)[0m
-[38;2;248;248;242m        [0m[38;2;166;226;46m--decorations[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<when>[0m
-[38;2;248;248;242m            When to show the decorations (*auto*, never, always).[0m
-
-[38;2;248;248;242m        [0m[38;2;166;226;46m--paging[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<when>[0m
-[38;2;248;248;242m            Specify when to use the pager, or use `-P` to disable (*auto*, never,[0m
-[38;2;248;248;242m            always).[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-m[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--map-syntax[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<glob:syntax>[0m[3;38;2;253;151;31m...[0m
-[38;2;248;248;242m            Use the specified syntax for files matching the glob pattern[0m
-[38;2;248;248;242m            ('*.cpp:C++').[0m
-[38;2;248;248;242m        [0m[38;2;166;226;46m--theme[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<theme>[0m[38;2;248;248;242m                  Set the color theme for syntax highlighting.[0m
-[38;2;248;248;242m        [0m[38;2;166;226;46m--list-themes[0m[38;2;248;248;242m                    Display all supported highlighting themes.[0m
-[38;2;248;248;242m        [0m[38;2;166;226;46m--style[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<components>[0m
-[38;2;248;248;242m            Comma-separated list of style elements to display (*auto*, full, plain,[0m
-[38;2;248;248;242m            changes, header, grid, rule, numbers, snip).[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-r[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--line-range[0m[38;2;248;248;242m [0m[3;38;2;253;151;31m<N:M>[0m[3;38;2;253;151;31m...[0m[38;2;248;248;242m            Only print the lines from N to M.[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-L[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--list-languages[0m[38;2;248;248;242m                 Display all supported languages.[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-h[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--help[0m[38;2;248;248;242m                           Print this help message.[0m
-[38;2;248;248;242m    [0m[38;2;166;226;46m-V[0m[38;2;248;248;242m, [0m[38;2;166;226;46m--version[0m[38;2;248;248;242m                        Show version information.[0m
-
-[38;2;253;151;31mARGS:[0m
-[38;2;248;248;242m    [0m[3;38;2;253;151;31m<FILE>...[0m[38;2;248;248;242m    File(s) to print / concatenate. Use '-' for standard input.[0m
-
-[38;2;253;151;31mSUBCOMMANDS:[0m
-[38;2;248;248;242m    [0m[38;2;249;38;114mcache[0m[38;2;248;248;242m    Modify the syntax-definition and theme cache[0m
-
-[38;2;248;248;242mNote: `bat -h` prints a short and concise overview while `bat --help` gives all[0m
-[38;2;248;248;242mdetails.[0m
+[38;2;248;248;242mNote: `bat -h` prints a short and concise overview while `bat --help` gives all details.[0m

--- a/tests/syntax-tests/source/cmd-help/test.cmd-help
+++ b/tests/syntax-tests/source/cmd-help/test.cmd-help
@@ -1,54 +1,43 @@
-bat 0.20.0 (e735562-modified)
-A cat(1) clone with syntax highlighting and Git integration.
+bat 0.22.1
+A cat(1) clone with wings.
+
+Use '--help' instead of '-h' to see a more detailed version of the help text.
 
 USAGE:
     bat [OPTIONS] [FILE]...
     bat <SUBCOMMAND>
 
-OPTIONS:
-    -A, --show-all
-            Show non-printable characters (space, tab, newline, ..).
-
-    -p, --plain                          Show plain style (alias for '--style=plain').
-    -l, --language <language>            Set the language for syntax highlighting.
-    -H, --highlight-line <N:M>...        Highlight lines N through M.
-        --file-name <name>...            Specify the name to display for a file.
-    -d, --diff
-            Only show lines that have been added/removed/modified.
-
-        --tabs <T>                       Set the tab width to T spaces.
-        --wrap <mode>
-            Specify the text-wrapping mode (*auto*, never, character).
-
-    -n, --number
-            Show line numbers (alias for '--style=numbers').
-
-        --color <when>                   When to use colors (*auto*, never, always).
-        --italic-text <when>             Use italics in output (always, *never*)
-        --decorations <when>
-            When to show the decorations (*auto*, never, always).
-
-        --paging <when>
-            Specify when to use the pager, or use `-P` to disable (*auto*, never,
-            always).
-    -m, --map-syntax <glob:syntax>...
-            Use the specified syntax for files matching the glob pattern
-            ('*.cpp:C++').
-        --theme <theme>                  Set the color theme for syntax highlighting.
-        --list-themes                    Display all supported highlighting themes.
-        --style <components>
-            Comma-separated list of style elements to display (*auto*, full, plain,
-            changes, header, grid, rule, numbers, snip).
-    -r, --line-range <N:M>...            Only print the lines from N to M.
-    -L, --list-languages                 Display all supported languages.
-    -h, --help                           Print this help message.
-    -V, --version                        Show version information.
-
 ARGS:
     <FILE>...    File(s) to print / concatenate. Use '-' for standard input.
+
+OPTIONS:
+    -A, --show-all                    Show non-printable characters (space, tab, newline, ..).
+    -p, --plain                       Show plain style (alias for '--style=plain').
+    -l, --language <language>         Set the language for syntax highlighting.
+    -H, --highlight-line <N:M>        Highlight lines N through M.
+        --file-name <name>            Specify the name to display for a file.
+    -d, --diff                        Only show lines that have been added/removed/modified.
+        --tabs <T>                    Set the tab width to T spaces.
+        --wrap <mode>                 Specify the text-wrapping mode (*auto*, never, character).
+    -n, --number                      Show line numbers (alias for '--style=numbers').
+        --color <when>                When to use colors (*auto*, never, always).
+        --italic-text <when>          Use italics in output (always, *never*)
+        --decorations <when>          When to show the decorations (*auto*, never, always).
+        --paging <when>               Specify when to use the pager, or use `-P` to disable (*auto*,
+                                      never, always).
+    -m, --map-syntax <glob:syntax>    Use the specified syntax for files matching the glob pattern
+                                      ('*.cpp:C++').
+        --theme <theme>               Set the color theme for syntax highlighting.
+        --list-themes                 Display all supported highlighting themes.
+        --style <components>          Comma-separated list of style elements to display (*default*,
+                                      auto, full, plain, changes, header, header-filename,
+                                      header-filesize, grid, rule, numbers, snip).
+    -r, --line-range <N:M>            Only print the lines from N to M.
+    -L, --list-languages              Display all supported languages.
+    -h, --help                        Print this help message.
+    -V, --version                     Print version information
 
 SUBCOMMANDS:
     cache    Modify the syntax-definition and theme cache
 
-Note: `bat -h` prints a short and concise overview while `bat --help` gives all
-details.
+Note: `bat -h` prints a short and concise overview while `bat --help` gives all details.


### PR DESCRIPTION
This update includes an overhaul of scope names to better support the set of themes included with bat.

You can find a visual diff for every theme in this PR: https://github.com/victor-gp/cmd-help-sublime-syntax/pull/17

This PR updates the cmd-help syntax test because the scopes (-> colors) have changed.

This PR supersedes #2409.