### PR TITLE
Add context-around-highlight option

### DIFF
--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -121,6 +121,16 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("context-around-highlight")
+                .long("context-around-highlight")
+                .action(ArgAction::Set)
+                .requires("highlight-line")
+                .conflicts_with("line-range")
+                .conflicts_with("diff")
+                .value_name("N")
+                .help("Show lines from highlighted line - N through highlighted line + N"),
+        )
+        .arg(
             Arg::new("file-name")
                 .long("file-name")
                 .action(ArgAction::Append)

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -77,6 +77,12 @@ impl LineRange {
             ),
         }
     }
+    pub fn get_lower(&self) -> usize {
+        self.lower
+    }
+    pub fn get_upper(&self) -> usize {
+        self.upper
+    }
 
     pub(crate) fn is_inside(&self, line: usize) -> bool {
         line >= self.lower && line <= self.upper


### PR DESCRIPTION
The motivation behind this PR is mostly for my own convenience. 

I use ripgrep + fzf a lot in my workflow(where I use bat for previewing result). 

I have one function in my zshrc which looks like this:

![image](https://github.com/sharkdp/bat/assets/38459660/10348cf7-b870-43fb-a67e-af7bb4c1483a)

So when I search for something using `ff nvim`, I get something like this:

![image](https://github.com/sharkdp/bat/assets/38459660/79381335-32c3-4235-a5d6-a00f2cad22d1)

I was quite frustrated by this because I have context of what's happening after the matching line but not before. 
This could probably be done by using some very very hacky script but I just thought adding this feature to bat might be more easier.

I'm making this PR to solve that issue because it might be helpful to other folks too.

After this change and making some change to my zsh function, I get something like this for preview
![image](https://github.com/sharkdp/bat/assets/38459660/992d0f0a-88c2-432d-b8e3-9b1afa5c079d)


Feel free to close this if you think this won't be useful or is not needed.

If you think it'll be useful, I'd be very happy to make necessary changes for this to be merged