### PR TITLE
Update base16 URLs to link to community run version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ## Other
 
+- Update base16 README links to community driven base16 work #2871 (@JamyGolden)
 - Work around build failures when building `bat` from vendored sources #3179 (@dtolnay)
 - CICD: Stop building for x86_64-pc-windows-gnu which fails #3261 (Enselic)
 

--- a/README.md
+++ b/README.md
@@ -512,12 +512,12 @@ even when truecolor support is available:
 
 - `ansi` looks decent on any terminal. It uses 3-bit colors: black, red, green,
   yellow, blue, magenta, cyan, and white.
-- `base16` is designed for [base16](https://github.com/chriskempson/base16) terminal themes. It uses
+- `base16` is designed for [base16](https://github.com/tinted-theming/home) terminal themes. It uses
   4-bit colors (3-bit colors plus bright variants) in accordance with the
-  [base16 styling guidelines](https://github.com/chriskempson/base16/blob/master/styling.md).
-- `base16-256` is designed for [base16-shell](https://github.com/chriskempson/base16-shell).
+  [base16 styling guidelines](https://github.com/tinted-theming/home/blob/main/styling.md).
+- `base16-256` is designed for [tinted-shell](https://github.com/tinted-theming/tinted-shell).
   It replaces certain bright colors with 8-bit colors from 16 to 21. **Do not** use this simply
-  because you have a 256-color terminal but are not using base16-shell.
+  because you have a 256-color terminal but are not using tinted-shell.
 
 Although these themes are more restricted, they have three advantages over truecolor themes. They:
 

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -461,11 +461,11 @@ bat --list-themes | fzf --preview="bat --theme={} --color=always /path/to/file"
 
 - `ansi`는 어떤 터미널에서도 무난하게 보입니다. 이는 3비트 색상을 사용합니다:
   검정, 빨강, 녹색, 노랑, 파랑, 마젠타, 시안, 하양.
-- `base16`은 [base16](https://github.com/chriskempson/base16) 터미널 테마를 위해
+- `base16`은 [base16](https://github.com/tinted-theming/home) 터미널 테마를 위해
   디자인되었습니다.
-  이는 [base16 스타일 가이드라인](https://github.com/chriskempson/base16/blob/master/styling.md)에
+  이는 [base16 스타일 가이드라인](https://github.com/tinted-theming/home/blob/main/styling.md)에
   따라 4비트 색상(3비트 색상에 밝은 변형 추가)을 사용합니다.
-- `base16-256`는 [base16-shell](https://github.com/chriskempson/base16-shell)을
+- `base16-256`는 [base16-shell](https://github.com/tinted-theming/base16-shell)을
   위해 디자인되었습니다.
   이는 16부터 21의 일부 밝은 색상을 8비트 색상으로 대치합니다.
   단지 256-색상 터미널을 쓰지만 base16-shell을 쓰지 않는다고 해서 이것을

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -401,8 +401,8 @@ bat --list-themes | fzf --preview="bat --theme={} --color=always /path/to/file"
 `bat` 自带三个 [8-bit 色彩](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) 主题：
 
 - `ansi` 适应于大部分终端。它使用 3-bit 色彩：黑红绿黄蓝洋红靛青白。
-- `base16`专为 [base16](https://github.com/chriskempson/base16) 终端设计。它使用 4-bit 色彩（带有亮度的 3-bit 色彩）。根据 [base16 styling guidelines](https://github.com/chriskempson/base16/blob/master/styling.md) 制作。
-- `base16-25`专为 [base16-shell](https://github.com/chriskempson/base16-shell) 设计。它把部分亮色替换为 8-bit 色彩。请不要直接使用该主题，除非你清楚你的256色终端是否使用 base16-shell。
+- `base16`专为 [base16](https://github.com/tinted-theming/home) 终端设计。它使用 4-bit 色彩（带有亮度的 3-bit 色彩）。根据 [base16 styling guidelines](https://github.com/tinted-theming/home/blob/main/styling.md) 制作。
+- `base16-25`专为 [base16-shell](https://github.com/tinted-theming/base16-shell) 设计。它把部分亮色替换为 8-bit 色彩。请不要直接使用该主题，除非你清楚你的256色终端是否使用 base16-shell。
 
 尽管这些主题具有诸多限制，但具有一些 truecolor 主题不具有的三个优点：
 


### PR DESCRIPTION
Tinted Theming (previously base16-project) is a maintained and community run version of base16: https://github.com/tinted-theming/home/issues/51

A discussion around creating a base16 organization originally took place in 2016 on an issue in the original base16 repo: https://web.archive.org/web/20220603173440/https://github.com/chriskempson/base16/issues/74. The repo was subsequently nuked and most [git history](https://github.com/chriskempson/base16/commits/main/) as well as PRs and issues were destroyed (which is why I linked the web archive version of the issue).

## PR description

This PR updates the following links:
- `https://github.com/chriskempson/base16` -> `https://github.com/tinted-theming/home`
- `https://github.com/chriskempson/base16/blob/master/styling.md` -> `https://github.com/tinted-theming/home/blob/main/styling.md`
- `https://github.com/chriskempson/base16-shell` -> `https://github.com/tinted-theming/base16-shell`

Our [base16-shell](https://github.com/tinted-theming/base16-shell) repo is updated weekly with the [latest schemes](https://github.com/tinted-theming/schemes).