### PR TITLE
add json key highlighting patch for twodark

### DIFF
--- a/assets/patches/TwoDark.tmTheme.patch
+++ b/assets/patches/TwoDark.tmTheme.patch
@@ -1,0 +1,20 @@
+diff --git themes/TwoDark/TwoDark.tmTheme themes/TwoDark/TwoDark.tmTheme
+index 87fd358..56376d3 100644
+--- themes/TwoDark/TwoDark.tmTheme
++++ themes/TwoDark/TwoDark.tmTheme
+@@ -533,7 +533,7 @@
+ 			<key>name</key>
+ 			<string>Json key</string>
+ 			<key>scope</key>
+-			<string>source.json                           meta.structure.dictionary.json                              string.quoted.double.json</string>
++			<string>source.json                           meta.mapping.key.json                              string.quoted.double.json</string>
+ 			<key>settings</key>
+ 			<dict>
+ 				<key>foreground</key>
+@@ -875,4 +875,4 @@
+ 	<key>comment</key>
+ 	<string>Work in progress</string>
+ </dict>
+-</plist>
+\ No newline at end of file
++</plist>


### PR DESCRIPTION
Adds JSON key highlight fixes for TwoDark theme.

Before:

<img width="1168" alt="twodark-json-before" src="https://user-images.githubusercontent.com/134032/210181462-c786a7cf-94b5-42bd-8d3e-2253ecd546d4.png">

After:

<img width="1175" alt="twodark-json-after" src="https://user-images.githubusercontent.com/134032/210181466-461fc227-1deb-4546-8ab0-659275622560.png">

