### PR TITLE
Setup auto-merge of dependabot PRs that pass CI

### DIFF
--- a/.github/workflows/Auto-merge-dependabot-PRs.yml
+++ b/.github/workflows/Auto-merge-dependabot-PRs.yml
@@ -1,0 +1,23 @@
+# This workflow triggers auto-merge of any PR that dependabot creates so that
+# PRs will be merged automatically without maintainer intervention if CI passes
+name: Auto-merge dependabot PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  auto-merge:
+    if: github.repository == 'sharkdp/bat' && startsWith(github.head_ref, 'dependabot/')
+    runs-on: ubuntu-latest
+    environment:
+      name: auto-merge
+      url: https://github.com/sharkdp/bat/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml
+    env:
+      GITHUB_TOKEN: ${{ secrets.AUTO_MERGE_GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          gh pr review ${{ github.event.pull_request.number }} --comment --body "If CI passes, this dependabot PR will be [auto-merged](https://github.com/sharkdp/bat/blob/main/.github/workflows/Auto-merge-dependabot-PRs.yml) 🚀"
+      - run: |
+          gh pr merge --auto --squash ${{ github.event.pull_request.number }}


### PR DESCRIPTION
I have been using this myself in cargo-public-api, and what we have here is the result of several iterations, and this has worked well for quite some time now.

To activate this, we need to:
* Go to https://github.com/sharkdp/bat/settings/branches (only you can do this sharkdp)
  * Click 'Edit' for 'master'
  * Check 'Require status checks to pass before merging'
  * Check 'Require branches to be up to date before merging'
  * For 'Status checks that are required.', add 'all-jobs'
* Create a token for a bot-user. We can use @EnselicCICD, or maybe you sharkdp can create your own account. GitHub ToS explicitly allows one machine-account per user last time I checked.
* Add that user as a collaborator to this repo (only you can do this sharkdp).

Maintainers will still be able to push directly to main.

### Require branches to be up to date before merging

If we don't enable this, we will get problems with dependabot PRs that individually pass CI, but combined do not. dependabot will auto-rebase its PRs so until all PRs are merged (or CI fails).

### What about merge of pointless dependabot bumps?

Sometimes dependabot bumps the version of a git repo that conatins a syntax, but the bump does not change .sublime-syntax. I think we can live with this. It's not a big deal by my estimation.

### What about CHANGELOG.md?

Before a release we need we can let GitHub generate release notes from a draft release, and then we can check what dependabot has bumped in terms of syntaxes and themes, and add that to CHANGELOG.md. I should update release-checklist.md later.

I'm sure there are details I've missed, but this is a start to set this up.
