### PR TITLE
CICD: Run cargo audit

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -131,6 +131,13 @@ jobs:
     - name: Show man page
       run: man $(find . -name bat.1)
 
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo audit
+
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}


### PR DESCRIPTION
This CI check will fail if there are crates with known security vulnerabilities in Cargo.lock.

It will not fail because of warnings. We currently have two warnings:

```console
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 543 security advisories (from /home/martin/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (184 crate dependencies)
Crate:     encoding
Version:   0.2.33
Warning:   unmaintained
Title:     `encoding` is unmaintained
Date:      2021-12-05
ID:        RUSTSEC-2021-0153
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0153
Dependency tree:
encoding 0.2.33
└── bat 0.23.0

Crate:     atty
Version:   0.2.14
Warning:   unsound
Title:     Potential unaligned read
Date:      2021-07-04
ID:        RUSTSEC-2021-0145
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0145
Dependency tree:
atty 0.2.14
└── grep-cli 0.1.7
    └── bat 0.23.0

warning: 2 allowed warnings found
```

Note that `cargo-audit` is installed by default on GitHub's Ubuntu runners.

I've run this in my own projects for quite some time, and it works well in my experience.

If we run into a dep that has a vulnerability but no known fix, we can temporarily disable this check again. But it is good practice to run cargo-audit when possible.
