### PR TITLE
CI: add changelog check

### DIFF
--- a/.github/workflows/require-changelog-for-PRs.yml
+++ b/.github/workflows/require-changelog-for-PRs.yml
@@ -1,0 +1,24 @@
+name: Changelog
+
+on:
+  pull_request:
+
+jobs:
+  check-changelog:
+    name: Check for changelog entry
+    runs-on: ubuntu-latest
+    env:
+      PR_SUBMITTER: ${{ github.actor }}
+      PR_NUMBER: ${{ github.event.number }}
+      PR_BASE: ${{ github.base_ref }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch PR base
+        run: git fetch --no-tags --prune --depth=1 origin
+      - name: Search for added line in changelog
+        run: |
+          ADDED=$(git diff -U0 "origin/${PR_BASE}" HEAD -- CHANGELOG.md | grep -P '^\+[^\+].+$')
+          echo "Added lines in CHANGELOG.md:"
+          echo "$ADDED"
+          echo "Grepping for PR info:"
+          grep "#${PR_NUMBER}\\b.*@${PR_SUBMITTER}\\b" <<< "$ADDED"

--- a/.github/workflows/require-changelog-for-PRs.yml
+++ b/.github/workflows/require-changelog-for-PRs.yml
@@ -7,6 +7,8 @@ jobs:
   check-changelog:
     name: Check for changelog entry
     runs-on: ubuntu-latest
+    # dependabot PRs are automerged if CI passes; we shouldn't block these
+    if: github.actor != 'dependabot[bot]'
     env:
       PR_SUBMITTER: ${{ github.actor }}
       PR_NUMBER: ${{ github.event.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Upgrade to Rust 2021 edition #2748 (@cyqsimon)
 - Refactor and cleanup build script #2756 (@cyqsimon)
+- Checks changelog has been written to for PRs in CI #2766 (@cyqsimon)
 
 ## Syntaxes
 


### PR DESCRIPTION
This workflow ensures that every PR has a corresponding entry in CHANGELOG.md that includes the PR number and the submitter ID.