### PR TITLE
Fix paging not happening when stdout is interactive but stdin is not

### DIFF
--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -104,7 +104,7 @@ impl App {
                     // If we are reading from stdin, only enable paging if we write to an
                     // interactive terminal and if we do not *read* from an interactive
                     // terminal.
-                    if self.interactive_output && std::io::stdin().is_terminal() {
+                    if self.interactive_output && !std::io::stdin().is_terminal() {
                         PagingMode::QuitIfOneScreen
                     } else {
                         PagingMode::Never


### PR DESCRIPTION
This seems to have been introduced in 57cc0d843567eef566540074b391f8212d859871 since the condition `!atty::is(Stream::Stdin)` was inverted to `std::io::stdin().is_terminal()`. This seems to be a mistake since the comment says
```
// If we are reading from stdin, only enable paging if we write to an
// interactive terminal and if we do not *read* from an interactive
// terminal.
```
but the current code enables paging if stdin **is interactive**. 

This PR just flips the condition back to how it was to restore the original behavior. 
No changelog update as there hasn't been a release since the regression was introduced.  

Fixes #2572 