### PR TITLE
Fix syntax tests failure on macOS during the daytime

### DIFF
--- a/tests/syntax-tests/create_highlighted_versions.py
+++ b/tests/syntax-tests/create_highlighted_versions.py
@@ -8,11 +8,13 @@ import os
 import argparse
 from multiprocessing import Pool
 
+# Avoid 'default' theme because it can choose a different theme based on
+# the appearance settings on macOS.
 BAT_OPTIONS = [
     "--no-config",
     "--style=plain",
     "--color=always",
-    "--theme=default",
+    "--theme=Monokai Extended",
     "--italic-text=always",
 ]
 


### PR DESCRIPTION
I'm setting 'Auto' appearance mode in the OS settings. It automatically sets the light mode during the daytime and switches to the dark mode at night.

<img width="257" alt="image" src="https://github.com/sharkdp/bat/assets/823277/7c7cb581-cfab-4b9a-bc46-ea894d8aa1a6">

Since syntax tests use `default` theme, bat automatically switches the default color theme looking at the OS settings on macOS. However syntax tests assume the theme is always dark. So the tests fail during the daytime in my environment.

This PR fixes the issue by setting `Monokai Extended` (which is the default color theme in dark mode) explicitly.