### PR TITLE
Fix arithmetic overflow in `LineRange::parse_range`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Fix `more` not being found on Windows when provided via `BAT_PAGER`, see #2570, #2580, and #2651 (@mataha)
 - Switched default behavior of `--map-syntax` to be case insensitive #2520
 - Updated version of `serde_yaml` to `0.9`. See #2627 (@Raghav-Bell)
+- Fixed arithmetic overflow in `LineRange::from`, see #2674 (@skoriop)
+
 ## Other
 
 - Output directory for generated assets (completion, manual) can be customized, see #2515 (@tranzystorek-io)

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -129,6 +129,13 @@ fn test_parse_plus() {
 }
 
 #[test]
+fn test_parse_plus_overflow() {
+    let range = LineRange::from("18446744073709551615:+1").expect("Shouldn't fail on test!");
+    assert_eq!(18446744073709551615, range.lower);
+    assert_eq!(18446744073709551615, range.upper);
+}
+
+#[test]
 fn test_parse_plus_fail() {
     let range = LineRange::from("40:+z");
     assert!(range.is_err());

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -53,7 +53,7 @@ impl LineRange {
                     let more_lines = &line_numbers[1][1..]
                         .parse()
                         .map_err(|_| "Invalid character after +")?;
-                    new_range.lower + more_lines
+                    new_range.lower.saturating_add(*more_lines)
                 } else if first_byte == Some(b'-') {
                     // this will prevent values like "-+5" even though "+5" is valid integer
                     if line_numbers[1][1..].bytes().next() == Some(b'+') {

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -130,9 +130,9 @@ fn test_parse_plus() {
 
 #[test]
 fn test_parse_plus_overflow() {
-    let range = LineRange::from("18446744073709551615:+1").expect("Shouldn't fail on test!");
-    assert_eq!(18446744073709551615, range.lower);
-    assert_eq!(18446744073709551615, range.upper);
+    let range = LineRange::from(&format!("{}:+1", usize::MAX)).expect("Shouldn't fail on test!");
+    assert_eq!(usize::MAX, range.lower);
+    assert_eq!(usize::MAX, range.upper);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #2674 

