### PR TITLE
Replace unmaintained `encoding` dependency with `encoding_rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
  "console",
  "content_inspector",
  "dirs",
- "encoding",
+ "encoding_rs",
  "expect-test",
  "flate2",
  "git2",
@@ -383,68 +383,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encoding"
-version = "0.2.33"
+name = "encoding_rs"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "encoding-index-japanese",
- "encoding-index-korean",
- "encoding-index-simpchinese",
- "encoding-index-singlebyte",
- "encoding-index-tradchinese",
+ "cfg-if",
 ]
-
-[[package]]
-name = "encoding-index-japanese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-korean"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-simpchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-singlebyte"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-tradchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding_index_tests"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "errno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ once_cell = "1.17"
 thiserror = "1.0"
 wild = { version = "2.1", optional = true }
 content_inspector = "0.2.4"
-encoding = "0.2"
 shell-words = { version = "1.1.0", optional = true }
 unicode-width = "0.1.10"
 globset = "0.4"
@@ -64,6 +63,7 @@ grep-cli = { version = "0.1.9", optional = true }
 regex = { version = "1.8.3", optional = true }
 walkdir = { version = "2.3", optional = true }
 bytesize = { version = "1.2.0" }
+encoding_rs = "0.8.32"
 
 [dependencies.git2]
 version = "0.18"


### PR DESCRIPTION
bat depends on `encoding` crate but it is [no longer maintained](https://github.com/lifthrasiir/rust-encoding/issues/127). This is reported as [RUSTSEC-2021-0153](https://rustsec.org/advisories/RUSTSEC-2021-0153) in the advisory DB. The advisory suggests [`encoding_rs` crate](https://crates.io/crates/encoding_rs) as alternative.

This PR replaces the unmaintained crate with the alternative.

As a side effect, this patch makes bat's UTF16 support a bit more efficient:

- Decoding with UTF16LE or UTF16BE is now handled with `Cow` instead of `String`. It means that it can avoid extra allocation by reusing the original string buffer when no character in the buffer was replaced while encoding.
- Removing BOM is now handled by `encoding_rs` more efficiently thanks to [`encode_with_bom_removal`](https://docs.rs/encoding_rs/latest/encoding_rs/struct.Encoding.html#method.decode_with_bom_removal) methods. The previous implementation always allocated new buffer only for removing BOM.