### PR TITLE
Build script refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +112,7 @@ name = "bat"
 version = "0.24.0"
 dependencies = [
  "ansi_colours",
+ "anyhow",
  "assert_cmd",
  "bincode",
  "bugreport",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,9 @@ tempfile = "3.8.1"
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.26.4", default-features = false, features = ["term"] }
 
+[build-dependencies]
+anyhow = "1.0.75"
+
 [build-dependencies.clap]
 version = "4.4.6"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "bat"
 repository = "https://github.com/sharkdp/bat"
 version = "0.24.0"
 exclude = ["assets/syntaxes/*", "assets/themes/*"]
-build = "build.rs"
+build = "build/main.rs"
 edition = '2021'
 rust-version = "1.70"
 

--- a/build.rs
+++ b/build.rs
@@ -18,11 +18,14 @@ fn gen_man_and_comp() -> anyhow::Result<()> {
     let executable_name_uppercase = executable_name.to_uppercase();
     let project_version = env::var("CARGO_PKG_VERSION")?;
 
-    let mut variables = HashMap::new();
-    variables.insert("PROJECT_NAME", project_name);
-    variables.insert("PROJECT_EXECUTABLE", executable_name);
-    variables.insert("PROJECT_EXECUTABLE_UPPERCASE", executable_name_uppercase);
-    variables.insert("PROJECT_VERSION", project_version);
+    let variables = [
+        ("PROJECT_NAME", project_name),
+        ("PROJECT_EXECUTABLE", executable_name),
+        ("PROJECT_EXECUTABLE_UPPERCASE", executable_name_uppercase),
+        ("PROJECT_VERSION", project_version),
+    ]
+    .into_iter()
+    .collect();
 
     let Some(out_dir) = env::var_os("BAT_ASSETS_GEN_DIR")
         .or_else(|| env::var_os("OUT_DIR"))

--- a/build.rs
+++ b/build.rs
@@ -77,7 +77,7 @@ fn render_template(
 
     for (variable_name, value) in variables {
         // Replace {{variable_name}} by the value
-        let pattern = format!("{{{{{variable_name}}}}}", variable_name = variable_name);
+        let pattern = format!("{{{{{variable_name}}}}}");
         content = content.replace(&pattern, value);
     }
 

--- a/build.rs
+++ b/build.rs
@@ -1,37 +1,20 @@
-// For bat-as-a-library, no build script is required. The build script is for
-// the manpage and completions, which are only relevant to the bat application.
-#[cfg(not(feature = "application"))]
-fn main() {}
+use std::{collections::HashMap, fs, path::Path};
 
-#[cfg(feature = "application")]
 fn main() -> anyhow::Result<()> {
-    use std::collections::HashMap;
-    use std::fs;
-    use std::path::Path;
+    #[cfg(feature = "application")]
+    gen_man_and_comp()?;
 
+    Ok(())
+}
+
+/// Generate manpage and shell completions for the bat application.
+#[cfg(feature = "application")]
+fn gen_man_and_comp() -> anyhow::Result<()> {
     // Read environment variables.
     let project_name = option_env!("PROJECT_NAME").unwrap_or("bat");
     let executable_name = option_env!("PROJECT_EXECUTABLE").unwrap_or(project_name);
     let executable_name_uppercase = executable_name.to_uppercase();
     static PROJECT_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-    /// Generates a file from a template.
-    fn template(
-        variables: &HashMap<&str, &str>,
-        in_file: &str,
-        out_file: impl AsRef<Path>,
-    ) -> anyhow::Result<()> {
-        let mut content = fs::read_to_string(in_file)?;
-
-        for (variable_name, value) in variables {
-            // Replace {{variable_name}} by the value
-            let pattern = format!("{{{{{variable_name}}}}}", variable_name = variable_name);
-            content = content.replace(&pattern, value);
-        }
-
-        fs::write(out_file, content)?;
-        Ok(())
-    }
 
     let mut variables = HashMap::new();
     variables.insert("PROJECT_NAME", project_name);
@@ -49,31 +32,50 @@ fn main() -> anyhow::Result<()> {
     fs::create_dir_all(out_dir.join("assets/manual")).unwrap();
     fs::create_dir_all(out_dir.join("assets/completions")).unwrap();
 
-    template(
+    render_template(
         &variables,
         "assets/manual/bat.1.in",
         out_dir.join("assets/manual/bat.1"),
     )?;
-    template(
+    render_template(
         &variables,
         "assets/completions/bat.bash.in",
         out_dir.join("assets/completions/bat.bash"),
     )?;
-    template(
+    render_template(
         &variables,
         "assets/completions/bat.fish.in",
         out_dir.join("assets/completions/bat.fish"),
     )?;
-    template(
+    render_template(
         &variables,
         "assets/completions/_bat.ps1.in",
         out_dir.join("assets/completions/_bat.ps1"),
     )?;
-    template(
+    render_template(
         &variables,
         "assets/completions/bat.zsh.in",
         out_dir.join("assets/completions/bat.zsh"),
     )?;
 
+    Ok(())
+}
+
+/// Generates a file from a template.
+#[allow(dead_code)]
+fn render_template(
+    variables: &HashMap<&str, &str>,
+    in_file: &str,
+    out_file: impl AsRef<Path>,
+) -> anyhow::Result<()> {
+    let mut content = fs::read_to_string(in_file)?;
+
+    for (variable_name, value) in variables {
+        // Replace {{variable_name}} by the value
+        let pattern = format!("{{{{{variable_name}}}}}", variable_name = variable_name);
+        content = content.replace(&pattern, value);
+    }
+
+    fs::write(out_file, content)?;
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,3 @@
-// TODO: Re-enable generation of shell completion files (below) when clap 3 is out.
-// For more details, see https://github.com/sharkdp/bat/issues/372
-
 // For bat-as-a-library, no build script is required. The build script is for
 // the manpage and completions, which are only relevant to the bat application.
 #[cfg(not(feature = "application"))]
@@ -79,30 +76,3 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-
-// #[macro_use]
-// extern crate clap;
-
-// use clap::Shell;
-// use std::fs;
-
-// include!("src/clap_app.rs");
-
-// const BIN_NAME: &str = "bat";
-
-// fn main() {
-//     let outdir = std::env::var_os("SHELL_COMPLETIONS_DIR").or(std::env::var_os("OUT_DIR"));
-
-//     let outdir = match outdir {
-//         None => return,
-//         Some(outdir) => outdir,
-//     };
-
-//     fs::create_dir_all(&outdir).unwrap();
-
-//     let mut app = build_app(true);
-//     app.gen_completions(BIN_NAME, Shell::Bash, &outdir);
-//     app.gen_completions(BIN_NAME, Shell::Fish, &outdir);
-//     app.gen_completions(BIN_NAME, Shell::Zsh, &outdir);
-//     app.gen_completions(BIN_NAME, Shell::PowerShell, &outdir);
-// }

--- a/build.rs
+++ b/build.rs
@@ -4,9 +4,8 @@
 fn main() {}
 
 #[cfg(feature = "application")]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> anyhow::Result<()> {
     use std::collections::HashMap;
-    use std::error::Error;
     use std::fs;
     use std::path::Path;
 
@@ -21,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         variables: &HashMap<&str, &str>,
         in_file: &str,
         out_file: impl AsRef<Path>,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> anyhow::Result<()> {
         let mut content = fs::read_to_string(in_file)?;
 
         for (variable_name, value) in variables {
@@ -40,9 +39,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     variables.insert("PROJECT_EXECUTABLE_UPPERCASE", &executable_name_uppercase);
     variables.insert("PROJECT_VERSION", PROJECT_VERSION);
 
-    let out_dir_env = std::env::var_os("BAT_ASSETS_GEN_DIR")
-        .or_else(|| std::env::var_os("OUT_DIR"))
-        .expect("BAT_ASSETS_GEN_DIR or OUT_DIR to be set in build.rs");
+    let Some(out_dir_env) =
+        std::env::var_os("BAT_ASSETS_GEN_DIR").or_else(|| std::env::var_os("OUT_DIR"))
+    else {
+        anyhow::bail!("BAT_ASSETS_GEN_DIR or OUT_DIR should be set for build.rs");
+    };
     let out_dir = Path::new(&out_dir_env);
 
     fs::create_dir_all(out_dir.join("assets/manual")).unwrap();

--- a/build/application.rs
+++ b/build/application.rs
@@ -1,17 +1,9 @@
-use std::{collections::HashMap, fs, path::Path};
+use std::{env, fs, path::PathBuf};
 
-fn main() -> anyhow::Result<()> {
-    #[cfg(feature = "application")]
-    gen_man_and_comp()?;
-
-    Ok(())
-}
+use crate::util::render_template;
 
 /// Generate manpage and shell completions for the bat application.
-#[cfg(feature = "application")]
-fn gen_man_and_comp() -> anyhow::Result<()> {
-    use std::{env, path::PathBuf};
-
+pub fn gen_man_and_comp() -> anyhow::Result<()> {
     // Read environment variables.
     let project_name = env::var("PROJECT_NAME").unwrap_or("bat".into());
     let executable_name = env::var("PROJECT_EXECUTABLE").unwrap_or(project_name.clone());
@@ -63,24 +55,5 @@ fn gen_man_and_comp() -> anyhow::Result<()> {
         out_dir.join("assets/completions/bat.zsh"),
     )?;
 
-    Ok(())
-}
-
-/// Generates a file from a template.
-#[allow(dead_code)]
-fn render_template(
-    variables: &HashMap<&str, String>,
-    in_file: &str,
-    out_file: impl AsRef<Path>,
-) -> anyhow::Result<()> {
-    let mut content = fs::read_to_string(in_file)?;
-
-    for (variable_name, value) in variables {
-        // Replace {{variable_name}} by the value
-        let pattern = format!("{{{{{variable_name}}}}}");
-        content = content.replace(&pattern, value);
-    }
-
-    fs::write(out_file, content)?;
     Ok(())
 }

--- a/build/application.rs
+++ b/build/application.rs
@@ -4,6 +4,14 @@ use crate::util::render_template;
 
 /// Generate manpage and shell completions for the bat application.
 pub fn gen_man_and_comp() -> anyhow::Result<()> {
+    println!("cargo:rerun-if-changed=assets/manual/");
+    println!("cargo:rerun-if-changed=assets/completions/");
+
+    println!("cargo:rerun-if-env-changed=PROJECT_NAME");
+    println!("cargo:rerun-if-env-changed=PROJECT_EXECUTABLE");
+    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
+    println!("cargo:rerun-if-env-changed=BAT_ASSETS_GEN_DIR");
+
     // Read environment variables.
     let project_name = env::var("PROJECT_NAME").unwrap_or("bat".into());
     let executable_name = env::var("PROJECT_EXECUTABLE").unwrap_or(project_name.clone());

--- a/build/main.rs
+++ b/build/main.rs
@@ -3,6 +3,10 @@ mod application;
 mod util;
 
 fn main() -> anyhow::Result<()> {
+    // only watch manually-designated files
+    // see: https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed
+    println!("cargo:rerun-if-changed=build/");
+
     #[cfg(feature = "application")]
     application::gen_man_and_comp()?;
 

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,0 +1,10 @@
+#[cfg(feature = "application")]
+mod application;
+mod util;
+
+fn main() -> anyhow::Result<()> {
+    #[cfg(feature = "application")]
+    application::gen_man_and_comp()?;
+
+    Ok(())
+}

--- a/build/util.rs
+++ b/build/util.rs
@@ -1,0 +1,21 @@
+#![allow(dead_code)]
+
+use std::{collections::HashMap, fs, path::Path};
+
+/// Generates a file from a template.
+pub fn render_template(
+    variables: &HashMap<&str, String>,
+    in_file: &str,
+    out_file: impl AsRef<Path>,
+) -> anyhow::Result<()> {
+    let mut content = fs::read_to_string(in_file)?;
+
+    for (variable_name, value) in variables {
+        // Replace {{variable_name}} by the value
+        let pattern = format!("{{{{{variable_name}}}}}");
+        content = content.replace(&pattern, value);
+    }
+
+    fs::write(out_file, content)?;
+    Ok(())
+}


### PR DESCRIPTION
The original intent behind this PR is to accommodate for #2747 (PR: #2755), which requires significant code additional to the build script. Hence it would make sense to clean up the build script beforehand and make it organizationally amenable to said addition (i.e. splitting the code into multiple files and modules). There should be no functional changes.

While doing so, I also did some maintenance work:
- cleaned out the old compgen code that's unlikely to ever be used again
- use `anyhow` to make life a bit easier
- fix inaccurate use of the `option_env!` and `env!` macros (the environment variables should be read at build script run time, not build script compile time)
- use newer code style, specifically
  - implicit variable capture in format string ([since 1.58.0](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings))
  - use `[].into_iter().collect()` to immutably construct a `HashMap` ([since 1.56.0 & 2021 edition](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html)) 
- only rerun build script when relevant source files/env change