### PR TITLE
Fix code fence in doc comment

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -84,7 +84,7 @@ impl HighlightingAssets {
     /// platform, the default theme depends on
     /// ```bash
     /// defaults read -globalDomain AppleInterfaceStyle
-    /// ````
+    /// ```
     /// To avoid the overhead of the check on macOS, simply specify a theme
     /// explicitly via `--theme`, `BAT_THEME`, or `~/.config/bat`.
     ///


### PR DESCRIPTION
This PR fixes the code fence in doc comment. This broke syntax highlighting when editing this file in Vim.