### PR TITLE
Document default style components

### DIFF
--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -123,6 +123,9 @@ Options:
           set a default style, add the '--style=".."' option to the configuration file or export the
           BAT_STYLE environment variable (e.g.: export BAT_STYLE="..").
           
+          By default, the following components are enabled:
+            changes, grid, header-filename, numbers, snip
+          
           Possible values:
           
             * default: enables recommended style components (default).

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -432,6 +432,8 @@ pub fn build_app(interactive_output: bool) -> Command {
                      pre-defined style ('full'). To set a default style, add the \
                      '--style=\"..\"' option to the configuration file or export the \
                      BAT_STYLE environment variable (e.g.: export BAT_STYLE=\"..\").\n\n\
+                     By default, the following components are enabled:\n  \
+                        changes, grid, header-filename, numbers, snip\n\n\
                      Possible values:\n\n  \
                      * default: enables recommended style components (default).\n  \
                      * full: enables all available components.\n  \


### PR DESCRIPTION
Adds a short note to the help text of `--style` explaining which style components are enabled by default.