### PR TITLE
Add `os-release` syntax mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Syntaxes
 
+- Associate `os-release` with `bash` syntax, see #2587 (@cyqsimon)
+
 ## Themes
 
 ## `bat` as a library

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -64,6 +64,12 @@ impl<'a> SyntaxMapping<'a> {
             )
             .unwrap();
         mapping
+            .insert(
+                "os-release",
+                MappingTarget::MapTo("Bourne Again Shell (bash)"),
+            )
+            .unwrap();
+        mapping
             .insert("*.pac", MappingTarget::MapTo("JavaScript (Babel)"))
             .unwrap();
         mapping


### PR DESCRIPTION
`/etc/os-release` and `/usr/lib/os-release` are files found on basically every Linux distro that describe the OS. As far as I know, there is no other use case for the file name `os-release`.

See https://www.freedesktop.org/software/systemd/man/os-release.html