### PR TITLE
Fix `jq` expression for retrieving `rust-version` in MSRV build job

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Get the MSRV from the package metadata
       id: msrv
-      run: cargo metadata --no-deps --format-version 1 | jq -r '"version=" + (.packages[] | select(.name = "bat").rust_version)' >> $GITHUB_OUTPUT
+      run: cargo metadata --no-deps --format-version 1 | jq -r '"version=" + (.packages[] | select(.name == "bat")).rust_version' >> $GITHUB_OUTPUT
     - name: Install rust toolchain (v${{ steps.msrv.outputs.version }})
       uses: dtolnay/rust-toolchain@master
       with:


### PR DESCRIPTION
With the correct operator, the `bat` package is correctly selected and the `--no-deps` argument can be omitted.

However, without the `--no-deps' argument, cargo must fetch all dependencies.