### PR TITLE
Change CONTRIBUTING.md according to new changelog requirements

### DIFF
--- a/.github/workflows/require-changelog-for-PRs.yml
+++ b/.github/workflows/require-changelog-for-PRs.yml
@@ -29,5 +29,5 @@ jobs:
           ADDED=$(git diff -U0 "origin/${PR_BASE}" HEAD -- CHANGELOG.md | grep -P '^\+[^\+].+$')
           echo "Added lines in CHANGELOG.md:"
           echo "$ADDED"
-          echo "Grepping for PR info:"
+          echo "Grepping for PR info (see CONTRIBUTING.md):"
           grep "#${PR_NUMBER}\\b.*@${PR_SUBMITTER}\\b" <<< "$ADDED"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,12 @@ The top of the `CHANGELOG` contains a *"unreleased"* section with a few
 subsections (Features, Bugfixes, …). Please add your entry to the subsection
 that best describes your change.
 
-Entries follow this format:
+Entries must follow this format:
 ```
 - Short description of what has been changed, see #123 (@user)
 ```
-Here, `#123` is the number of the original issue and/or your pull request.
-Please replace `@user` by your GitHub username.
+Please replace `#123` with the number of your pull request (not issue) and
+`@user` by your GitHub username.
 
 
 ## Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,31 @@ Thank you for considering to contribute to `bat`!
 
 ## Add an entry to the changelog
 
-If your contribution changes the behavior of `bat` (as opposed to a typo-fix
-in the documentation), please update the [`CHANGELOG.md`](CHANGELOG.md) file
-and describe your changes. This makes the release process much easier and
-therefore helps to get your changes into a new `bat` release faster.
+Keeping the [`CHANGELOG.md`](CHANGELOG.md) file up-to-date makes the release
+process much easier and therefore helps to get your changes into a new `bat`
+release faster. However, not every change to the repository requires a
+changelog entry. Below are a few examples of that.
+
+Please update the changelog if your contribution contains changes regarding
+any of the following:
+  - the behavior of `bat`
+  - syntax mappings
+  - syntax definitions
+  - themes
+  - the build system, linting, or CI workflows
+
+A changelog entry is not necessary when:
+  - updating documentation
+  - fixing typos
+
+>[!NOTE]
+> For PRs, a CI workflow verifies that a suitable changelog entry is
+> added. If such an entry is missing, the workflow will fail. If your
+> changes do not need an entry to the changelog (see above), that
+> workflow failure can be disregarded.
+
+
+### Changelog entry format
 
 The top of the `CHANGELOG` contains a *"unreleased"* section with a few
 subsections (Features, Bugfixes, …). Please add your entry to the subsection


### PR DESCRIPTION
In PR #2766 ([`bcc2de86`](https://github.com/sharkdp/bat/commit/bcc2de86b47c26ad5393588aaead540e348dfc3c)) a new workflow was added which ensures that the `CHANGELOG` stays up to date and that entries follow a certain format. However, this has led to quite a bit of confusion among contributors (https://github.com/sharkdp/bat/pull/2827#issuecomment-1874709439). For example, the authors of #2827, #2807, #2835 and #2818 had to modify the changelog multiple times to match the requirements.

To solve that, this PR changes CONTRIBUTING.md according to the new format requirements. Also, a note is added to the workflow to point contributors in the right direction.

But I do have a question that I'm myself confused about. The CONTRIBUTING.md states:
> If your contribution changes the behavior of `bat` (as opposed to a typo-fix
in the documentation), please update the [`CHANGELOG.md`](CHANGELOG.md) file
and describe your changes.

So, do PRs like this one need a changelog entry? I think CONTRIBUTING.md says no, but the workflow will fail nonetheless.