### PR TITLE
Bump edition to 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Other
 
+- Upgrade to Rust 2021 edition
+
 ## Syntaxes
 
 ## Themes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Other
 
-- Upgrade to Rust 2021 edition
+- Upgrade to Rust 2021 edition #2748 (@cyqsimon)
 
 ## Syntaxes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/sharkdp/bat"
 version = "0.24.0"
 exclude = ["assets/syntaxes/*", "assets/themes/*"]
 build = "build.rs"
-edition = '2018'
+edition = '2021'
 rust-version = "1.70"
 
 [features]


### PR DESCRIPTION
The MSRV is already 1.70 anyway, so this has no effect on compatibility.

## Checklist
- [x] `cargo fix --edition`
- [x] `cargo fix --edition-idioms` - no warnings or errors
- [x] `cargo clippy` - no warnings or errors
- [x] `cargo test` - passed