### PR TITLE
Enable `bat` to find `more` binary on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,17 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,12 +191,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "once_cell",
  "regex-automata",
  "serde",
 ]
@@ -618,11 +606,10 @@ dependencies = [
 
 [[package]]
 name = "grep-cli"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19fc6687bc64b6719a839cd24f2c700bcb05ffeb684d19da6a637c2455a7ba1"
+checksum = "8fe4bdbf4300c8b039f5d7eec7fbc6760d2c85bb15ac7499c4d235667f6d747a"
 dependencies = [
- "atty",
  "bstr",
  "globset",
  "lazy_static",
@@ -638,15 +625,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -699,7 +677,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
  "rustix 0.36.8",
  "windows-sys 0.45.0",
@@ -1063,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ path_abs = { version = "0.5", default-features = false }
 clircle = "0.4"
 bugreport = { version = "0.5.0", optional = true }
 dirs = { version = "5.0.0", optional = true }
-grep-cli = { version = "0.1.7", optional = true }
+grep-cli = { version = "0.1.9", optional = true }
 regex = { version = "1.8.3", optional = true }
 walkdir = { version = "2.3", optional = true }
 bytesize = { version = "1.2.0" }

--- a/src/output.rs
+++ b/src/output.rs
@@ -114,6 +114,8 @@ impl OutputType {
                 p.args(args);
             }
             p.env("LESSCHARSET", "UTF-8");
+        } else if pager.kind == PagerKind::More && cfg!(windows) && args.is_empty() {
+            p.arg("/E"); // Enable extended features of Windows' 'more' by default
         } else {
             p.args(args);
         };


### PR DESCRIPTION
On Windows, `more` is a COM executable (i.e. its extension is `com`). As `resolve_binary()` tries to emulate the behaviour of Win32 API's `CreateProcess()`, it will search for `more.exe` and fail. This commit adds an exception to that by specifying the pager's binary explicitly.

Fixes #2570. See also BurntSushi/ripgrep#2523.

I'd like to add that `more` is not as bad as README makes it to be - it *does* support colors:

![cmd_COSn24wvTg](https://github.com/sharkdp/bat/assets/7210216/865d101c-7bb6-4412-9bd5-6239f8afe739)