### PR TITLE
Use the `is-terminal` crate instead of `atty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ version = "0.23.0"
 dependencies = [
  "ansi_colours",
  "assert_cmd",
- "atty",
  "bincode",
  "bugreport",
  "bytesize",
@@ -84,6 +83,7 @@ dependencies = [
  "git2",
  "globset",
  "grep-cli",
+ "is-terminal",
  "nix",
  "nu-ansi-term",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ application = [
 # Mainly for developers that want to iterate quickly
 # Be aware that the included features might change in the future
 minimal-application = [
-    "atty",
+    "is-terminal",
     "clap",
     "dirs",
     "paging",
@@ -41,7 +41,7 @@ regex-onig = ["syntect/regex-onig"] # Use the "oniguruma" regex engine
 regex-fancy = ["syntect/regex-fancy"] # Use the rust-only "fancy-regex" engine
 
 [dependencies]
-atty = { version = "0.2.14", optional = true }
+is-terminal = { version = "0.4.4", optional = true }
 nu-ansi-term = "0.47.0"
 ansi_colours = "^1.2"
 bincode = "1.0"

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};
 
-use atty::{self, Stream};
+use is_terminal::IsTerminal;
 
 use crate::{
     clap_app,
@@ -40,7 +40,7 @@ impl App {
         #[cfg(windows)]
         let _ = nu_ansi_term::enable_ansi_support();
 
-        let interactive_output = atty::is(Stream::Stdout);
+        let interactive_output = std::io::stdout().is_terminal();
 
         Ok(App {
             matches: Self::matches(interactive_output)?,
@@ -104,7 +104,7 @@ impl App {
                     // If we are reading from stdin, only enable paging if we write to an
                     // interactive terminal and if we do not *read* from an interactive
                     // terminal.
-                    if self.interactive_output && !atty::is(Stream::Stdin) {
+                    if self.interactive_output && std::io::stdin().is_terminal() {
                         PagingMode::QuitIfOneScreen
                     } else {
                         PagingMode::Never


### PR DESCRIPTION
The crate is already used by `clap` and a similar trait is about to be stabilized in `std`.

https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html