### PR TITLE
Improvements and fixes to zsh completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Refactor and cleanup build script #2756 (@cyqsimon)
 - Checks changelog has been written to for PRs in CI #2766 (@cyqsimon)
 - Minor benchmark script improvements #2768 (@cyqsimon)
+- Update and improve `zsh` completion, see #2772 (@okapia)
 
 ## Syntaxes
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -1,19 +1,20 @@
 #compdef {{PROJECT_EXECUTABLE}}
 
-local context state state_descr line
+local curcontext="$curcontext" ret=1
+local -a state state_descr line
 typeset -A opt_args
 
 (( $+functions[_{{PROJECT_EXECUTABLE}}_cache_subcommand] )) ||
 _{{PROJECT_EXECUTABLE}}_cache_subcommand() {
     local -a args
     args=(
-        '(-b --build -c --clear)'{-b,--build}'[Initialize or update the syntax/theme cache]'
-        '(-b --build -c --clear)'{-c,--clear}'[Remove the cached syntax definitions and themes]'
-        '(--source)'--source='[Use a different directory to load syntaxes and themes from]:directory:_files -/'
-        '(--target)'--target='[Use a different directory to store the cached syntax and theme set]:directory:_files -/'
-        '(--blank)'--blank'[Create completely new syntax and theme sets]'
-        '(: -)'{-h,--help}'[Prints help information]'
-        '*: :'
+        '(-b --build -c --clear)'{-b,--build}'[initialize or update the syntax/theme cache]'
+        '(-b --build -c --clear)'{-c,--clear}'[remove the cached syntax definitions and themes]'
+        --source='[specify directory to load syntaxes and themes from]:directory:_files -/'
+        --target='[specify directory to store the cached syntax and theme set in]:directory:_files -/'
+        --blank'[create completely new syntax and theme sets]'
+        --acknowledgements'[build acknowledgements.bin]'
+        '(: -)'{-h,--help}'[show help information]'
     )
 
     _arguments -S -s $args
@@ -23,69 +24,79 @@ _{{PROJECT_EXECUTABLE}}_cache_subcommand() {
 _{{PROJECT_EXECUTABLE}}_main() {
     local -a args
     args=(
-        '(-A --show-all)'{-A,--show-all}'[Show non-printable characters (space, tab, newline, ..)]'
-        '*'{-p,--plain}'[Show plain style (alias for `--style=plain`), repeat twice to disable disable automatic paging (alias for `--paging=never`)]'
-        '(-l --language)'{-l+,--language=}'[Set the language for syntax highlighting]:<language>:->language'
-        '(-H --highlight-line)'{-H,--highlight-line}'[Highlight lines N through M]:<N\:M>...'
-        '(--file-name)'--file-name'[Specify the name to display for a file]:<name>...:_files'
-        '(-d --diff)'--diff'[Only show lines that have been added/removed/modified]'
-        '(--diff-context)'--diff-context'[Include N lines of context around added/removed/modified lines when using `--diff`]:<N> (lines):()'
-        '(--tabs)'--tabs'[Set the tab width to T spaces]:<T> (tab width):()'
-        '(--wrap)'--wrap='[Specify the text-wrapping mode]:<when>:(auto never character)'
-        '(--terminal-width)'--terminal-width'[Explicitly set the width of the terminal instead of determining it automatically]:<width>'
-        '(-n --number)'{-n,--number}'[Show line numbers]'
-        '(--color)'--color='[When to use colors]:<when>:(auto never always)'
-        '(--italic-text)'--italic-text='[Use italics in output]:<when>:(always never)'
-        '(--decorations)'--decorations='[When to show the decorations]:<when>:(auto never always)'
-        '(--paging)'--paging='[Specify when to use the pager]:<when>:(auto never always)'
-        '(-m --map-syntax)'{-m+,--map-syntax=}'[Use the specified syntax for files matching the glob pattern]:<glob\:syntax>...'
-        '(--theme)'--theme='[Set the color theme for syntax highlighting]:<theme>:->theme'
-        '(: --list-themes --list-languages -L)'--list-themes'[Display all supported highlighting themes]'
-        '(--style)'--style='[Comma-separated list of style elements to display]:<components>:->style'
-        '(-r --line-range)'{-r+,--line-range=}'[Only print the lines from N to M]:<N\:M>...'
-        '(: --list-themes --list-languages -L)'{-L,--list-languages}'[Display all supported languages]'
-        '(: --no-config)'--no-config'[Do not use the configuration file]'
-        '(: --no-custom-assets)'--no-custom-assets'[Do not load custom assets]'
-        '(: --lessopen)'--lessopen'[Enable the $LESSOPEN preprocessor]'
-        '(: --no-lessopen)'--no-lessopen'[Disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)]'
-        '(: --config-dir)'--config-dir'[Show bat'"'"'s configuration directory]'
-        '(: --config-file)'--config-file'[Show path to the configuration file]'
-        '(: --generate-config-file)'--generate-config-file'[Generates a default configuration file]'
-        '(: --cache-dir)'--cache-dir'[Show bat'"'"'s cache directory]'
-        '(: -)'{-h,--help}'[Print this help message]'
-        '(: -)'{-V,--version}'[Show version information]'
-        '*: :_files'
+        '(-A --show-all)'{-A,--show-all}'[show non-printable characters (space, tab, newline, ..)]'
+        --nonprintable-notation='[specify how to display non-printable characters when using --show-all]:notation:(caret unicode)'
+        \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable disable automatic paging (alias for `--paging=never`)]'
+        '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
+        \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
+        \*--file-name='[specify the name to display for a file]:name:_files'
+        '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'
+        --diff-context='[specify lines of context around added/removed/modified lines when using `--diff`]:lines'
+        --tabs='[set the tab width]:tab width [4]'
+        --wrap='[specify the text-wrapping mode]:mode [auto]:(auto never character)'
+        '!(--wrap)'{-S,--chop-long-lines}
+        --terminal-width='[explicitly set the width of the terminal instead of determining it automatically]:width'
+        '(-n --number --diff --diff-context)'{-n,--number}'[show line numbers]'
+        --color='[specify when to use colors]:when:(auto never always)'
+        --italic-text='[use italics in output]:when:(always never)'
+        --decorations='[specify when to show the decorations]:when:(auto never always)'
+        --paging='[specify when to use the pager]:when:(auto never always)'
+        '(-m --map-syntax)'{-m+,--map-syntax=}'[map a glob pattern to an existing syntax name]: :->syntax-maps'
+        '(--theme)'--theme='[set the color theme for syntax highlighting]:theme:->themes'
+        '(: --list-themes --list-languages -L)'--list-themes'[show all supported highlighting themes]'
+        --style='[comma-separated list of style elements to display]: : _values "style [default]"
+            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+        \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
+        '(* -)'{-L,--list-languages}'[display all supported languages]'
+        "--no-config[don't use the configuration file]"
+        "--no-custom-assets[don't load custom assets]"
+        '(--no-lessopen)'--lessopen'[enable the $LESSOPEN preprocessor]'
+        '(--lessopen)'--no-lessopen'[disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)]'
+        '(* -)'--config-dir"[show bat's configuration directory]"
+        '(* -)'--config-file'[show path to the configuration file]'
+        '(* -)'--generate-config-file'[generate a default configuration file]'
+        '(* -)'--cache-dir"[show bat's cache directory]"
+        '(* -)'{-h,--help}'[show help information]'
+        '(* -)'{-V,--version}'[show version information]'
+        '*: :{ _files || compadd cache }'
     )
 
-    _arguments -S -s $args
+    _arguments -S -s $args && ret=0
 
     case "$state" in
-        language)
+        syntax-maps)
+          if ! compset -P '*:'; then
+            _message -e patterns 'glob pattern:language'
+            return
+          fi
+        ;& # fall-through
+
+        languages)
             local IFS=$'\n'
             local -a languages
             languages=( $({{PROJECT_EXECUTABLE}} --list-languages | awk -F':|,' '{ for (i = 1; i <= NF; ++i) printf("%s:%s\n", $i, $1) }') )
 
