### PR TITLE
Relax syntax mapping rule restrictions to allow brace expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Pull in fix for unsafe-libyaml security advisory, see #2812 (@dtolnay)
 - Update git-version dependency to use Syn v2, see #2816 (@dtolnay)
 - Update git2 dependency to v0.18.2, see #2852 (@eth-p)
+- Relax syntax mapping rule restrictions to allow brace expansion #2865 (@cyqsimon)
 
 ## Syntaxes
 

--- a/build/syntax_mapping.rs
+++ b/build/syntax_mapping.rs
@@ -53,14 +53,16 @@ struct Matcher(Vec<MatcherSegment>);
 ///
 /// Note that this implementation is rather strict: it will greedily interpret
 /// every valid environment variable replacement as such, then immediately
-/// hard-error if it finds a '$', '{', or '}' anywhere in the remaining text
-/// segments.
+/// hard-error if it finds a '$' anywhere in the remaining text segments.
 ///
 /// The reason for this strictness is I currently cannot think of a valid reason
-/// why you would ever need '$', '{', or '}' as plaintext in a glob pattern.
-/// Therefore any such occurrences are likely human errors.
+/// why you would ever need '$' as plaintext in a glob pattern. Therefore any
+/// such occurrences are likely human errors.
 ///
 /// If we later discover some edge cases, it's okay to make it more permissive.
+///
+/// Revision history:
+/// - 2024-02-20: allow `{` and `}` (glob brace expansion)
 impl FromStr for Matcher {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -106,7 +108,7 @@ impl FromStr for Matcher {
         if non_empty_segments
             .iter()
             .filter_map(Seg::text)
-            .any(|t| t.contains(['$', '{', '}']))
+            .any(|t| t.contains('$'))
         {
             bail!(r#"Invalid matcher: "{s}""#);
         }


### PR DESCRIPTION
It turns out there is a valid reason for glob rules to contain `{` and `}`. So I relaxed the compile time restriction.

See https://globster.xyz/.