### PR TITLE
Associate `*.sarif` files with `json` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Associate `Containerfile` with `Dockerfile` syntax, see #2606 (@einfachIrgendwer0815)
 - Replaced quotes with double quotes so fzf integration example script works on windows and linux. see #2095 (@johnmatthiggins)
 - Associate `ksh` files with `bash` syntax, see #2633 (@johnmatthiggins)
+- Associate `sarif` files with `JSON` syntax, see #2695 (@rhysd)
 - Associate `ron` files with `rust` syntax, see #2427 (@YeungOnion)
 
 ## Themes

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -76,9 +76,9 @@ impl<'a> SyntaxMapping<'a> {
             .insert("fish_history", MappingTarget::MapTo("YAML"))
             .unwrap();
 
-        mapping
-            .insert("*.jsonl", MappingTarget::MapTo("JSON"))
-            .unwrap();
+        for glob in ["*.jsonl", "*.sarif"] {
+            mapping.insert(glob, MappingTarget::MapTo("JSON")).unwrap();
+        }
 
         // See #2151, https://nmap.org/book/nse-language.html
         mapping


### PR DESCRIPTION
[SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html) is a format for reporting static analysis results. It is [used by GitHub CodeQL](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning?learn=code_security_integration&learnProduct=code-security) for example.

Here are some samples from Microsoft's VSCode extension:

https://github.com/microsoft/sarif-vscode-extension/tree/main/samples

The SARIF format is built on top of JSON so the `.sarif` files can be highlighted as JSON. This PR adds support for the file extension.