### PR TITLE
Add syntax mapping for podman quadlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 - `cmd-help`: scope subcommands followed by other terms, and other misc improvements, see #2819 (@victor-gp)
 - Upgrade JQ syntax, see #2820 (@dependabot[bot])
+- Add syntax mapping for quadman quadlets #2866 (@cyqsimon)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/linux/50-podman-quadlet.toml
+++ b/src/syntax_mapping/builtins/linux/50-podman-quadlet.toml
@@ -1,0 +1,7 @@
+# see `man quadlet`
+[mappings]
+"INI" = [
+    "**/containers/systemd/*.{container,volume,network,kube,image}",
+    "**/containers/systemd/users/*.{container,volume,network,kube,image}",
+    "**/containers/systemd/users/*/*.{container,volume,network,kube,image}",
+]


### PR DESCRIPTION
See https://www.redhat.com/sysadmin/quadlet-podman

Queued up after #2865 as this syntax mapping uses brace expansion.