### PR TITLE
Print $TERM in --diagnostics

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -272,24 +272,24 @@ fn invoke_bugreport(app: &App, cache_dir: &Path) {
         .info(OperatingSystem::default())
         .info(CommandLine::default())
         .info(EnvironmentVariables::list(&[
-            "SHELL",
-            "PAGER",
-            "LESS",
-            "LANG",
-            "LC_ALL",
-            "BAT_PAGER",
-            "BAT_PAGING",
             "BAT_CACHE_PATH",
             "BAT_CONFIG_PATH",
             "BAT_OPTS",
+            "BAT_PAGER",
+            "BAT_PAGING",
             "BAT_STYLE",
             "BAT_TABS",
             "BAT_THEME",
-            "XDG_CONFIG_HOME",
-            "XDG_CACHE_HOME",
             "COLORTERM",
-            "NO_COLOR",
+            "LANG",
+            "LC_ALL",
+            "LESS",
             "MANPAGER",
+            "NO_COLOR",
+            "PAGER",
+            "SHELL",
+            "XDG_CACHE_HOME",
+            "XDG_CONFIG_HOME",
         ]))
         .info(FileContent::new("System Config file", system_config_file()))
         .info(FileContent::new("Config file", config_file()))

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -288,6 +288,7 @@ fn invoke_bugreport(app: &App, cache_dir: &Path) {
             "NO_COLOR",
             "PAGER",
             "SHELL",
+            "TERM",
             "XDG_CACHE_HOME",
             "XDG_CONFIG_HOME",
         ]))


### PR DESCRIPTION
- **Sort env vars printed by --diagnostic**
- **Print $TERM with --diagnostic**

I would also like `--diagnostics` to print the current terminal emulator, but I can't find a portable way to do it.

Maybe `readlink "/proc/$(cat /proc/$(echo $$)/stat|cut -d ' ' -f 4)/exe"` for Linux?
