### PR TITLE
CICD: Add `all-jobs` job

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -14,6 +14,23 @@ on:
       - '*'
 
 jobs:
+  all-jobs:
+    if: always() # Otherwise this job is skipped if the matrix job fails
+    name: all-jobs
+    runs-on: ubuntu-latest
+    needs:
+      - crate_metadata
+      - ensure_cargo_fmt
+      - min_version
+      - license_checks
+      - test_with_new_syntaxes_and_themes
+      - test_with_system_config
+      - documentation
+      - cargo-audit
+      - build
+    steps:
+      - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+
   crate_metadata:
     name: Extract crate metadata
     runs-on: ubuntu-latest


### PR DESCRIPTION
This opens up future possibilities:
* GitHub's auto-merge feature that merges a PR once CI passes
* Auto-merge of dependabot PRs that pass CI ([example](https://github.com/Enselic/cargo-public-api/pull/425))

But before we do any of that we need to have this new job merged for a while to see that it works also in bat's CI setup. In other words, we need to check that it only pass if all other jobs pass, and fails otherwise.
