### PR TITLE
Add `*.ron` syntax mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Associate `os-release` with `bash` syntax, see #2587 (@cyqsimon)
 - Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
 - Associate `ksh` files with `bash` syntax, see #2633 (@johnmatthiggins)
+- Associate `ron` files with `rust` syntax, see #2427 (@YeungOnion)
 
 ## Themes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Associate `os-release` with `bash` syntax, see #2587 (@cyqsimon)
 - Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
+- Replaced quotes with double quotes so fzf integration example script works on windows and linux. see #2095 (@johnmatthiggins)
 - Associate `ksh` files with `bash` syntax, see #2633 (@johnmatthiggins)
 - Associate `ron` files with `rust` syntax, see #2427 (@YeungOnion)
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ use `bat`s `--color=always` option to force colorized output. You can also use `
 option to restrict the load times for long files:
 
 ```bash
-fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}'
+fzf --preview "bat --color=always --style=numbers --line-range=:500 {}"
 ```
 
 For more information, see [`fzf`'s `README`](https://github.com/junegunn/fzf#preview-window).

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -152,6 +152,10 @@ impl<'a> SyntaxMapping<'a> {
             .insert("*.hook", MappingTarget::MapTo("INI"))
             .unwrap();
 
+        mapping
+            .insert("*.ron", MappingTarget::MapTo("Rust"))
+            .unwrap();
+
         // Global git config files rooted in `$XDG_CONFIG_HOME/git/` or `$HOME/.config/git/`
         // See e.g. https://git-scm.com/docs/git-config#FILES
         if let Some(xdg_config_home) =


### PR DESCRIPTION
Add a mapping to use `Rust` for rusty object notation, identified by `.ron` extension. See [#2427](https://github.com/sharkdp/bat/issues/2427).