### PR TITLE
display which theme is the default one in basic output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Relax syntax mapping rule restrictions to allow brace expansion #2865 (@cyqsimon)
 - Apply clippy fixes #2864 (@cyqsimon)
 - Faster startup by offloading glob matcher building to a worker thread #2868 (@cyqsimon)
+- Display which theme is the default one in basic output (no colors), see #2937 (@sblondon)
 - Display which theme is the default one in colored output, see #2838 (@sblondon)
 
 ## Syntaxes

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -200,8 +200,8 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
 
+    let default_theme = HighlightingAssets::default_theme();
     if config.colored_output {
-        let default_theme = HighlightingAssets::default_theme();
         for theme in assets.themes() {
             let default_theme_info = if default_theme == theme {
                 " (default)"
@@ -230,7 +230,12 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
         )?;
     } else {
         for theme in assets.themes() {
-            writeln!(stdout, "{theme}")?;
+            let default_theme_info = if default_theme == theme {
+                " (default)"
+            } else {
+                ""
+            };
+            writeln!(stdout, "{theme}{default_theme_info}")?;
         }
     }
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -201,13 +201,13 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
     let mut stdout = stdout.lock();
 
     let default_theme = HighlightingAssets::default_theme();
-    if config.colored_output {
-        for theme in assets.themes() {
-            let default_theme_info = if default_theme == theme {
-                " (default)"
-            } else {
-                ""
-            };
+    for theme in assets.themes() {
+        let default_theme_info = if default_theme == theme {
+            " (default)"
+        } else {
+            ""
+        };
+        if config.colored_output {
             writeln!(
                 stdout,
                 "Theme: {}{}\n",
@@ -219,7 +219,12 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
                 .run(vec![theme_preview_file()], None)
                 .ok();
             writeln!(stdout)?;
+        } else {
+            writeln!(stdout, "{theme}{default_theme_info}")?;
         }
+    }
+
+    if config.colored_output {
         writeln!(
             stdout,
             "Further themes can be installed to '{}', \
@@ -228,15 +233,6 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
             https://github.com/sharkdp/bat#adding-new-themes",
             config_dir.join("themes").to_string_lossy()
         )?;
-    } else {
-        for theme in assets.themes() {
-            let default_theme_info = if default_theme == theme {
-                " (default)"
-            } else {
-                ""
-            };
-            writeln!(stdout, "{theme}{default_theme_info}")?;
-        }
     }
 
     Ok(())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -273,7 +273,7 @@ fn squeeze_limit_line_numbers() {
 }
 
 #[test]
-fn list_themes() {
+fn list_themes_with_colors() {
     #[cfg(target_os = "macos")]
     let default_theme_chunk = "Monokai Extended Light\x1B[0m (default)";
 
@@ -288,6 +288,23 @@ fn list_themes() {
         .stdout(predicate::str::contains("DarkNeon").normalize())
         .stdout(predicate::str::contains(default_theme_chunk).normalize())
         .stdout(predicate::str::contains("Output the square of a number.").normalize());
+}
+
+#[test]
+fn list_themes_without_colors() {
+    #[cfg(target_os = "macos")]
+    let default_theme_chunk = "Monokai Extended Light (default)";
+
+    #[cfg(not(target_os = "macos"))]
+    let default_theme_chunk = "Monokai Extended (default)";
+
+    bat()
+        .arg("--color=never")
+        .arg("--list-themes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DarkNeon").normalize())
+        .stdout(predicate::str::contains(default_theme_chunk).normalize());
 }
 
 #[test]


### PR DESCRIPTION
The previous [PR #2838](https://github.com/sharkdp/bat/pull/2838) shows which theme is the default one in colored output when `--list-themes` argument is used. This PR does the same with not colored output (as suggested by @Enselic ).

The output is:

![bat_default_theme](https://github.com/sharkdp/bat/assets/1708780/c5fb1c36-6c60-4aad-8834-44f4fd5c35d0)


I think about another commit to refactor the internal of `list_themes()` function (so it should not the squashed with the previous one).

Current code: 

```rust
    if config.colored_output {
        for theme in assets.themes() {
            // display colored theme
            // display "Further themes can be installed..."
    } else {
        for theme in assets.themes() {
           // display basic theme
        }
    }
```

To:
```rust
    for theme in assets.themes() {
        if config.colored_output {
            // display colored theme
        } else {
           // display basic theme
       }
    }
    if config.colored_output {
            // display "Further themes can be installed..."
    } 

```

What do you think about it?