### PR TITLE
Replace unmaintained GitHub Actions

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -215,8 +215,8 @@ jobs:
         fi
 
         # Let subsequent steps know where to find the (stripped) bin
-        echo ::set-output name=BIN_PATH::${BIN_PATH}
-        echo ::set-output name=BIN_NAME::${BIN_NAME}
+        echo "BIN_PATH=${BIN_PATH}" >> $GITHUB_OUTPUT
+        echo "BIN_NAME=${BIN_NAME}" >> $GITHUB_OUTPUT
 
     - name: Set testing options
       id: test-options
@@ -225,7 +225,7 @@ jobs:
         # test only library unit tests and binary for arm-type targets
         unset CARGO_TEST_OPTIONS
         unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--lib --bin ${PROJECT_NAME}" ;; esac;
-        echo ::set-output name=CARGO_TEST_OPTIONS::${CARGO_TEST_OPTIONS}
+        echo "CARGO_TEST_OPTIONS=${CARGO_TEST_OPTIONS}" >> $GITHUB_OUTPUT
 
     - name: Run tests
       shell: bash
@@ -266,7 +266,7 @@ jobs:
         PKG_suffix=".tar.gz" ; case ${{ matrix.job.target }} in *-pc-windows-*) PKG_suffix=".zip" ;; esac;
         PKG_BASENAME=${PROJECT_NAME}-v${PROJECT_VERSION}-${{ matrix.job.target }}
         PKG_NAME=${PKG_BASENAME}${PKG_suffix}
-        echo ::set-output name=PKG_NAME::${PKG_NAME}
+        echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_OUTPUT
 
         PKG_STAGING="${{ env.CICD_INTERMEDIATES_DIR }}/package"
         ARCHIVE_DIR="${PKG_STAGING}/${PKG_BASENAME}/"
@@ -297,7 +297,7 @@ jobs:
         popd >/dev/null
 
         # Let subsequent steps know where to find the compressed package
-        echo ::set-output name=PKG_PATH::"${PKG_STAGING}/${PKG_NAME}"
+        echo "PKG_PATH=${PKG_STAGING}/${PKG_NAME}" >> $GITHUB_OUTPUT
 
     - name: Create Debian package
       id: debian-package
@@ -324,7 +324,7 @@ jobs:
         esac;
 
         DPKG_NAME="${DPKG_BASENAME}_${DPKG_VERSION}_${DPKG_ARCH}.deb"
-        echo ::set-output name=DPKG_NAME::${DPKG_NAME}
+        echo "DPKG_NAME=${DPKG_NAME}" >> $GITHUB_OUTPUT
 
         # Binary
         install -Dm755 "${{ steps.strip.outputs.BIN_PATH }}" "${DPKG_DIR}/usr/bin/${{ steps.strip.outputs.BIN_NAME }}"
@@ -403,7 +403,7 @@ jobs:
         EOF
 
         DPKG_PATH="${DPKG_STAGING}/${DPKG_NAME}"
-        echo ::set-output name=DPKG_PATH::${DPKG_PATH}
+        echo "DPKG_PATH=${DPKG_PATH}" >> $GITHUB_OUTPUT
 
         # build dpkg
         fakeroot dpkg-deb --build "${DPKG_DIR}" "${DPKG_PATH}"
@@ -426,7 +426,7 @@ jobs:
       shell: bash
       run: |
         unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
-        echo ::set-output name=IS_RELEASE::${IS_RELEASE}
+        echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
     - name: Publish archives and packages
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -18,11 +18,8 @@ jobs:
     name: Ensure 'cargo fmt' has been run
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        default: true
-        profile: minimal
         components: rustfmt
     - uses: actions/checkout@v3
     - run: cargo fmt -- --check
@@ -46,22 +43,14 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install rust toolchain (v${{ env.MIN_SUPPORTED_RUST_VERSION }})
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.MIN_SUPPORTED_RUST_VERSION }}
-        default: true
-        profile: minimal # minimal component installation (ie, no documentation)
         components: clippy
     - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --locked --all-targets ${{ env.MSRV_FEATURES }}
+      run: cargo clippy --locked --all-targets ${{ env.MSRV_FEATURES }}
     - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --locked ${{ env.MSRV_FEATURES }}
+      run: cargo test --locked ${{ env.MSRV_FEATURES }}
 
   test_with_new_syntaxes_and_themes:
     name: Run tests with updated syntaxes and themes
@@ -72,33 +61,17 @@ jobs:
       with:
         submodules: true # we need all syntax and theme submodules
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal
+      uses: dtolnay/rust-toolchain@stable
     - name: Build and install bat
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: --locked --path .
+      run: cargo install --locked --path .
     - name: Rebuild binary assets (syntaxes and themes)
       run: bash assets/create.sh
     - name: Build and install bat with updated assets
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: --locked --path .
+      run: cargo install --locked --path .
     - name: Run unit tests with new syntaxes and themes
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --locked --release
+      run: cargo test --locked --release
     - name: Run ignored-by-default unit tests with new syntaxes and themes
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --locked --release --test assets -- --ignored
+      run: cargo test --locked --release --test assets -- --ignored
     - name: Syntax highlighting regression test
       run: tests/syntax-tests/regression_test.sh
     - name: List of languages
