### PR TITLE
Treat OSC ANSI Sequences as Invisible Text & Add OSC 8 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix long file name wrapping in header, see #2835 (@FilipRazek)
 - Fix `NO_COLOR` support, see #2767 (@acuteenvy)
+- Fix handling of inputs with OSC ANSI escape sequences, see #2541 and #2544 (@eth-p)
 
 ## Other
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -598,12 +598,12 @@ impl<'a> Printer for InteractivePrinter<'a> {
                     match chunk {
                         // Regular text.
                         EscapeSequence::Text(text) => {
-                            let text = &*self.preprocess(text, &mut cursor_total);
+                            let text = self.preprocess(text, &mut cursor_total);
                             let text_trimmed = text.trim_end_matches(|c| c == '\r' || c == '\n');
 
                             write!(
                                 handle,
-                                "{}",
+                                "{}{}",
                                 as_terminal_escaped(
                                     style,
                                     &format!("{}{}", self.ansi_style, text_trimmed),
@@ -611,9 +611,11 @@ impl<'a> Printer for InteractivePrinter<'a> {
                                     colored_output,
                                     italics,
                                     background_color
-                                )
+                                ),
+                                self.ansi_style.to_reset_sequence(),
                             )?;
 
+                            // Pad the rest of the line.
                             if text.len() != text_trimmed.len() {
                                 if let Some(background_color) = background_color {
                                     let ansi_style = Style {
@@ -693,7 +695,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
                                     // It wraps.
                                     write!(
                                         handle,
-                                        "{}\n{}",
+                                        "{}{}\n{}",
                                         as_terminal_escaped(
                                             style,
                                             &format!("{}{}", self.ansi_style, line_buf),
@@ -702,6 +704,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
                                             self.config.use_italic_text,
                                             background_color
                                         ),
+                                        self.ansi_style.to_reset_sequence(),
                                         panel_wrap.clone().unwrap()
                                     )?;
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -33,7 +33,7 @@ use crate::line_range::RangeCheckResult;
 use crate::preprocessor::{expand_tabs, replace_nonprintable};
 use crate::style::StyleComponent;
 use crate::terminal::{as_terminal_escaped, to_ansi_color};
-use crate::vscreen::AnsiStyle;
+use crate::vscreen::{strip_problematic_sequences, AnsiStyle};
 use crate::wrapping::WrappingMode;
 
 pub enum OutputHandle<'a> {
@@ -581,7 +581,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
             let italics = self.config.use_italic_text;
 
             for &(style, region) in &regions {
-                let ansi_iterator = AnsiCodeIterator::new(region);
+                let text = strip_problematic_sequences(region);
+                let ansi_iterator = AnsiCodeIterator::new(&text);
                 for chunk in ansi_iterator {
                     match chunk {
                         // ANSI escape passthrough.
@@ -634,7 +635,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
             }
         } else {
             for &(style, region) in &regions {
-                let ansi_iterator = AnsiCodeIterator::new(region);
+                let text = strip_problematic_sequences(region);
+                let ansi_iterator = AnsiCodeIterator::new(&text);
                 for chunk in ansi_iterator {
                     match chunk {
                         // ANSI escape passthrough.

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -1,4 +1,8 @@
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    iter::Peekable,
+    str::CharIndices,
+};
 
 // Wrapper to avoid unnecessary branching when input doesn't have ANSI escape sequences.
 pub struct AnsiStyle {
@@ -209,4 +213,474 @@ fn join(
         .map(|i| i.to_string())
         .collect::<Vec<String>>()
         .join(delimiter)
+}
+
+/// A range of indices for a raw ANSI escape sequence.
+#[derive(Debug, PartialEq)]
+enum EscapeSequenceOffsets {
+    Text {
+        start: usize,
+        end: usize,
+    },
+    Unknown {
+        start: usize,
+        end: usize,
+    },
+    NF {
+        // https://en.wikipedia.org/wiki/ANSI_escape_code#nF_Escape_sequences
+        start_sequence: usize,
+        start: usize,
+        end: usize,
+    },
+    OSC {
+        // https://en.wikipedia.org/wiki/ANSI_escape_code#OSC_(Operating_System_Command)_sequences
+        start_sequence: usize,
+        start_command: usize,
+        start_terminator: usize,
+        end: usize,
+    },
+    CSI {
+        // https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
+        start_sequence: usize,
+        start_parameters: usize,
+        start_intermediates: usize,
+        start_final_byte: usize,
+        end: usize,
+    },
+}
+
+/// An iterator over the offests of ANSI/VT escape sequences within a string.
+///
+/// ## Example
+///
+/// ```ignore
+/// let iter = EscapeSequenceOffsetsIterator::new("\x1B[33mThis is yellow text.\x1B[m");
+/// ```
+struct EscapeSequenceOffsetsIterator<'a> {
+    text: &'a str,
+    chars: Peekable<CharIndices<'a>>,
+}
+
+impl<'a> EscapeSequenceOffsetsIterator<'a> {
+    pub fn new(text: &'a str) -> EscapeSequenceOffsetsIterator<'a> {
+        return EscapeSequenceOffsetsIterator {
+            text,
+            chars: text.char_indices().peekable(),
+        };
+    }
+
+    /// Takes values from the iterator while the predicate returns true.
+    /// If the predicate returns false, that value is left.
+    fn chars_take_while(&mut self, pred: impl Fn(char) -> bool) -> Option<(usize, usize)> {
+        if self.chars.peek().is_none() {
+            return None;
+        }
+
+        let start = self.chars.peek().unwrap().0;
+        let mut end: usize = start;
+        while let Some((i, c)) = self.chars.peek() {
+            if !pred(*c) {
+                break;
+            }
+
+            end = *i + c.len_utf8();
+            self.chars.next();
+        }
+
+        Some((start, end))
+    }
+
+    fn next_text(&mut self) -> Option<EscapeSequenceOffsets> {
+        match self.chars_take_while(|c| c != '\x1B') {
+            None => None,
+            Some((start, end)) => Some(EscapeSequenceOffsets::Text { start, end }),
+        }
+    }
+
+    fn next_sequence(&mut self) -> Option<EscapeSequenceOffsets> {
+        let (start_sequence, c) = self.chars.next().expect("to not be finished");
+        match self.chars.peek() {
+            None => Some(EscapeSequenceOffsets::Unknown {
+                start: start_sequence,
+                end: start_sequence + c.len_utf8(),
+            }),
+
+            Some((_, ']')) => self.next_osc(start_sequence),
+            Some((_, '[')) => self.next_csi(start_sequence),
+            Some((i, c)) => match c {
+                '\x20'..='\x2F' => self.next_nf(start_sequence),
+                c => Some(EscapeSequenceOffsets::Unknown {
+                    start: start_sequence,
+                    end: i + c.len_utf8(),
+                }),
+            },
+        }
+    }
+
+    fn next_osc(&mut self, start_sequence: usize) -> Option<EscapeSequenceOffsets> {
+        let (osc_open_index, osc_open_char) = self.chars.next().expect("to not be finished");
+        debug_assert_eq!(osc_open_char, ']');
+
+        let mut start_terminator: usize;
+        let mut end_sequence: usize;
+
+        loop {
+            match self.chars_take_while(|c| !matches!(c, '\x07' | '\x1B')) {
+                None => {
+                    start_terminator = self.text.len();
+                    end_sequence = start_terminator;
+                    break;
+                }
+
+                Some((_, end)) => {
+                    start_terminator = end;
+                    end_sequence = end;
+                }
+            }
+
+            match self.chars.next() {
+                Some((ti, '\x07')) => {
+                    end_sequence = ti + '\x07'.len_utf8();
+                    break;
+                }
+
+                Some((ti, '\x1B')) => {
+                    match self.chars.next() {
+                        Some((i, '\\')) => {
+                            end_sequence = i + '\\'.len_utf8();
+                            break;
+                        }
+
+                        None => {
+                            end_sequence = ti + '\x1B'.len_utf8();
+                            break;
+                        }
+
+                        _ => {
+                            // Repeat, since `\\`(anything) isn't a valid ST.
+                        }
+                    }
+                }
+
+                None => {
+                    // Prematurely ends.
+                    break;
+                }
+
+                Some((_, tc)) => {
+                    panic!("this should not be reached: char {:?}", tc)
+                }
+            }
+        }
+
+        Some(EscapeSequenceOffsets::OSC {
+            start_sequence,
+            start_command: osc_open_index + osc_open_char.len_utf8(),
+            start_terminator: start_terminator,
+            end: end_sequence,
+        })
+    }
+
+    fn next_csi(&mut self, start_sequence: usize) -> Option<EscapeSequenceOffsets> {
+        let (csi_open_index, csi_open_char) = self.chars.next().expect("to not be finished");
+        debug_assert_eq!(csi_open_char, '[');
+
+        let start_parameters: usize = csi_open_index + csi_open_char.len_utf8();
+
+        // Keep iterating while within the range of `0x30-0x3F`.
+        let mut start_intermediates: usize = start_parameters;
+        if let Some((_, end)) = self.chars_take_while(|c| matches!(c, '\x30'..='\x3F')) {
+            start_intermediates = end;
+        }
+
+        // Keep iterating while within the range of `0x20-0x2F`.
+        let mut start_final_byte: usize = start_intermediates;
+        if let Some((_, end)) = self.chars_take_while(|c| matches!(c, '\x20'..='\x2F')) {
+            start_final_byte = end;
+        }
+
+        // Take the last char.
+        let end_of_sequence = match self.chars.next() {
+            None => start_final_byte,
+            Some((i, c)) => i + c.len_utf8(),
+        };
+
+        Some(EscapeSequenceOffsets::CSI {
+            start_sequence,
+            start_parameters,
+            start_intermediates,
+            start_final_byte,
+            end: end_of_sequence,
+        })
+    }
+
+    fn next_nf(&mut self, start_sequence: usize) -> Option<EscapeSequenceOffsets> {
+        let (nf_open_index, nf_open_char) = self.chars.next().expect("to not be finished");
+        debug_assert!(matches!(nf_open_char, '\x20'..='\x2F'));
+
+        let start: usize = nf_open_index;
+        let mut end: usize = start;
+
+        // Keep iterating while within the range of `0x20-0x2F`.
+        match self.chars_take_while(|c| matches!(c, '\x20'..='\x2F')) {
+            Some((_, i)) => end = i,
+            None => {
+                return Some(EscapeSequenceOffsets::NF {
+                    start_sequence,
+                    start,
+                    end,
+                })
+            }
+        }
+
+        // Get the final byte.
+        match self.chars.next() {
+            Some((i, c)) => end = i + c.len_utf8(),
+            None => {}
+        }
+
+        Some(EscapeSequenceOffsets::NF {
+            start_sequence,
+            start,
+            end,
+        })
+    }
+}
+
+impl<'a> Iterator for EscapeSequenceOffsetsIterator<'a> {
+    type Item = EscapeSequenceOffsets;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.chars.peek() {
+            Some((_, '\x1B')) => self.next_sequence(),
+            Some((_, _)) => self.next_text(),
+            None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::vscreen::{EscapeSequenceOffsets, EscapeSequenceOffsetsIterator};
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_text() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("text");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::Text { start: 0, end: 4 })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_text_stops_at_esc() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("text\x1B[ming");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::Text { start: 0, end: 4 })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_osc_with_bel() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B]abc\x07");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::OSC {
+                start_sequence: 0,
+                start_command: 2,
+                start_terminator: 5,
+                end: 6,
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_osc_with_st() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B]abc\x1B\\");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::OSC {
+                start_sequence: 0,
+                start_command: 2,
+                start_terminator: 5,
+                end: 7,
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_osc_thats_broken() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B]ab");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::OSC {
+                start_sequence: 0,
+                start_command: 2,
+                start_terminator: 4,
+                end: 4,
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_csi() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B[m");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 0,
+                start_parameters: 2,
+                start_intermediates: 2,
+                start_final_byte: 2,
+                end: 3
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_csi_with_parameters() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B[1;34m");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 0,
+                start_parameters: 2,
+                start_intermediates: 6,
+                start_final_byte: 6,
+                end: 7
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_csi_with_intermediates() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B[$m");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 0,
+                start_parameters: 2,
+                start_intermediates: 2,
+                start_final_byte: 3,
+                end: 4
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_csi_with_parameters_and_intermediates() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B[1$m");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 0,
+                start_parameters: 2,
+                start_intermediates: 3,
+                start_final_byte: 4,
+                end: 5
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_csi_thats_broken() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B[");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 0,
+                start_parameters: 2,
+                start_intermediates: 2,
+                start_final_byte: 2,
+                end: 2
+            })
+        );
+
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B[1");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 0,
+                start_parameters: 2,
+                start_intermediates: 3,
+                start_final_byte: 3,
+                end: 3
+            })
+        );
+
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B[1$");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 0,
+                start_parameters: 2,
+                start_intermediates: 3,
+                start_final_byte: 4,
+                end: 4
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_nf() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B($0");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::NF {
+                start_sequence: 0,
+                start: 1,
+                end: 4
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_nf_thats_broken() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1B(");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::NF {
+                start_sequence: 0,
+                start: 1,
+                end: 1
+            })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_iterates() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("text\x1B[33m\x1B]OSC\x07\x1B(0");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::Text { start: 0, end: 4 })
+        );
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 4,
+                start_parameters: 6,
+                start_intermediates: 8,
+                start_final_byte: 8,
+                end: 9
+            })
+        );
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::OSC {
+                start_sequence: 9,
+                start_command: 11,
+                start_terminator: 14,
+                end: 15
+            })
+        );
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::NF {
+                start_sequence: 15,
+                start: 16,
+                end: 18
+            })
+        );
+        assert_eq!(iter.next(), None);
+    }
 }

