### PR TITLE
Fix off-by-one error in line number continuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix long file name wrapping in header, see #2835 (@FilipRazek)
 - Fix `NO_COLOR` support, see #2767 (@acuteenvy)
 - Fix handling of inputs with OSC ANSI escape sequences, see #2541 and #2544 (@eth-p)
+- Fix panel width when line 10000 wraps, see #2854 (@eth-p)
 
 ## Other
 

--- a/src/decorations.rs
+++ b/src/decorations.rs
@@ -46,7 +46,7 @@ impl Decoration for LineNumberDecoration {
         _printer: &InteractivePrinter,
     ) -> DecorationText {
         if continuation {
-            if line_number > self.cached_wrap_invalid_at {
+            if line_number >= self.cached_wrap_invalid_at {
                 let new_width = self.cached_wrap.width + 1;
                 return DecorationText {
                     text: self.color.paint(" ".repeat(new_width)).to_string(),


### PR DESCRIPTION
Fixes the following:

![image](https://github.com/sharkdp/bat/assets/32112321/f970e9a8-9598-4bda-8bf7-e53cb854384f)

To look like:

![image](https://github.com/sharkdp/bat/assets/32112321/7cb46cfc-87bc-4962-869a-5a8bff90020f)