@@ -118,21 +91,11 @@ jobs:
       run: |
         echo "BAT_SYSTEM_CONFIG_PREFIX=$GITHUB_WORKSPACE/tests/examples/system_config" >> $GITHUB_ENV
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal
+      uses: dtolnay/rust-toolchain@stable
     - name: Build and install bat
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: --locked --path .
+      run: cargo install --locked --path .
     - name: Run unit tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --locked --test system_wide_config -- --ignored
+      run: cargo test --locked --test system_wide_config -- --ignored
 
   documentation:
     name: Documentation
@@ -141,18 +104,11 @@ jobs:
     - name: Git checkout
       uses: actions/checkout@v3
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal
+      uses: dtolnay/rust-toolchain@stable
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings
-      uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --locked --no-deps --document-private-items --all-features
+      run: cargo doc --locked --no-deps --document-private-items --all-features
     - name: Show man page
       run: man $(find . -name bat.1)
 
@@ -174,6 +130,8 @@ jobs:
           - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
+    env:
+      BUILD_CMD: cargo
     steps:
     - name: Checkout source code
       uses: actions/checkout@v3
@@ -195,12 +153,20 @@ jobs:
         echo "PROJECT_HOMEPAGE=$(sed -n 's/^homepage = "\(.*\)"/\1/p' Cargo.toml)" >> $GITHUB_ENV
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        target: ${{ matrix.job.target }}
-        override: true
-        profile: minimal # minimal component installation (ie, no documentation)
+        targets: ${{ matrix.job.target }}
+
+    - name: Install cross
+      if: matrix.job.use-cross
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cross
+
+    - name: Overwrite build command env variable
+      if: matrix.job.use-cross
+      shell: bash
+      run: echo "BUILD_CMD=cross" >> $GITHUB_ENV
 
     - name: Show version information (Rust, cargo, GCC)
       shell: bash
@@ -213,11 +179,8 @@ jobs:
         rustc -V
 
     - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: build
-        args: --locked --release --target=${{ matrix.job.target }}
+      shell: bash
+      run: $BUILD_CMD build --locked --release --target=${{ matrix.job.target }}
 
     - name: Strip debug information from executable
       id: strip
@@ -265,60 +228,36 @@ jobs:
         echo ::set-output name=CARGO_TEST_OPTIONS::${CARGO_TEST_OPTIONS}
 
     - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: test
-        args: --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
+      shell: bash
+      run: $BUILD_CMD test --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
 
     - name: Run bat
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: run
-        args: --locked --target=${{ matrix.job.target }} -- --paging=never --color=always --theme=ansi Cargo.toml src/config.rs
+      shell: bash
+      run: $BUILD_CMD run --locked --target=${{ matrix.job.target }} -- --paging=never --color=always --theme=ansi Cargo.toml src/config.rs
 
     - name: Show diagnostics (bat --diagnostic)
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: run
-        args: --locked --target=${{ matrix.job.target }} -- --paging=never --color=always --theme=ansi Cargo.toml src/config.rs --diagnostic
+      shell: bash
+      run: $BUILD_CMD run --locked --target=${{ matrix.job.target }} -- --paging=never --color=always --theme=ansi Cargo.toml src/config.rs --diagnostic
 
     - name: "Feature check: regex-onig"
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: check
-        args: --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig
+      shell: bash
+      run: $BUILD_CMD check --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig
 
     - name: "Feature check: regex-onig,git"
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: check
-        args: --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig,git
+      shell: bash
+      run: $BUILD_CMD check --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig,git
 
     - name: "Feature check: regex-onig,paging"
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: check
-        args: --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig,paging
+      shell: bash
+      run: $BUILD_CMD check --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig,paging
 
     - name: "Feature check: regex-onig,git,paging"
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: check
-        args: --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig,git,paging
+      shell: bash
+      run: $BUILD_CMD check --locked --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features regex-onig,git,paging
 
     - name: "Feature check: minimal-application"
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: ${{ matrix.job.use-cross }}
-        command: check
-        args: --locked --target=${{ matrix.job.target }} --verbose --no-default-features --features minimal-application
+      shell: bash
+      run: $BUILD_CMD check --locked --target=${{ matrix.job.target }} --verbose --no-default-features --features minimal-application
 
     - name: Create tarball
       id: package


### PR DESCRIPTION
This PR fixes all current deprecation warnings by the build jobs.

The unmaintained `actions-rs/*` actions are replaced with [`dtolnay/rust-toolchain`],
[`taiki-e/install-action`] and plain cargo commands.

The deprecated `set-output` command is replaced by writing the output variables into a file. 
See [announcement].
```bash
echo "NAME=${value}" >> $GITHUB_OUTPUT
```

[`dtolnay/rust-toolchain`]: https://github.com/dtolnay/rust-toolchain
[`taiki-e/install-action`]: https://github.com/taiki-e/install-action
[announcement]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/