-            _describe 'language' languages
+            _describe 'language' languages && ret=0
         ;;
 
-        theme)
-            local IFS=$'\n'
-            local -a themes
-            themes=( $({{PROJECT_EXECUTABLE}} --list-themes | sort) )
+        themes)
+            local -a themes expl
+            themes=( ${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --list-themes)"} )
 
-            _values 'theme' $themes
-        ;;
-
-        style)
-            _values -s , 'style' default auto full plain changes header header-filename header-filesize grid rule numbers snip
+            _wanted themes expl 'theme' compadd -a themes && ret=0
         ;;
     esac
+
+    return ret
 }
 
 case $words[2] in
     cache)
         ## Completion of the 'cache' command itself is removed for better UX
         ## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
+        shift words
+        (( CURRENT-- ))
+        curcontext="${curcontext%:*}-${words[1]}:"
         _{{PROJECT_EXECUTABLE}}_cache_subcommand
     ;;
 


### PR DESCRIPTION
* Use correct return status so that approximate completion isn't broken. Zsh completions should not return 0 if they fail to add matches. Supporting this typically involves a local variable named `ret` as in the patch. Someone was complaining on a forum about this not working which is what motivated me to take a look 
* Follow zsh conventions on description forms. Not using capitalisation is the convention going back a long time and most people agree that consistency is more important than any preference one way or another. There was also some things which look like copy-paste from help output. We don't put types in angle brackets, e.g. <mode> - users can configure that if they like it and references to something like N only make sense in help output where N also appears in a syntax summary.
* Some options can be used multiple times, e.g. -H, -r, --file-name. That's the initial `*` in the spec.
* Set completion context correctly for the cache subcommand. This matters for configuration with `zstyle`.
* Better completion for --map-syntax argument
* Add --nonprintable-notation option. There's also -S/--chop-long-lines but I'm not sure whether these are deprecated forms of `--wrap`.
* Correct some of the mutual exclusion lists for options. Options don't need to exclude themselves - that's the default. And some options were excluding `:` instead of `*` which doesn't make sense with `_files` being called from a `*` spec - perhaps that was reflecting an old form the function took.

I also put in a fallback to complete "cache" if `_files` fails. I think this addresses the concerns from the old linked github issue while allowing `bat cac` to complete to 'cache' if there aren't already files. The normal zsh approach would actually be to use `_alternative` and allow the user to configure it.