### PR TITLE
Update Arch Linux package URL in README files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Refactor and cleanup build script #2756 (@cyqsimon)
 - Checks changelog has been written to for PRs in CI #2766 (@cyqsimon)
 - Minor benchmark script improvements #2768 (@cyqsimon)
+- Update Arch Linux package URL in README files #2779 (@brunobell)
 
 ## Syntaxes
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ apk add bat
 
 ### On Arch Linux
 
-You can install [the `bat` package](https://www.archlinux.org/packages/community/x86_64/bat/)
+You can install [the `bat` package](https://www.archlinux.org/packages/extra/x86_64/bat/)
 from the official sources:
 
 ```bash

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -219,7 +219,7 @@ apk add bat
 
 ###  On Arch Linux
 
-[Arch Linuxの公式リソース](https://www.archlinux.org/packages/community/x86_64/bat/)
+[Arch Linuxの公式リソース](https://www.archlinux.org/packages/extra/x86_64/bat/)
 からインストールできます。
 
 ```bash

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -264,7 +264,7 @@ apk add bat
 ### Arch Linux에서
 
 공식 소스를 통해
-[`bat` 패키지](https://www.archlinux.org/packages/community/x86_64/bat/)를
+[`bat` 패키지](https://www.archlinux.org/packages/extra/x86_64/bat/)를
 설치할 수 있습니다:
 
 ```bash

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -201,7 +201,7 @@ apk add bat
 
 ### Arch Linux
 
-Вы можете установить [`bat`](https://www.archlinux.org/packages/community/x86_64/bat/) из официального источника:
+Вы можете установить [`bat`](https://www.archlinux.org/packages/extra/x86_64/bat/) из официального источника:
 
 ```bash
 pacman -S bat

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -232,7 +232,7 @@ apk add bat
 
 ### Arch Linux
 
-你可以用下面下列命令从官方源中安装[`bat`包](https://www.archlinux.org/packages/community/x86_64/bat/)：
+你可以用下面下列命令从官方源中安装[`bat`包](https://www.archlinux.org/packages/extra/x86_64/bat/)：
 
 ```bash
 pacman -S bat


### PR DESCRIPTION
The old URL returns 404 now.