### PR TITLE
fix: Add syntax mapping `*.jsonl` => `json`

### DIFF
--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -70,6 +70,10 @@ impl<'a> SyntaxMapping<'a> {
             .insert("fish_history", MappingTarget::MapTo("YAML"))
             .unwrap();
 
+        mapping
+            .insert("*.jsonl", MappingTarget::MapTo("JSON"))
+            .unwrap();
+
         // See #2151, https://nmap.org/book/nse-language.html
         mapping
             .insert("*.nse", MappingTarget::MapTo("Lua"))


### PR DESCRIPTION
This PR fixes #2535

It adds a syntax mapping that treats `.jsonl` files as `JSON` in terms of syntax highlighting.