### PR TITLE
feat: map nix-store style *-nginx.cofig

### DIFF
--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -89,8 +89,7 @@ impl<'a> SyntaxMapping<'a> {
         for glob in &[
             "/etc/nginx/**/*.conf",
             "/etc/nginx/sites-*/**/*",
-            "nginx.conf",
-            "mime.types",
+            "**nginx.conf",
         ] {
             mapping.insert(glob, MappingTarget::MapTo("nginx")).unwrap();
         }


### PR DESCRIPTION
```console
./target/debug/bat /nix/store/sm8lcsj94pqsb43ssb7cx3r424zs71p1-nginx.conf
```

is now properly styled.

This is a very typical nix store autogenerated NixOS nginx config naming scheme.

```console
./target/debug/bat -L
[ ... ]
nginx                     conf.erb, nginx.conf, mime.types, fastcgi_params, scgi_params, uwsgi_params, /etc/nginx/**/*.conf,
                          /etc/nginx/sites-*/**/*, **nginx.conf
```

This means the removal of `mime.types` and `nginx.conf` has been merely a deduplication.

This is a small QoL improvement, but let's say that many NixOS users _love_ `bat`.