### PR TITLE
Eliminate dependency on serde's "derive" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   - [BREAKING] `SyntaxMapping::{empty,builtin}` are removed; use `SyntaxMapping::new` instead
   - [BREAKING] `SyntaxMapping::mappings` is replaced by `SyntaxMapping::{builtin,custom,all}_mappings`
 - Make `Controller::run_with_error_handler`'s error handler `FnMut`, see #2831 (@rhysd)
+- Improve compile time by 20%, see #2815 (@dtolnay)
 
 # v0.24.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "run_script",
  "semver",
  "serde",
+ "serde_derive",
  "serde_with",
  "serde_yaml",
  "serial_test",
@@ -581,7 +582,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1028,7 +1029,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1039,14 +1040,8 @@ checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -1160,19 +1155,20 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "serde",
+ "serde_derive",
  "serde_with_macros",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1259,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02b4b303bf8d08bfeb0445cba5068a3d306b6baece1d5582171a9bf49188f91"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -1271,8 +1267,9 @@ dependencies = [
  "once_cell",
  "onig",
  "plist",
- "regex-syntax 0.7.5",
+ "regex-syntax",
  "serde",
+ "serde_derive",
  "serde_json",
  "thiserror",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ content_inspector = "0.2.4"
 shell-words = { version = "1.1.0", optional = true }
 unicode-width = "0.1.11"
 globset = "0.4"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
+serde_derive = "1.0"
 serde_yaml = "0.9.28"
 semver = "1.0"
 path_abs = { version = "0.5", default-features = false }
@@ -74,7 +75,7 @@ optional = true
 default-features = false
 
 [dependencies.syntect]
-version = "5.1.0"
+version = "5.2.0"
 default-features = false
 features = ["parsing"]
 
@@ -94,6 +95,7 @@ serial_test = { version = "2.0.0", default-features = false }
 predicates = "3.0.4"
 wait-timeout = "0.2.0"
 tempfile = "3.8.1"
+serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.26.4", default-features = false, features = ["term"] }
@@ -104,8 +106,9 @@ indexmap = { version = "2.2.2", features = ["serde"] }
 itertools = "0.11.0"
 once_cell = "1.18"
 regex = "1.10.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_with = { version = "3.4.0", default-features = false, features = ["macros"] }
+serde = "1.0"
+serde_derive = "1.0"
+serde_with = { version = "3.6.1", default-features = false, features = ["macros"] }
 toml = { version = "0.8.9", features = ["preserve_order"] }
 walkdir = "2.4"
 

--- a/build/syntax_mapping.rs
+++ b/build/syntax_mapping.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 use serde_with::DeserializeFromStr;
 use walkdir::WalkDir;
 

--- a/src/assets/assets_metadata.rs
+++ b/src/assets/assets_metadata.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::time::SystemTime;
 
 use semver::Version;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::error::*;
 

--- a/src/assets/lazy_theme_set.rs
+++ b/src/assets/lazy_theme_set.rs
@@ -3,8 +3,7 @@ use super::*;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
-use serde::Deserialize;
-use serde::Serialize;
+use serde_derive::{Deserialize, Serialize};
 
 use once_cell::unsync::OnceCell;
 


### PR DESCRIPTION
This PR pulls in https://github.com/trishume/syntect/pull/511 and https://github.com/niklasmohrin/clircle/pull/12 to improve bat compile time by 20%. (`bat` is on the critical path for `cargo-expand`'s build, so I am interested in this PR because it will speed up `cargo-expand` compilation by the same amount.)

`cargo build --lib --timings`:

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img src="https://github.com/sharkdp/bat/assets/1940490/ebc00a86-c961-428f-9de6-1871c71a6f47"></td><td><img src="https://github.com/sharkdp/bat/assets/1940490/2d4b62d0-4a72-429e-a6bd-8d2f82581c14"></td></tr>
</table>