### PR TITLE
feat: Optionally write to a buffer instead of stdout

### DIFF
--- a/examples/buffer.rs
+++ b/examples/buffer.rs
@@ -1,0 +1,17 @@
+use bat::{assets::HighlightingAssets, config::Config, controller::Controller, Input};
+
+fn main() {
+    let mut buffer = String::new();
+    let config = Config {
+        colored_output: true,
+        ..Default::default()
+    };
+    let assets = HighlightingAssets::from_binary();
+    let controller = Controller::new(&config, &assets);
+    let input = Input::from_file(file!());
+    controller
+        .run(vec![input.into()], Some(&mut buffer))
+        .unwrap();
+
+    println!("{buffer}");
+}

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -206,7 +206,7 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
             )?;
             config.theme = theme.to_string();
             Controller::new(&config, &assets)
-                .run(vec![theme_preview_file()])
+                .run(vec![theme_preview_file()], None)
                 .ok();
             writeln!(stdout)?;
         }
@@ -230,7 +230,7 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
 fn run_controller(inputs: Vec<Input>, config: &Config, cache_dir: &Path) -> Result<bool> {
     let assets = assets_from_cache_or_binary(config.use_custom_assets, cache_dir)?;
     let controller = Controller::new(config, &assets);
-    controller.run(inputs)
+    controller.run(inputs, None)
 }
 
 #[cfg(feature = "bugreport")]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -98,7 +98,9 @@ impl<'b> Controller<'b> {
             };
             if let Err(error) = result {
                 match writer {
-                    OutputHandle::FmtWrite(writer) => todo!(),
+                    // It doesn't make much sense to send errors straight to stderr if the user
+                    // provided their own buffer, so we just return it.
+                    OutputHandle::FmtWrite(_) => return Err(error),
                     OutputHandle::IoWrite(ref mut writer) => {
                         if attached_to_pager {
                             handle_error(&error, writer);

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -79,11 +79,10 @@ impl<'b> Controller<'b> {
             clircle::Identifier::stdout()
         };
 
-        //let writer = output_type.handle()?;
-        let mut writer = output_buffer.map_or_else(
-            || OutputHandle::IoWrite(output_type.handle().unwrap()),
-            |buf| OutputHandle::FmtWrite(buf),
-        );
+        let mut writer = match output_buffer {
+            Some(buf) => OutputHandle::FmtWrite(buf),
+            None => OutputHandle::IoWrite(output_type.handle()?),
+        };
         let mut no_errors: bool = true;
         let stderr = io::stderr();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] ::std::io::Error),
     #[error(transparent)]
+    Fmt(#[from] ::std::fmt::Error),
+    #[error(transparent)]
     SyntectError(#[from] ::syntect::Error),
     #[error(transparent)]
     SyntectLoadingError(#[from] ::syntect::LoadingError),

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -300,7 +300,7 @@ impl<'a> PrettyPrinter<'a> {
 
         // Run the controller
         let controller = Controller::new(&self.config, &self.assets);
-        controller.run(inputs.into_iter().map(|i| i.into()).collect())
+        controller.run(inputs.into_iter().map(|i| i.into()).collect(), None)
     }
 }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -461,7 +461,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
             self.colors
                 .grid
                 .paint(format!("{}{}{}{}", panel, snip_left, title, snip_right))
-        );
+        )?;
 
         Ok(())
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -134,7 +134,16 @@ impl<'a> Printer for SimplePrinter<'a> {
             } else {
                 match handle {
                     OutputHandle::IoWrite(handle) => handle.write_all(line_buffer)?,
-                    OutputHandle::FmtWrite(handle) => todo!(),
+                    OutputHandle::FmtWrite(handle) => {
+                        write!(
+                            handle,
+                            "{}",
+                            std::str::from_utf8(line_buffer).map_err(|_| Error::Msg(
+                                "encountered invalid utf8 while printing to non-io buffer"
+                                    .to_string()
+                            ))?
+                        )?;
+                    }
                 }
             };
         }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -71,18 +71,18 @@ macro_rules! writeln_handle {
 pub(crate) trait Printer {
     fn print_header(
         &mut self,
-        handle: OutputHandle,
+        handle: &mut OutputHandle,
         input: &OpenedInput,
         add_header_padding: bool,
     ) -> Result<()>;
-    fn print_footer(&mut self, handle: OutputHandle, input: &OpenedInput) -> Result<()>;
+    fn print_footer(&mut self, handle: &mut OutputHandle, input: &OpenedInput) -> Result<()>;
 
-    fn print_snip(&mut self, handle: OutputHandle) -> Result<()>;
+    fn print_snip(&mut self, handle: &mut OutputHandle) -> Result<()>;
 
     fn print_line(
         &mut self,
         out_of_range: bool,
-        handle: OutputHandle,
+        handle: &mut OutputHandle,
         line_number: usize,
         line_buffer: &[u8],
     ) -> Result<()>;
@@ -101,25 +101,25 @@ impl<'a> SimplePrinter<'a> {
 impl<'a> Printer for SimplePrinter<'a> {
     fn print_header(
         &mut self,
-        _handle: OutputHandle,
+        _handle: &mut OutputHandle,
         _input: &OpenedInput,
         _add_header_padding: bool,
     ) -> Result<()> {
         Ok(())
     }
 
-    fn print_footer(&mut self, _handle: OutputHandle, _input: &OpenedInput) -> Result<()> {
+    fn print_footer(&mut self, _handle: &mut OutputHandle, _input: &OpenedInput) -> Result<()> {
         Ok(())
     }
 
-    fn print_snip(&mut self, _handle: OutputHandle) -> Result<()> {
+    fn print_snip(&mut self, _handle: &mut OutputHandle) -> Result<()> {
         Ok(())
     }
 
     fn print_line(
         &mut self,
         out_of_range: bool,
-        handle: OutputHandle,
+        handle: &mut OutputHandle,
         _line_number: usize,
         line_buffer: &[u8],
     ) -> Result<()> {
@@ -253,7 +253,11 @@ impl<'a> InteractivePrinter<'a> {
         })
     }
 
-    fn print_horizontal_line_term(&mut self, handle: OutputHandle, style: Style) -> Result<()> {
+    fn print_horizontal_line_term(
+        &mut self,
+        handle: &mut OutputHandle,
+        style: Style,
+    ) -> Result<()> {
         writeln_handle!(
             handle,
             "{}",
@@ -262,7 +266,7 @@ impl<'a> InteractivePrinter<'a> {
         Ok(())
     }
 
-    fn print_horizontal_line(&mut self, handle: OutputHandle, grid_char: char) -> Result<()> {
+    fn print_horizontal_line(&mut self, handle: &mut OutputHandle, grid_char: char) -> Result<()> {
         if self.panel_width == 0 {
             self.print_horizontal_line_term(handle, self.colors.grid)?;
         } else {
@@ -292,7 +296,7 @@ impl<'a> InteractivePrinter<'a> {
         }
     }
 
-    fn print_header_component_indent(&mut self, handle: OutputHandle) -> Result<()> {
+    fn print_header_component_indent(&mut self, handle: &mut OutputHandle) -> Result<()> {
         if self.config.style_components.grid() {
             write_handle!(
                 handle,
@@ -320,7 +324,7 @@ impl<'a> InteractivePrinter<'a> {
 impl<'a> Printer for InteractivePrinter<'a> {
     fn print_header(
         &mut self,
-        handle: OutputHandle,
+        handle: &mut OutputHandle,
         input: &OpenedInput,
         add_header_padding: bool,
     ) -> Result<()> {
@@ -419,7 +423,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
         Ok(())
     }
 
-    fn print_footer(&mut self, handle: OutputHandle, _input: &OpenedInput) -> Result<()> {
+    fn print_footer(&mut self, handle: &mut OutputHandle, _input: &OpenedInput) -> Result<()> {
         if self.config.style_components.grid()
             && (self.content_type.map_or(false, |c| c.is_text()) || self.config.show_nonprintable)
         {
@@ -429,7 +433,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
         }
     }
 
-    fn print_snip(&mut self, handle: OutputHandle) -> Result<()> {
+    fn print_snip(&mut self, handle: &mut OutputHandle) -> Result<()> {
         let panel = self.create_fake_panel(" ...");
         let panel_count = panel.chars().count();
 
@@ -456,7 +460,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
     fn print_line(
         &mut self,
         out_of_range: bool,
-        handle: OutputHandle,
+        handle: &mut OutputHandle,
         line_number: usize,
         line_buffer: &[u8],
     ) -> Result<()> {


### PR DESCRIPTION
Following on from my comment in #956, this PR adds the ability to write output to a `std::fmt` buffer instead of stdout. It does this by changing the `handle` used by the printer to be a mutable reference to either one of `dyn fmt::Write` or `dyn io::Write`.

Included is also an added example to show that it works. I didn't add it to the `PrettyPrinter` but I can do if it seems like a good idea.

Anything else let me know!