### PR TITLE
Temporarily change dependabot to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: monthly
-    time: "04:00"
+    interval: daily
+    time: "16:00"
     timezone: Europe/Berlin
   ignore:
   - dependency-name: git2
@@ -13,8 +13,8 @@ updates:
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
-    interval: monthly
-    time: "04:00"
+    interval: daily
+    time: "16:00"
     timezone: Europe/Berlin
 - package-ecosystem: "github-actions"
   directory: "/"


### PR DESCRIPTION
So we can more easily test that dependabot auto-merge works as it should. Once we have confirmed it does, we revert this commit.