--- a/tests/examples/regression_tests/issue_2541.txt
+++ b/tests/examples/regression_tests/issue_2541.txt
@@ -1,0 +1,1 @@
+]8;;http://example.com\This is a link]8;;\n

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1163,6 +1163,20 @@ fn bom_stripped_when_no_color_and_not_loop_through() {
         );
 }
 
+// Regression test for https://github.com/sharkdp/bat/issues/2541
+#[test]
+fn no_broken_osc_emit_with_line_wrapping() {
+    bat()
+        .arg("--color=always")
+        .arg("--decorations=never")
+        .arg("--wrap=character")
+        .arg("--terminal-width=40")
+        .arg("regression_tests/issue_2541.txt")
+        .assert()
+        .success()
+        .stdout(predicate::function(|s: &str| s.lines().count() == 1));
+}
+
 #[test]
 fn can_print_file_named_cache() {
     bat_with_config()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1966,7 +1966,7 @@ fn ansi_hyperlink_emitted_when_wrapped() {
         .write_stdin("\x1B]8;;http://example.com/\x1B\\Hyperlinks..........Wrap across lines.\n")
         .assert()
         .success()
-        .stdout("\x1B]8;;http://example.com/\x1B\\\x1B]8;;http://example.com/\x1B\\Hyperlinks..........\n\x1B]8;;http://example.com/\x1B\\Wrap across lines.\n")
+        .stdout("\x1B]8;;http://example.com/\x1B\\\x1B]8;;http://example.com/\x1B\\Hyperlinks..........\x1B]8;;\x1B\\\n\x1B]8;;http://example.com/\x1B\\Wrap across lines.\n")
         // FIXME:                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ should not be emitted twice.
         .stderr("");
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1952,6 +1952,25 @@ fn ansi_sgr_emitted_when_wrapped() {
         .stderr("");
 }
 
+// Ensure that a simple ANSI sequence passthrough is emitted properly on wrapped lines.
+// This also helps ensure that escape sequences are counted as part of the visible characters when wrapping.
+#[test]
+fn ansi_hyperlink_emitted_when_wrapped() {
+    bat()
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--terminal-width=20")
+        .arg("--wrap=character")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .write_stdin("\x1B]8;;http://example.com/\x1B\\Hyperlinks..........Wrap across lines.\n")
+        .assert()
+        .success()
+        .stdout("\x1B]8;;http://example.com/\x1B\\\x1B]8;;http://example.com/\x1B\\Hyperlinks..........\n\x1B]8;;http://example.com/\x1B\\Wrap across lines.\n")
+        // FIXME:                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ should not be emitted twice.
+        .stderr("");
+}
+
 // Ensure that multiple ANSI sequence SGR attributes are combined when emitted on wrapped lines.
 #[test]
 fn ansi_sgr_joins_attributes_when_wrapped() {


### PR DESCRIPTION
Fixes #2541 by ~~removing OSC sequences from lines before starting to print them.~~ no longer considering ANSI OSC sequences as visible text.

|<img width="1278" alt="image" src="https://user-images.githubusercontent.com/32112321/232371560-eaa6389a-2ae4-434e-9e90-3f9e8fdf6a72.png">|
|:-:|
|(Left: Fixed, Right: Current version)|

Prior to this change, we don't interpret OSC sequences in any special way. They aren't caught by `console::AnsiCodeIterator`, so the OSC sequences were being treated as visible text.

- When the OSC is printed in full, the terminal would see a valid sequence and hide it. As a consequence, lines would b e wrapped too early.

- When the OSC is broken for line wrapping, the terminal wouldn't see a valid sequence. In this case, it prints both halves of the text on different lines and appears to be junk.

---

**Edit:** I had some extra time. A couple of new commits gave special handling for the OSC 8 sequence, allowing bat to disable the hyperlink at the end of the line and then re-emit it at the start of the next line.

<img width="1838" alt="image" src="https://user-images.githubusercontent.com/32112321/232653339-a4b09511-2ada-4b93-9259-5f736be9dca4.png">
