### PR TITLE
Bump cmd-help syntax to `b150d84`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ## Syntaxes
 
+- `cmd-help`: scope subcommands followed by other terms, and other misc improvements, see #2819 (@victor-gp)
+
 ## Themes
 
 ## `bat` as a library

--- a/tests/syntax-tests/highlighted/cmd-help/test.cmd-help
+++ b/tests/syntax-tests/highlighted/cmd-help/test.cmd-help
@@ -4,8 +4,8 @@
 [38;2;248;248;242mUse '--help' instead of '-h' to see a more detailed version of the help text.[0m
 
 [38;2;246;170;17mUSAGE:[0m
-[38;2;248;248;242m    bat [OPTIONS] [FILE]...[0m
-[38;2;248;248;242m    bat <SUBCOMMAND>[0m
+[38;2;248;248;242m    [0m[38;2;190;132;255mbat[0m[38;2;248;248;242m [OPTIONS] [FILE]...[0m
+[38;2;248;248;242m    [0m[38;2;190;132;255mbat[0m[38;2;248;248;242m <SUBCOMMAND>[0m
 
 [38;2;246;170;17mARGS:[0m
 [38;2;248;248;242m    [0m[38;2;249;38;114m<FILE>...[0m[38;2;248;248;242m    File(s) to print / concatenate. Use '-' for standard input.[0m


### PR DESCRIPTION
Manual update (as opposed to [Dependabot's](https://github.com/sharkdp/bat/pull/2683)) because the highlighting for the test help message has changed. It's all good because it's as intended, an improvement.

See victor-gp/cmd-help-sublime-syntax#23

Before/After (`bat` is colorized in Usage lines):

![Screenshot from 2023-12-29 17-28-45](https://github.com/sharkdp/bat/assets/43856183/af18c63e-b28f-429f-947d-52d624009a13)

![Screenshot from 2023-12-29 18-02-27](https://github.com/sharkdp/bat/assets/43856183/17d9ec3b-6555-45ff-8cec-e52c4eb036a1)
