### PR TITLE
Consider adding `?exclude_unsupported=1` to repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Please report any issues with the help syntax in [this repository](https://githu
 
 ## Installation
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg)](https://repology.org/project/bat-cat/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg?exclude_unsupported=1)](https://repology.org/project/bat-cat/versions)
 
 ### On Ubuntu (using `apt`)
 *... and other Debian-based Linux distributions.*

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -181,7 +181,7 @@ man 2 select
 
 ## インストール
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg)](https://repology.org/project/bat-cat/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg?exclude_unsupported=1)](https://repology.org/project/bat-cat/versions)
 
 ###  On Ubuntu (`apt` を使用)
 *... や他のDebianベースのLinuxディストリビューション*

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -214,7 +214,7 @@ man 2 select
 
 ## 설치
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg)](https://repology.org/project/bat-cat/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg?exclude_unsupported=1)](https://repology.org/project/bat-cat/versions)
 
 ### Ubuntu에서 (`apt` 사용)
 *... 그리고 다른 Debian 기반의 Linux 배포판들에서.*

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -160,7 +160,7 @@ man 2 select
 
 ## Установка
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg)](https://repology.org/project/bat-cat/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg?exclude_unsupported=1)](https://repology.org/project/bat-cat/versions)
 
 ### Ubuntu (с помощью `apt`)
 *... и другие дистрибутивы основанные на Debian.*

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -191,7 +191,7 @@ man 2 select
 
 ## 安装
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg)](https://repology.org/project/bat-cat/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg?exclude_unsupported=1)](https://repology.org/project/bat-cat/versions)
 
 ### Ubuntu (使用 `apt`)
 


### PR DESCRIPTION
`bat` is already in a lot of no-longer-supported package repos, and that will only continue growing over time. Might as well not display them on the repology badge

_A side-by-side_

| `master` | `?exclude_unsupported=1` |
| ---: | :--- |
| [![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg)](https://repology.org/project/bat-cat/versions) | [![Packaging status](https://repology.org/badge/vertical-allrepos/bat-cat.svg?exclude_unsupported=1)](https://repology.org/project/bat-cat/versions) |