### PR TITLE
Replace `dirs` crate with `etcetera` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,13 +129,14 @@ dependencies = [
  "clircle",
  "console",
  "content_inspector",
- "dirs",
  "encoding_rs",
+ "etcetera",
  "expect-test",
  "flate2",
  "git2",
  "globset",
  "grep-cli",
+ "home",
  "nix",
  "nu-ansi-term",
  "once_cell",
@@ -339,26 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "dirs"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
-dependencies = [
- "libc",
- "redox_users",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "dissimilar"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +391,17 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -470,17 +462,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -558,6 +539,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "idna"
@@ -921,17 +911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
 ]
 
 [[package]]
@@ -1342,12 +1321,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wild"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ application = [
 # Be aware that the included features might change in the future
 minimal-application = [
     "clap",
-    "dirs",
+    "etcetera",
     "paging",
     "regex-onig",
     "wild",
@@ -58,7 +58,7 @@ semver = "1.0"
 path_abs = { version = "0.5", default-features = false }
 clircle = "0.4"
 bugreport = { version = "0.5.0", optional = true }
-dirs = { version = "5.0.0", optional = true }
+etcetera = { version = "0.8.0", optional = true }
 grep-cli = { version = "0.1.9", optional = true }
 regex = { version = "1.8.3", optional = true }
 walkdir = { version = "2.3", optional = true }
@@ -81,7 +81,7 @@ optional = true
 features = ["wrap_help", "cargo"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-dirs = "5.0.0"
+home = "0.5.4"
 plist = "1.4.3"
 
 [dev-dependencies]

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -404,7 +404,7 @@ fn macos_dark_mode_active() -> bool {
     const PREFERENCES_FILE: &str = "Library/Preferences/.GlobalPreferences.plist";
     const STYLE_KEY: &str = "AppleInterfaceStyle";
 
-    let preferences_file = dirs::home_dir()
+    let preferences_file = home::home_dir()
         .map(|home| home.join(PREFERENCES_FILE))
         .expect("Could not get home directory");
 


### PR DESCRIPTION
The cache & config paths are unchanged. The `etcetera` crate allows you to use the XDG spec on macOS too without any hassle. In addition, it is slightly smaller.

Disclaimer: I've recently become a maintainer of the `etcetera` crate. AFAIK, it is the only crate that can replace this logic.