### PR TITLE
Set PagerMode to Never when none of input files exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Bugfixes
+- Set PagerMode to Never when none of input files exists, see #2590 (@saguywalker)
 
 ## Other
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -46,8 +46,9 @@ impl<'b> Controller<'b> {
             let mut paging_mode = self.config.paging_mode;
             if self.config.paging_mode != PagingMode::Never {
                 let call_pager = inputs.iter().any(|input| {
-                    if let InputKind::OrdinaryFile(ref path) = input.kind {
-                        Path::new(path).exists()
+                    if let InputKind::OrdinaryFile(ref path_str) = input.kind {
+                        let path = Path::new(path_str);
+                        path.exists() && path.is_file()
                     } else {
                         true
                     }


### PR DESCRIPTION
This PR fixes https://github.com/sharkdp/bat/issues/2561
 
Behavior when input is directory and existed

Master branch: `call_pager` is `true` because it only checks whether the path exists or not.
This PR: adds extra check to make sure that it's a file

<img width="1222" alt="image" src="https://github.com/sharkdp/bat/assets/25146296/e24ca500-790d-4c38-9f23-6cc140014ec0">
