### PR TITLE
Added JSONC and aws credentials to the syntax mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Pull in fix for unsafe-libyaml security advisory, see #2812 (@dtolnay)
 - Update git-version dependency to use Syn v2, see #2816 (@dtolnay)
 - Update git2 dependency to v0.18.2, see #2852 (@eth-p)
+- Added auto detect syntax for `.jsonc` #2795 (@mxaddict)
+- Added auto detect syntax for `.aws/{config,credentials}` #2795 (@mxaddict)
 
 ## Syntaxes
 

--- a/src/syntax_mapping/builtins/common/50-aws-credentials.toml
+++ b/src/syntax_mapping/builtins/common/50-aws-credentials.toml
@@ -1,0 +1,2 @@
+[mappings]
+"INI" = ["**/.aws/credentials", "**/.aws/config"]

--- a/src/syntax_mapping/builtins/common/50-json.toml
+++ b/src/syntax_mapping/builtins/common/50-json.toml
@@ -1,3 +1,3 @@
 # JSON Lines is a simple variation of JSON #2535
 [mappings]
-"JSON" = ["*.jsonl"]
+"JSON" = ["*.jsonl", "*.jsonc"]


### PR DESCRIPTION
I'm not 100% sure this is where these should be added.

Let me know if I need to move them somewhere else.