### PR TITLE
Minor benchmark script improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Upgrade to Rust 2021 edition #2748 (@cyqsimon)
 - Refactor and cleanup build script #2756 (@cyqsimon)
 - Checks changelog has been written to for PRs in CI #2766 (@cyqsimon)
+- Minor benchmark script improvements #2768 (@cyqsimon)
 
 ## Syntaxes
 

--- a/tests/benchmarks/run-benchmarks.sh
+++ b/tests/benchmarks/run-benchmarks.sh
@@ -50,6 +50,7 @@ TARGET_DIR="$(get_cargo_target_dir)"
 TARGET_RELEASE="${TARGET_DIR}/release/bat"
 
 WARMUP_COUNT=3
+RUN_COUNT=10
 
 # Determine which target to benchmark.
 BAT=''
@@ -88,6 +89,7 @@ hyperfine \
 	"$(printf "%q" "$BAT") --no-config" \
 	--command-name "bat" \
 	--warmup "$WARMUP_COUNT" \
+    --runs "$RUN_COUNT" \
     --export-markdown "$RESULT_DIR/startup-time.md" \
     --export-json "$RESULT_DIR/startup-time.json"
 cat "$RESULT_DIR/startup-time.md" >> "$REPORT"
@@ -98,6 +100,7 @@ hyperfine \
 	"$(printf "%q" "$BAT") --no-config --color=always startup-time-src/small-CpuInfo-file.cpuinfo" \
 	--command-name "bat … small-CpuInfo-file.cpuinfo" \
 	--warmup "$WARMUP_COUNT" \
+    --runs "$RUN_COUNT" \
     --export-markdown "$RESULT_DIR/startup-time-with-syntax-highlighting.md" \
     --export-json "$RESULT_DIR/startup-time-with-syntax-highlighting.json"
 cat "$RESULT_DIR/startup-time-with-syntax-highlighting.md" >> "$REPORT"
@@ -108,6 +111,7 @@ hyperfine \
 	"$(printf "%q" "$BAT") --no-config --color=always startup-time-src/small-Markdown-file.md" \
 	--command-name "bat … small-Markdown-file.md" \
 	--warmup "$WARMUP_COUNT" \
+    --runs "$RUN_COUNT" \
     --export-markdown "$RESULT_DIR/startup-time-with-syntax-with-dependencies.md" \
     --export-json "$RESULT_DIR/startup-time-with-syntax-with-dependencies.json"
 cat "$RESULT_DIR/startup-time-with-syntax-with-dependencies.md" >> "$REPORT"
@@ -118,6 +122,7 @@ hyperfine \
 	"$(printf "%q" "$BAT") --no-config --language=txt --style=plain highlighting-speed-src/numpy_test_multiarray.py" \
 	--command-name 'bat … --language=txt numpy_test_multiarray.py' \
 	--warmup "$WARMUP_COUNT" \
+    --runs "$RUN_COUNT" \
     --export-markdown "$RESULT_DIR/plain-text-speed.md" \
     --export-json "$RESULT_DIR/plain-text-speed.json"
 cat "$RESULT_DIR/plain-text-speed.md" >> "$REPORT"
@@ -129,6 +134,7 @@ for wrap in character never; do
 
 		heading "Syntax highlighting speed --wrap=${wrap}: \`$filename\`"
 		hyperfine --warmup "$WARMUP_COUNT" \
+    		--runs "$RUN_COUNT" \
 			"$(printf "%q" "$BAT") --no-config --style=full --color=always --wrap=${wrap} --terminal-width=80 '$SRC'" \
 			--command-name "bat … ${filename}" \
 			--export-markdown "$RESULT_DIR/syntax-highlighting-speed-${filename}.md" \
@@ -143,6 +149,7 @@ hyperfine \
 	"$(printf "%q" "$BAT") --no-config --language=txt --style=plain many-small-files/*.txt" \
 	--command-name 'bat … --language=txt *.txt' \
 	--warmup "$WARMUP_COUNT" \
+    --runs "$RUN_COUNT" \
     --export-markdown "$RESULT_DIR/many-small-files-speed.md" \
     --export-json "$RESULT_DIR/many-small-files-speed.json"
 cat "$RESULT_DIR/many-small-files-speed.md" >> "$REPORT"

--- a/tests/benchmarks/run-benchmarks.sh
+++ b/tests/benchmarks/run-benchmarks.sh
@@ -49,8 +49,8 @@ REPORT="$RESULT_DIR/report.md"
 TARGET_DIR="$(get_cargo_target_dir)"
 TARGET_RELEASE="${TARGET_DIR}/release/bat"
 
-WARMUP_COUNT=3
-RUN_COUNT=10
+: ${WARMUP_COUNT:=3}
+: ${RUN_COUNT:=10}
 
 # Determine which target to benchmark.
 BAT=''


### PR DESCRIPTION
The default run count of 10 was insufficient to stabilise results on my box. So I made the script more easily customisable.

Now you can do this: `RUN_COUNT=50 ./run-benchmarks.sh --release`