### PR TITLE
No duplicate keys test, fixes #2643

### DIFF
--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -160,13 +160,13 @@ impl<'a> SyntaxMapping<'a> {
                 .filter(|val| !val.is_empty())
                 .map(|home| Path::new(&home).join(".config")),
         ) {
-            (Some(xdg_config_home), Some(default_config_home)) => {
-                if xdg_config_home == default_config_home {
-                    insert_git_config_global(&mut mapping, &xdg_config_home)
-                } else {
-                    insert_git_config_global(&mut mapping, &xdg_config_home);
-                    insert_git_config_global(&mut mapping, &default_config_home)
-                }
+            (Some(xdg_config_home), Some(default_config_home))
+                if xdg_config_home == default_config_home => {
+                insert_git_config_global(&mut mapping, &xdg_config_home)
+            }
+            (Some(xdg_config_home), Some(default_config_home)) /* else guard */ => {
+                insert_git_config_global(&mut mapping, &xdg_config_home);
+                insert_git_config_global(&mut mapping, &default_config_home)
             }
             (Some(config_home), None) => insert_git_config_global(&mut mapping, &config_home),
             (None, Some(config_home)) => insert_git_config_global(&mut mapping, &config_home),

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -282,4 +282,20 @@ mod tests {
             Some(MappingTarget::MapToUnknown)
         );
     }
+
+    #[test]
+    /// verifies that SyntaxMapping::builtin() doesn't repeat `Glob`-based keys
+    fn no_duplicate_builtin_keys() {
+        let mappings = SyntaxMapping::builtin().mappings;
+        for i in 0..mappings.len() {
+            let mut tail = mappings[i + 1..].into_iter();
+            match tail.find(|item| item.0.glob() == mappings[i].0.glob()) {
+                Some(duplicate) => panic!(
+                    "duplicate in SyntaxMapping::builtin() for glob {}",
+                    duplicate.0.glob().glob()
+                ),
+                None => (),
+            }
+        }
+    }
 }

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -234,48 +234,52 @@ impl<'a> SyntaxMapping<'a> {
     }
 }
 
-#[test]
-fn basic() {
-    let mut map = SyntaxMapping::empty();
-    map.insert("/path/to/Cargo.lock", MappingTarget::MapTo("TOML"))
-        .ok();
-    map.insert("/path/to/.ignore", MappingTarget::MapTo("Git Ignore"))
-        .ok();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn basic() {
+        let mut map = SyntaxMapping::empty();
+        map.insert("/path/to/Cargo.lock", MappingTarget::MapTo("TOML"))
+            .ok();
+        map.insert("/path/to/.ignore", MappingTarget::MapTo("Git Ignore"))
+            .ok();
 
-    assert_eq!(
-        map.get_syntax_for("/path/to/Cargo.lock"),
-        Some(MappingTarget::MapTo("TOML"))
-    );
-    assert_eq!(map.get_syntax_for("/path/to/other.lock"), None);
+        assert_eq!(
+            map.get_syntax_for("/path/to/Cargo.lock"),
+            Some(MappingTarget::MapTo("TOML"))
+        );
+        assert_eq!(map.get_syntax_for("/path/to/other.lock"), None);
 
-    assert_eq!(
-        map.get_syntax_for("/path/to/.ignore"),
-        Some(MappingTarget::MapTo("Git Ignore"))
-    );
-}
+        assert_eq!(
+            map.get_syntax_for("/path/to/.ignore"),
+            Some(MappingTarget::MapTo("Git Ignore"))
+        );
+    }
 
-#[test]
-fn user_can_override_builtin_mappings() {
-    let mut map = SyntaxMapping::builtin();
+    #[test]
+    fn user_can_override_builtin_mappings() {
+        let mut map = SyntaxMapping::builtin();
 
-    assert_eq!(
-        map.get_syntax_for("/etc/profile"),
-        Some(MappingTarget::MapTo("Bourne Again Shell (bash)"))
-    );
-    map.insert("/etc/profile", MappingTarget::MapTo("My Syntax"))
-        .ok();
-    assert_eq!(
-        map.get_syntax_for("/etc/profile"),
-        Some(MappingTarget::MapTo("My Syntax"))
-    );
-}
+        assert_eq!(
+            map.get_syntax_for("/etc/profile"),
+            Some(MappingTarget::MapTo("Bourne Again Shell (bash)"))
+        );
+        map.insert("/etc/profile", MappingTarget::MapTo("My Syntax"))
+            .ok();
+        assert_eq!(
+            map.get_syntax_for("/etc/profile"),
+            Some(MappingTarget::MapTo("My Syntax"))
+        );
+    }
 
-#[test]
-fn builtin_mappings() {
-    let map = SyntaxMapping::builtin();
+    #[test]
+    fn builtin_mappings() {
+        let map = SyntaxMapping::builtin();
 
-    assert_eq!(
-        map.get_syntax_for("/path/to/build"),
-        Some(MappingTarget::MapToUnknown)
-    );
+        assert_eq!(
+            map.get_syntax_for("/path/to/build"),
+            Some(MappingTarget::MapToUnknown)
+        );
+    }
 }


### PR DESCRIPTION
address #2643 

did a mistake on the other PR, but this adds the test to ensure there aren't duplicates. The test will show any instances of the first duplicated key found.

There's also a change to ensure that duplicate paths to git config directories aren't added - still allows for two different directories.