### PR TITLE
Cargo.lock: Bump proc-macro2 to fix build with Rust nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,9 +996,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Without fix:

    $ cargo +nightly build
       Compiling proc-macro2 v1.0.54
    error[E0635]: unknown feature `proc_macro_span_shrink`
      --> /home/martin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.54/src/lib.rs:92:30
       |
    92 |     feature(proc_macro_span, proc_macro_span_shrink)
       |                              ^^^^^^^^^^^^^^^^^^^^^^

    For more information about this error, try `rustc --explain E0635`.
    error: could not compile `proc-macro2` (lib) due to previous error