### PR TITLE
Add Git Blame style option.

### DIFF
--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -138,6 +138,7 @@ Options:
             * rule: horizontal lines to delimit files.
             * numbers: show line numbers in the side bar.
             * snip: draw separation lines between distinct line ranges.
+            * blame: show Git blame information.
 
   -r, --line-range <N:M>
           Only print the specified range of lines for each file. For example:
@@ -153,6 +154,12 @@ Options:
   -u, --unbuffered
           This option exists for POSIX-compliance reasons ('u' is for 'unbuffered'). The output is
           always unbuffered - this option is simply ignored.
+
+      --blame-format <format>
+          Set the format for the Git blame output. The format string can contain placeholders like
+          '%h' (abbreviated commit hash), '%an' (author name), '%H' (full commit hash), '%s'
+          (summary), '%d' (ref names), '%m' (message), '%ae' (author email), '%cn' (committer name),
+          '%ce' (committer email)
 
       --diagnostic
           Show diagnostic information for bug reports.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -45,11 +45,13 @@ Options:
           Display all supported highlighting themes.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
-          header, header-filename, header-filesize, grid, rule, numbers, snip).
+          header, header-filename, header-filesize, grid, rule, numbers, snip, blame).
   -r, --line-range <N:M>
           Only print the lines from N to M.
   -L, --list-languages
           Display all supported languages.
+      --blame-format <format>
+          Specify a format for the git-blame content.
   -h, --help
           Print help (see more with '--help')
   -V, --version

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -289,6 +289,12 @@ impl App {
             use_custom_assets: !self.matches.get_flag("no-custom-assets"),
             #[cfg(feature = "lessopen")]
             use_lessopen: self.matches.get_flag("lessopen"),
+            #[cfg(feature = "git")]
+            blame_format: self
+                .matches
+                .get_one::<String>("blame-format")
+                .map(String::from)
+                .unwrap_or_else(|| String::from("%h: %an <%ae>")),
         })
     }
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -411,6 +411,8 @@ pub fn build_app(interactive_output: bool) -> Command {
                             "snip",
                             #[cfg(feature = "git")]
                             "changes",
+                            #[cfg(feature = "git")]
+                            "blame",
                         ].contains(style)
                     });
 
@@ -422,7 +424,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).",
+                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip, blame).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -445,7 +447,8 @@ pub fn build_app(interactive_output: bool) -> Command {
                        and the header from the content.\n  \
                      * rule: horizontal lines to delimit files.\n  \
                      * numbers: show line numbers in the side bar.\n  \
-                     * snip: draw separation lines between distinct line ranges.",
+                     * snip: draw separation lines between distinct line ranges.\n  \
+                     * blame: show Git blame information.",
                 ),
         )
         .arg(
@@ -517,6 +520,23 @@ pub fn build_app(interactive_output: bool) -> Command {
                     .overrides_with("lessopen")
                     .hide(true)
                     .help("Disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)"),
+            )
+    }
+
+    #[cfg(feature = "git")]
+    {
+        app = app
+            .arg(
+                Arg::new("blame-format")
+                    .long("blame-format")
+                    .value_name("format")
+                    .help("Specify a format for the git-blame content.")
+                    .long_help(
+                        "Set the format for the Git blame output. The format string \
+                         can contain placeholders like '%h' (abbreviated commit hash), '%an' (author name), \
+                         '%H' (full commit hash), '%s' (summary), '%d' (ref names), '%m' (message), \
+                         '%ae' (author email), '%cn' (committer name), '%ce' (committer email)",
+                    ),
             )
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,10 @@ pub struct Config<'a> {
     // Whether or not to use $LESSOPEN if set
     #[cfg(feature = "lessopen")]
     pub use_lessopen: bool,
+
+    // Format for the git blame column
+    #[cfg(feature = "git")]
+    pub blame_format: String,
 }
 
 #[cfg(all(feature = "minimal-application", feature = "paging"))]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -3,8 +3,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-
