### PR TITLE
fix for issue #2095

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Associate `os-release` with `bash` syntax, see #2587 (@cyqsimon)
 - Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
 - Replaced quotes with double quotes so fzf integration example script works on windows and linux. see #2095 (@johnmatthiggins)
+- Associate `ksh` files with `bash` syntax, see #2633 (@johnmatthiggins)
 
 ## Themes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Associate `os-release` with `bash` syntax, see #2587 (@cyqsimon)
 - Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
+- Replaced quotes with double quotes so fzf integration example script works on windows and linux. see #2095 (@johnmatthiggins)
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ use `bat`s `--color=always` option to force colorized output. You can also use `
 option to restrict the load times for long files:
 
 ```bash
-fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}'
+fzf --preview "bat --color=always --style=numbers --line-range=:500 {}"
 ```
 
 For more information, see [`fzf`'s `README`](https://github.com/junegunn/fzf#preview-window).

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -90,6 +90,10 @@ impl<'a> SyntaxMapping<'a> {
             .insert("Containerfile", MappingTarget::MapTo("Dockerfile"))
             .unwrap();
 
+        mapping
+            .insert("*.ksh", MappingTarget::MapTo("Bourne Again Shell (bash)"))
+            .unwrap();
+
         // Nginx and Apache syntax files both want to style all ".conf" files
         // see #1131 and #1137
         mapping


### PR DESCRIPTION
Changed single quotes to double quotes in README.md fzf integration example for better compatibility across platforms. See issue #2095 