### PR TITLE
Enable extended features of `more` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Output directory for generated assets (completion, manual) can be customized, see #2515 (@tranzystorek-io)
 - Bump MSRV to 1.70, see #2651 (@mataha)
+- `more` on Windows now has extended features enabled, see #2657 (@mataha)
 
 ## Syntaxes
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -110,6 +110,8 @@ impl OutputType {
                     }
                     _ => {}
                 }
+            } else if pager.kind == PagerKind::More && cfg!(windows) && args.is_empty() {
+                p.arg("/E");
             } else {
                 p.args(args);
             }


### PR DESCRIPTION
This is an attempt to bring user experience on Windows in parity with other systems as by default `more` can't even skip n arbitrary lines.