### PR TITLE
Add `-s`/`--squeeze` and `--squeeze-limit` (based on #1441).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Features
 
 - Set terminal title to file names when Paging is not Paging::Never #2807 (@Oliver-Looney)
+- `bat --squeeze`/`bat -s` will now squeeze consecutive empty lines, see #1441 (@eth-p)
+- `bat --squeeze-limit` to set the maximum number of empty consecutive when using `--squeeze`, see #1441 (@eth-p)
+- `PrettyPrinter::squeeze_empty_lines` to support line squeezing for bat as a library, see #1441 (@eth-p)
 
 ## Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Features
 
 - Set terminal title to file names when Paging is not Paging::Never #2807 (@Oliver-Looney)
-- `bat --squeeze`/`bat -s` will now squeeze consecutive empty lines, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
-- `bat --squeeze-limit` to set the maximum number of empty consecutive when using `--squeeze`, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
+- `bat --squeeze-blank`/`bat -s` will now squeeze consecutive empty lines, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
+- `bat --squeeze-limit` to set the maximum number of empty consecutive when using `--squeeze-blank`, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
 - `PrettyPrinter::squeeze_empty_lines` to support line squeezing for bat as a library, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
 
 ## Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## Features
 
 - Set terminal title to file names when Paging is not Paging::Never #2807 (@Oliver-Looney)
-- `bat --squeeze`/`bat -s` will now squeeze consecutive empty lines, see #1441 (@eth-p)
-- `bat --squeeze-limit` to set the maximum number of empty consecutive when using `--squeeze`, see #1441 (@eth-p)
-- `PrettyPrinter::squeeze_empty_lines` to support line squeezing for bat as a library, see #1441 (@eth-p)
+- `bat --squeeze`/`bat -s` will now squeeze consecutive empty lines, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
+- `bat --squeeze-limit` to set the maximum number of empty consecutive when using `--squeeze`, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
+- `PrettyPrinter::squeeze_empty_lines` to support line squeezing for bat as a library, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
 
 ## Bugfixes
 

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -116,7 +116,7 @@ Options:
       --list-themes
           Display a list of supported themes for syntax highlighting.
 
-  -s, --squeeze
+  -s, --squeeze-blank
           Squeeze consecutive empty lines into a single empty line.
 
       --squeeze-limit <squeeze-limit>

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -116,6 +116,12 @@ Options:
       --list-themes
           Display a list of supported themes for syntax highlighting.
 
+  -s, --squeeze
+          Squeeze consecutive empty lines into a single empty line.
+
+      --squeeze-limit <squeeze-limit>
+          Set the maximum number of consecutive empty lines to be printed.
+
       --style <components>
           Configure which elements (line numbers, file headers, grid borders, Git modifications, ..)
           to display in addition to the file contents. The argument is a comma-separated list of

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -43,6 +43,10 @@ Options:
           Set the color theme for syntax highlighting.
       --list-themes
           Display all supported highlighting themes.
+  -s, --squeeze
+          Squeeze consecutive empty lines.
+      --squeeze-limit <squeeze-limit>
+          The maximum number of consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
           header, header-filename, header-filesize, grid, rule, numbers, snip).

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -45,8 +45,6 @@ Options:
           Display all supported highlighting themes.
   -s, --squeeze
           Squeeze consecutive empty lines.
-      --squeeze-limit <squeeze-limit>
-          The maximum number of consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
           header, header-filename, header-filesize, grid, rule, numbers, snip).

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -43,7 +43,7 @@ Options:
           Set the color theme for syntax highlighting.
       --list-themes
           Display all supported highlighting themes.