-use git2::{DiffOptions, IntoCString, Repository};
+use git2::{Commit, BlameHunk, Blame, BlameOptions, DiffOptions, IntoCString, Repository};
 
 #[derive(Copy, Clone, Debug)]
 pub enum LineChange {
@@ -15,6 +14,7 @@ pub enum LineChange {
 }
 
 pub type LineChanges = HashMap<u32, LineChange>;
+pub type LineBlames = HashMap<u32, String>;
 
 pub fn get_git_diff(filename: &Path) -> Option<LineChanges> {
     let repo = Repository::discover(filename).ok()?;
@@ -80,4 +80,66 @@ pub fn get_git_diff(filename: &Path) -> Option<LineChanges> {
     );
 
     Some(line_changes)
+}
+
+pub fn get_blame_line(blame: &Blame, filename: &Path, line: u32, blame_format: &str) -> Option<String> {
+    let repo = Repository::discover(filename).ok()?;
+    let default_return = "Unknown".to_string();
+    let diff = get_git_diff(filename).unwrap();
+    if diff.contains_key(&line) {
+        return Some(format!("{} <{}>", default_return, default_return));
+    }
+    if let Some(line_blame) = blame.get_line(line as usize) {
+        let signature = line_blame.final_signature();
+        let name = signature.name().unwrap_or(default_return.as_str());
+        let email = signature.email().unwrap_or(default_return.as_str());
+        if blame_format.is_empty() {
+            return Some(format!("{} <{}>", name, email));
+        }
+        let commit_id = line_blame.final_commit_id();
+        let commit = repo.find_commit(commit_id).ok()?;
+
+        return Some(format_blame(&line_blame, &commit, blame_format));
+    }
+    Some(default_return)
+}
+
+
+pub fn format_blame(blame_hunk: &BlameHunk, commit: &Commit, blame_format: &str) -> String {
+    let mut result = String::from(blame_format);
+    let abbreviated_id_buf = commit.as_object().short_id();
+    let abbreviated_id = abbreviated_id_buf.as_ref().ok().map(|id| id.as_str()).unwrap_or(Some(""));
+    let signature = blame_hunk.final_signature();
+    result = result.replace("%an", signature.name().unwrap_or("Unknown"));
+    result = result.replace("%ae", signature.email().unwrap_or("Unknown"));
+    result = result.replace("%H", commit.id().to_string().as_str());
+    result = result.replace("%h", abbreviated_id.unwrap());
+    result = result.replace("%s", commit.summary().unwrap_or("Unknown"));
+    result = result.replace("%cn", commit.author().name().unwrap_or("Unknown"));
+    result = result.replace("%ce", commit.author().email().unwrap_or("Unknown"));
+    result = result.replace("%b", commit.message().unwrap_or("Unknown"));
+    result = result.replace("%N", commit.parents().len().to_string().as_str());
+
+    result
+}
+
+pub fn get_blame_file(filename: &Path, blame_format: &str) -> Option<LineBlames> {
+    let lines_in_file = fs::read_to_string(filename).ok()?.lines().count();
+    let mut result = LineBlames::new();
+    let mut blame_options = BlameOptions::new();
+    let repo = Repository::discover(filename).ok()?;
+    let repo_path_absolute = fs::canonicalize(repo.workdir()?).ok()?;
+    let filepath_absolute = fs::canonicalize(filename).ok()?;
+    let filepath_relative_to_repo = filepath_absolute.strip_prefix(&repo_path_absolute).ok()?;
+
+    let blame = repo.blame_file(
+        filepath_relative_to_repo,
+        Some(&mut blame_options),
+    ).ok()?;
+    for i in 0..lines_in_file {
+        if let Some(str_result) = get_blame_line(&blame, filename, i as u32, blame_format) {
+            result.insert(i as u32, str_result);
+        }
+    }
+    Some(result)
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -9,6 +9,8 @@ pub enum StyleComponent {
     Auto,
     #[cfg(feature = "git")]
     Changes,
+    #[cfg(feature = "git")]
+    Blame,
     Grid,
     Rule,
     Header,
@@ -33,6 +35,8 @@ impl StyleComponent {
             }
             #[cfg(feature = "git")]
             StyleComponent::Changes => &[StyleComponent::Changes],
+            #[cfg(feature = "git")]
+            StyleComponent::Blame => &[StyleComponent::Blame],
             StyleComponent::Grid => &[StyleComponent::Grid],
             StyleComponent::Rule => &[StyleComponent::Rule],
             StyleComponent::Header => &[StyleComponent::HeaderFilename],
@@ -70,6 +74,8 @@ impl FromStr for StyleComponent {
             "auto" => Ok(StyleComponent::Auto),
             #[cfg(feature = "git")]
             "changes" => Ok(StyleComponent::Changes),
+            #[cfg(feature = "git")]
+            "blame" => Ok(StyleComponent::Blame),
             "grid" => Ok(StyleComponent::Grid),
             "rule" => Ok(StyleComponent::Rule),
             "header" => Ok(StyleComponent::Header),
@@ -96,6 +102,11 @@ impl StyleComponents {
     #[cfg(feature = "git")]
     pub fn changes(&self) -> bool {
         self.0.contains(&StyleComponent::Changes)
+    }
+
+    #[cfg(feature = "git")]
+    pub fn blame(&self) -> bool {
+        self.0.contains(&StyleComponent::Blame)
     }
 
     pub fn grid(&self) -> bool {


### PR DESCRIPTION
# Related Issues

#2810 #1536 

# Quick Summary

* Added a new decorator.
* Added required changes in `config` in order to recognize 2 new CLI options/arguments.
* Added a simple format ability with the placeholders from [git's pretty-formats](https://git-scm.com/docs/pretty-formats)
* Updated doc tests to take into consideration new options.

# Visual Example
```bat ./README.md --style=full,blame --blame-format="%h %cn"```
![image](https://github.com/sharkdp/bat/assets/32035685/a6e907b6-0ba8-4525-997e-409f50ee9932)
