### PR TITLE
display which theme is the default one in colored output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Relax syntax mapping rule restrictions to allow brace expansion #2865 (@cyqsimon)
 - Apply clippy fixes #2864 (@cyqsimon)
 - Faster startup by offloading glob matcher building to a worker thread #2868 (@cyqsimon)
-- Display which theme is the default one, see #2838 (@sblondon)
+- Display which theme is the default one in colored output, see #2838 (@sblondon)
 
 ## Syntaxes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Relax syntax mapping rule restrictions to allow brace expansion #2865 (@cyqsimon)
 - Apply clippy fixes #2864 (@cyqsimon)
 - Faster startup by offloading glob matcher building to a worker thread #2868 (@cyqsimon)
+- Display which theme is the default one, see #2838 (@sblondon)
 
 ## Syntaxes
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -30,6 +30,7 @@ use directories::PROJECT_DIRS;
 use globset::GlobMatcher;
 
 use bat::{
+    assets::HighlightingAssets,
     config::Config,
     controller::Controller,
     error::*,
@@ -200,11 +201,18 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
     let mut stdout = stdout.lock();
 
     if config.colored_output {
+        let default_theme = HighlightingAssets::default_theme();
         for theme in assets.themes() {
+            let default_theme_info = if default_theme == theme {
+                " (default)"
+            } else {
+                ""
+            };
             writeln!(
                 stdout,
-                "Theme: {}\n",
-                Style::new().bold().paint(theme.to_string())
+                "Theme: {}{}\n",
+                Style::new().bold().paint(theme.to_string()),
+                default_theme_info
             )?;
             config.theme = theme.to_string();
             Controller::new(&config, &assets)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -273,6 +273,24 @@ fn squeeze_limit_line_numbers() {
 }
 
 #[test]
+fn list_themes() {
+    #[cfg(target_os = "macos")]
+    let default_theme_chunk = "Monokai Extended Light\x1B[0m (default)";
+
+    #[cfg(not(target_os = "macos"))]
+    let default_theme_chunk = "Monokai Extended\x1B[0m (default)";
+
+    bat()
+        .arg("--color=always")
+        .arg("--list-themes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DarkNeon").normalize())
+        .stdout(predicate::str::contains(default_theme_chunk).normalize())
+        .stdout(predicate::str::contains("Output the square of a number.").normalize());
+}
+
+#[test]
 #[cfg_attr(any(not(feature = "git"), target_os = "windows"), ignore)]
 fn short_help() {
     test_help("-h", "../doc/short-help.txt");


### PR DESCRIPTION
The user knows which theme is used by default with `--list-themes` parameter.


This is a partial screenshot of the output:
![screenshot_theme_list](https://github.com/sharkdp/bat/assets/1708780/b4a51853-aa62-45f0-b1cc-8ff53597270e)

Only the `config.colored_output` displays the ` (default)` string. I didn't add it in the other case because it's really minimal but I will add it if you want.