### PR TITLE
Add `Containerfile` syntax mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Syntaxes
 
 - Associate `os-release` with `bash` syntax, see #2587 (@cyqsimon)
+- Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
 
 ## Themes
 

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -86,6 +86,10 @@ impl<'a> SyntaxMapping<'a> {
             .insert("rails", MappingTarget::MapToUnknown)
             .unwrap();
 
+        mapping
+            .insert("Containerfile", MappingTarget::MapTo("Dockerfile"))
+            .unwrap();
+
         // Nginx and Apache syntax files both want to style all ".conf" files
         // see #1131 and #1137
         mapping


### PR DESCRIPTION
Adds a syntax mapping to use `Dockerfile` syntax for `Containerfile`s. Based on #2606.