-  -s, --squeeze
+  -s, --squeeze-blank
           Squeeze consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -290,6 +290,11 @@ impl App {
             #[cfg(feature = "lessopen")]
             use_lessopen: self.matches.get_flag("lessopen"),
             set_terminal_title: self.matches.get_flag("set-terminal-title"),
+            squeeze_lines: if self.matches.get_flag("squeeze") {
+                1
+            } else {
+                0
+            },
         })
     }
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -291,9 +291,14 @@ impl App {
             use_lessopen: self.matches.get_flag("lessopen"),
             set_terminal_title: self.matches.get_flag("set-terminal-title"),
             squeeze_lines: if self.matches.get_flag("squeeze") {
-                1
+                Some(
+                    self.matches
+                        .get_one::<usize>("squeeze-limit")
+                        .map(|limit| limit.to_owned())
+                        .unwrap_or(1),
+                )
             } else {
-                0
+                None
             },
         })
     }

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -290,7 +290,7 @@ impl App {
             #[cfg(feature = "lessopen")]
             use_lessopen: self.matches.get_flag("lessopen"),
             set_terminal_title: self.matches.get_flag("set-terminal-title"),
-            squeeze_lines: if self.matches.get_flag("squeeze") {
+            squeeze_lines: if self.matches.get_flag("squeeze-blank") {
                 Some(
                     self.matches
                         .get_one::<usize>("squeeze-limit")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -396,6 +396,13 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long_help("Squeeze consecutive empty lines into a single empty line.")
         )
         .arg(
+            Arg::new("squeeze-limit")
+                .long("squeeze-limit")
+                .value_parser(|s: &str| s.parse::<usize>().map_err(|_| "Requires a non-negative number".to_owned()))
+                .help("The maximum number of consecutive empty lines.")
+                .long_help("Set the maximum number of consecutive empty lines to be printed.")
+        )
+        .arg(
             Arg::new("style")
                 .long("style")
                 .value_name("components")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -388,6 +388,14 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long_help("Display a list of supported themes for syntax highlighting."),
         )
         .arg(
+            Arg::new("squeeze")
+                .long("squeeze")
+                .short('s')
+                .action(ArgAction::SetTrue)
+                .help("Squeeze consecutive empty lines.")
+                .long_help("Squeeze consecutive empty lines into a single empty line.")
+        )
+        .arg(
             Arg::new("style")
                 .long("style")
                 .value_name("components")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -388,8 +388,8 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long_help("Display a list of supported themes for syntax highlighting."),
         )
         .arg(
-            Arg::new("squeeze")
-                .long("squeeze")
+            Arg::new("squeeze-blank")
+                .long("squeeze-blank")
                 .short('s')
                 .action(ArgAction::SetTrue)
                 .help("Squeeze consecutive empty lines.")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -399,8 +399,8 @@ pub fn build_app(interactive_output: bool) -> Command {
             Arg::new("squeeze-limit")
                 .long("squeeze-limit")
                 .value_parser(|s: &str| s.parse::<usize>().map_err(|_| "Requires a non-negative number".to_owned()))
-                .help("The maximum number of consecutive empty lines.")
                 .long_help("Set the maximum number of consecutive empty lines to be printed.")
+                .hide_short_help(true)
         )
         .arg(
             Arg::new("style")

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,9 @@ pub struct Config<'a> {
 
     // Weather or not to set terminal title when using a pager
     pub set_terminal_title: bool,
+
+    /// The maximum number of consecutive empty lines to display
+    pub squeeze_lines: usize,
 }
 
 #[cfg(all(feature = "minimal-application", feature = "paging"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,7 +99,7 @@ pub struct Config<'a> {
     pub set_terminal_title: bool,
 
     /// The maximum number of consecutive empty lines to display
-    pub squeeze_lines: usize,
+    pub squeeze_lines: Option<usize>,
 }
 
 #[cfg(all(feature = "minimal-application", feature = "paging"))]

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -231,8 +231,7 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     /// Specify the maximum number of consecutive empty lines to print.
-    /// If set to `0`, all empty lines will be shown.
-    pub fn squeeze_empty_lines(&mut self, maximum: usize) -> &mut Self {
+    pub fn squeeze_empty_lines(&mut self, maximum: Option<usize>) -> &mut Self {
         self.config.squeeze_lines = maximum;
         self
     }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -230,6 +230,13 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Specify the maximum number of consecutive empty lines to print.
+    /// If set to `0`, all empty lines will be shown.
+    pub fn squeeze_empty_lines(&mut self, maximum: usize) -> &mut Self {
+        self.config.squeeze_lines = maximum;
+        self
+    }
+
     /// Specify the highlighting theme
     pub fn theme(&mut self, theme: impl AsRef<str>) -> &mut Self {
         self.config.theme = theme.as_ref().to_owned();

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -580,10 +580,10 @@ impl<'a> Printer for InteractivePrinter<'a> {
         }
 
         // Skip squeezed lines.
-        if self.config.squeeze_lines > 0 {
+        if let Some(squeeze_limit) = self.config.squeeze_lines {
             if line.trim_end_matches(|c| c == '\r' || c == '\n').is_empty() {
                 self.consecutive_empty_lines += 1;
-                if self.consecutive_empty_lines > self.config.squeeze_lines {
+                if self.consecutive_empty_lines > squeeze_limit {
                     return Ok(());
                 }
             } else {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -101,11 +101,15 @@ pub(crate) trait Printer {
 
 pub struct SimplePrinter<'a> {
     config: &'a Config<'a>,
+    consecutive_empty_lines: usize,
 }
 
 impl<'a> SimplePrinter<'a> {
     pub fn new(config: &'a Config) -> Self {
-        SimplePrinter { config }
+        SimplePrinter {
+            config,
+            consecutive_empty_lines: 0,
+        }
     }
 }
 
@@ -134,6 +138,21 @@ impl<'a> Printer for SimplePrinter<'a> {
         _line_number: usize,
         line_buffer: &[u8],
     ) -> Result<()> {
+        // Skip squeezed lines.
+        if let Some(squeeze_limit) = self.config.squeeze_lines {
+            if String::from_utf8_lossy(line_buffer)
+                .trim_end_matches(|c| c == '\r' || c == '\n')
+                .is_empty()
+            {
+                self.consecutive_empty_lines += 1;
+                if self.consecutive_empty_lines > squeeze_limit {
+                    return Ok(());
+                }
+            } else {
+                self.consecutive_empty_lines = 0;
+            }
+        }
+
         if !out_of_range {
             if self.config.show_nonprintable {
                 let line = replace_nonprintable(

--- a/tests/examples/empty_lines.txt
+++ b/tests/examples/empty_lines.txt
@@ -1,0 +1,30 @@
+line 1
+
+
+
+line 5
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+line 20
+line 21
+
+
+line 24
+
+line 26
+
+
+
+line 30

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -209,6 +209,70 @@ fn line_range_multiple() {
 }
 
 #[test]
+fn squeeze() {
+    bat()
+        .arg("empty_lines.txt")
+        .arg("--squeeze")
+        .assert()
+        .success()
+        .stdout("line 1\n\nline 5\n\nline 20\nline 21\n\nline 24\n\nline 26\n\nline 30\n");
+}
+
+#[test]
+fn squeeze_line_numbers() {
+    bat()
+        .arg("empty_lines.txt")
+        .arg("--squeeze")
+        .arg("--decorations=always")
+        .arg("--number")
+        .assert()
+        .success()
+        .stdout("   1 line 1\n   2 \n   5 line 5\n   6 \n  20 line 20\n  21 line 21\n  22 \n  24 line 24\n  25 \n  26 line 26\n  27 \n  30 line 30\n");
+}
+
+#[test]
+fn squeeze_limit() {
+    bat()
+        .arg("empty_lines.txt")
+        .arg("--squeeze")
+        .arg("--squeeze-limit=2")
+        .assert()
+        .success()
+        .stdout("line 1\n\n\nline 5\n\n\nline 20\nline 21\n\n\nline 24\n\nline 26\n\n\nline 30\n");
+
+    bat()
+        .arg("empty_lines.txt")
+        .arg("--squeeze")
+        .arg("--squeeze-limit=5")
+        .assert()
+        .success()
+        .stdout("line 1\n\n\n\nline 5\n\n\n\n\n\nline 20\nline 21\n\n\nline 24\n\nline 26\n\n\n\nline 30\n");
+}
+
+#[test]
+fn squeeze_limit_line_numbers() {
+    bat()
+        .arg("empty_lines.txt")
+        .arg("--squeeze")
+        .arg("--squeeze-limit=2")
+        .arg("--decorations=always")
+        .arg("--number")
+        .assert()
+        .success()
+        .stdout("   1 line 1\n   2 \n   3 \n   5 line 5\n   6 \n   7 \n  20 line 20\n  21 line 21\n  22 \n  23 \n  24 line 24\n  25 \n  26 line 26\n  27 \n  28 \n  30 line 30\n");
+
+    bat()
+        .arg("empty_lines.txt")
+        .arg("--squeeze")
+        .arg("--squeeze-limit=5")
+        .arg("--decorations=always")
+        .arg("--number")
+        .assert()
+        .success()
+        .stdout("   1 line 1\n   2 \n   3 \n   4 \n   5 line 5\n   6 \n   7 \n   8 \n   9 \n  10 \n  20 line 20\n  21 line 21\n  22 \n  23 \n  24 line 24\n  25 \n  26 line 26\n  27 \n  28 \n  29 \n  30 line 30\n");
+}
+
+#[test]
 #[cfg_attr(any(not(feature = "git"), target_os = "windows"), ignore)]
 fn short_help() {
     test_help("-h", "../doc/short-help.txt");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -209,20 +209,20 @@ fn line_range_multiple() {
 }
 
 #[test]
-fn squeeze() {
+fn squeeze_blank() {
     bat()
         .arg("empty_lines.txt")
-        .arg("--squeeze")
+        .arg("--squeeze-blank")
         .assert()
         .success()
         .stdout("line 1\n\nline 5\n\nline 20\nline 21\n\nline 24\n\nline 26\n\nline 30\n");
 }
 
 #[test]
-fn squeeze_line_numbers() {
+fn squeeze_blank_line_numbers() {
     bat()
         .arg("empty_lines.txt")
-        .arg("--squeeze")
+        .arg("--squeeze-blank")
         .arg("--decorations=always")
         .arg("--number")
         .assert()
@@ -234,7 +234,7 @@ fn squeeze_line_numbers() {
 fn squeeze_limit() {
     bat()
         .arg("empty_lines.txt")
-        .arg("--squeeze")
+        .arg("--squeeze-blank")
         .arg("--squeeze-limit=2")
         .assert()
         .success()
@@ -242,7 +242,7 @@ fn squeeze_limit() {
 
     bat()
         .arg("empty_lines.txt")
-        .arg("--squeeze")
+        .arg("--squeeze-blank")
         .arg("--squeeze-limit=5")
         .assert()
         .success()
@@ -253,7 +253,7 @@ fn squeeze_limit() {
 fn squeeze_limit_line_numbers() {
     bat()
         .arg("empty_lines.txt")
-        .arg("--squeeze")
+        .arg("--squeeze-blank")
         .arg("--squeeze-limit=2")
         .arg("--decorations=always")
         .arg("--number")
@@ -263,7 +263,7 @@ fn squeeze_limit_line_numbers() {
 
     bat()
         .arg("empty_lines.txt")
-        .arg("--squeeze")
+        .arg("--squeeze-blank")
         .arg("--squeeze-limit=5")
         .arg("--decorations=always")
         .arg("--number")


### PR DESCRIPTION
Fixes #762
Based on #1441 by @eth-p 

What I did:
 - rebased commits of #1441 with slight changes to resolve conflicts
 - added the squeeze functionality that had been added to the `InteractivePrinter` in #1441 to the `SimplePrinter` as well
 - added integration tests