### PR TITLE
No duplicate keys test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Associate `os-release` with `bash` syntax, see #2587 (@cyqsimon)
 - Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
 - Associate `ksh` files with `bash` syntax, see #2633 (@johnmatthiggins)
+- Associate `ron` files with `rust` syntax, see #2427 (@YeungOnion)
 
 ## Themes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
 - Replaced quotes with double quotes so fzf integration example script works on windows and linux. see #2095 (@johnmatthiggins)
 - Associate `ksh` files with `bash` syntax, see #2633 (@johnmatthiggins)
-- Associate `ron` files with `rust` syntax, see #2427 (@YeungOnion)
 
 ## Themes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Associate `os-release` with `bash` syntax, see #2587 (@cyqsimon)
 - Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
+- Replaced quotes with double quotes so fzf integration example script works on windows and linux. see #2095 (@johnmatthiggins)
 - Associate `ksh` files with `bash` syntax, see #2633 (@johnmatthiggins)
 - Associate `ron` files with `rust` syntax, see #2427 (@YeungOnion)
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ use `bat`s `--color=always` option to force colorized output. You can also use `
 option to restrict the load times for long files:
 
 ```bash
-fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}'
+fzf --preview "bat --color=always --style=numbers --line-range=:500 {}"
 ```
 
 For more information, see [`fzf`'s `README`](https://github.com/junegunn/fzf#preview-window).

--- a/src/assets/build_assets/acknowledgements.rs
+++ b/src/assets/build_assets/acknowledgements.rs
@@ -156,7 +156,6 @@ fn normalize_license_text(license_text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(test)]
     use super::*;
 
     #[test]

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -286,4 +286,20 @@ mod tests {
             Some(MappingTarget::MapToUnknown)
         );
     }
+
+    #[test]
+    /// verifies that SyntaxMapping::builtin() doesn't repeat `Glob`-based keys
+    fn no_duplicate_builtin_keys() {
+        let mappings = SyntaxMapping::builtin().mappings;
+        for i in 0..mappings.len() {
+            let mut tail = mappings[i + 1..].into_iter();
+            match tail.find(|item| item.0.glob() == mappings[i].0.glob()) {
+                Some(duplicate) => panic!(
+                    "duplicate in SyntaxMapping::builtin() for glob {}",
+                    duplicate.0.glob().glob()
+                ),
+                None => (),
+            }
+        }
+    }
 }

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -238,48 +238,52 @@ impl<'a> SyntaxMapping<'a> {
     }
 }
 
-#[test]
-fn basic() {
-    let mut map = SyntaxMapping::empty();
-    map.insert("/path/to/Cargo.lock", MappingTarget::MapTo("TOML"))
-        .ok();
-    map.insert("/path/to/.ignore", MappingTarget::MapTo("Git Ignore"))
-        .ok();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn basic() {
+        let mut map = SyntaxMapping::empty();
+        map.insert("/path/to/Cargo.lock", MappingTarget::MapTo("TOML"))
+            .ok();
+        map.insert("/path/to/.ignore", MappingTarget::MapTo("Git Ignore"))
+            .ok();
 
-    assert_eq!(
-        map.get_syntax_for("/path/to/Cargo.lock"),
-        Some(MappingTarget::MapTo("TOML"))
-    );
-    assert_eq!(map.get_syntax_for("/path/to/other.lock"), None);
+        assert_eq!(
+            map.get_syntax_for("/path/to/Cargo.lock"),
+            Some(MappingTarget::MapTo("TOML"))
+        );
+        assert_eq!(map.get_syntax_for("/path/to/other.lock"), None);
 
-    assert_eq!(
-        map.get_syntax_for("/path/to/.ignore"),
-        Some(MappingTarget::MapTo("Git Ignore"))
-    );
-}
+        assert_eq!(
+            map.get_syntax_for("/path/to/.ignore"),
+            Some(MappingTarget::MapTo("Git Ignore"))
+        );
+    }
 
-#[test]
-fn user_can_override_builtin_mappings() {
-    let mut map = SyntaxMapping::builtin();
+    #[test]
+    fn user_can_override_builtin_mappings() {
+        let mut map = SyntaxMapping::builtin();
 
-    assert_eq!(
-        map.get_syntax_for("/etc/profile"),
-        Some(MappingTarget::MapTo("Bourne Again Shell (bash)"))
-    );
-    map.insert("/etc/profile", MappingTarget::MapTo("My Syntax"))
-        .ok();
-    assert_eq!(
-        map.get_syntax_for("/etc/profile"),
-        Some(MappingTarget::MapTo("My Syntax"))
-    );
-}
+        assert_eq!(
+            map.get_syntax_for("/etc/profile"),
+            Some(MappingTarget::MapTo("Bourne Again Shell (bash)"))
+        );
+        map.insert("/etc/profile", MappingTarget::MapTo("My Syntax"))
+            .ok();
+        assert_eq!(
+            map.get_syntax_for("/etc/profile"),
+            Some(MappingTarget::MapTo("My Syntax"))
+        );
+    }
 
-#[test]
-fn builtin_mappings() {
-    let map = SyntaxMapping::builtin();
+    #[test]
+    fn builtin_mappings() {
+        let map = SyntaxMapping::builtin();
 
-    assert_eq!(
-        map.get_syntax_for("/path/to/build"),
-        Some(MappingTarget::MapToUnknown)
-    );
+        assert_eq!(
+            map.get_syntax_for("/path/to/build"),
+            Some(MappingTarget::MapToUnknown)
+        );
+    }
 }

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -152,10 +152,6 @@ impl<'a> SyntaxMapping<'a> {
             .insert("*.hook", MappingTarget::MapTo("INI"))
             .unwrap();
 
-        mapping
-            .insert("*.ron", MappingTarget::MapTo("Rust"))
-            .unwrap();
-
         // Global git config files rooted in `$XDG_CONFIG_HOME/git/` or `$HOME/.config/git/`
         // See e.g. https://git-scm.com/docs/git-config#FILES
         if let Some(xdg_config_home) =

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -152,6 +152,10 @@ impl<'a> SyntaxMapping<'a> {
             .insert("*.hook", MappingTarget::MapTo("INI"))
             .unwrap();
 
+        mapping
+            .insert("*.ron", MappingTarget::MapTo("Rust"))
+            .unwrap();
+
         // Global git config files rooted in `$XDG_CONFIG_HOME/git/` or `$HOME/.config/git/`
         // See e.g. https://git-scm.com/docs/git-config#FILES
         if let Some(xdg_config_home) =


### PR DESCRIPTION
Addresses #2643 

The test `panic`'s at first instance of duplicate and emits string identifying the pattern. Is there an option to emit information for the duplicate beyond `cargo test no_duplicate_builtin_keys -- --nocapture`? 

Don't think this will change, but [this discussion on ripgrep/globset](https://github.com/BurntSushi/ripgrep/discussions/2581) mentioned `impl Eq for Glob`