### PR TITLE
Clean-up bash completion

### DIFF
--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -32,7 +32,7 @@ __bat_escape_completions()
 }
 
 _bat() {
-	local cur prev words cword split=false
+	local cur prev words split=false
 	if declare -F _init_completion >/dev/null 2>&1; then
 		_init_completion -s || return 0
 	else


### PR DESCRIPTION
"cword" is unset and even is not used in completion for other shells, so it probably shouldn't be here either. If it for some reason should be there add the directive "# shellcheck disable=SC2034" to the line above it.