### PR TITLE
Replace `dirs-next` with the original `dirs` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
  "clircle",
  "console",
  "content_inspector",
- "dirs-next",
+ "dirs",
  "encoding",
  "expect-test",
  "flate2",
@@ -268,24 +268,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ application = [
 minimal-application = [
     "atty",
     "clap",
-    "dirs-next",
+    "dirs",
     "paging",
     "regex-onig",
     "wild",
@@ -61,7 +61,7 @@ semver = "1.0"
 path_abs = { version = "0.5", default-features = false }
 clircle = "0.3"
 bugreport = { version = "0.5.0", optional = true }
-dirs-next = { version = "2.0.0", optional = true }
+dirs = { version = "5.0.0", optional = true }
 grep-cli = { version = "0.1.7", optional = true }
 regex = { version = "1.7.0", optional = true }
 walkdir = { version = "2.0", optional = true }
@@ -83,7 +83,7 @@ optional = true
 features = ["wrap_help", "cargo"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-dirs-next = "2.0.0"
+dirs = "5.0.0"
 plist = "1.3"
 
 [dev-dependencies]

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -404,7 +404,7 @@ fn macos_dark_mode_active() -> bool {
     const PREFERENCES_FILE: &str = "Library/Preferences/.GlobalPreferences.plist";
     const STYLE_KEY: &str = "AppleInterfaceStyle";
 
-    let preferences_file = dirs_next::home_dir()
+    let preferences_file = dirs::home_dir()
         .map(|home| home.join(PREFERENCES_FILE))
         .expect("Could not get home directory");
 

--- a/src/bin/bat/directories.rs
+++ b/src/bin/bat/directories.rs
@@ -26,10 +26,10 @@ impl BatProjectDirs {
                 let config_dir_op = env::var_os("XDG_CONFIG_HOME")
                     .map(PathBuf::from)
                     .filter(|p| p.is_absolute())
-                    .or_else(|| dirs_next::home_dir().map(|d| d.join(".config")));
+                    .or_else(|| dirs::home_dir().map(|d| d.join(".config")));
 
                 #[cfg(not(target_os = "macos"))]
-                let config_dir_op = dirs_next::config_dir();
+                let config_dir_op = dirs::config_dir();
 
                 config_dir_op.map(|d| d.join("bat"))?
             };
@@ -51,10 +51,10 @@ impl BatProjectDirs {
         let cache_dir_op = env::var_os("XDG_CACHE_HOME")
             .map(PathBuf::from)
             .filter(|p| p.is_absolute())
-            .or_else(|| dirs_next::home_dir().map(|d| d.join(".cache")));
+            .or_else(|| dirs::home_dir().map(|d| d.join(".cache")));
 
         #[cfg(not(target_os = "macos"))]
-        let cache_dir_op = dirs_next::cache_dir();
+        let cache_dir_op = dirs::cache_dir();
 
         cache_dir_op.map(|d| d.join("bat"))
     }


### PR DESCRIPTION
The `dirs` crate was forked as `dirs-next` after the original repos were archived.

The fork hasn't released a new version [since October 2020](https://crates.io/crates/dirs-next/versions), while the original has been taken off the shelf and has seen updates since then.

A [new version](https://crates.io/crates/dirs/5.0.0) was released just some days ago, switching from `winapi` to `windows-sys`.