### PR TITLE
enable the 'conversions' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ regex = { version = "1.10.2", optional = true }
 walkdir = { version = "2.4", optional = true }
 bytesize = { version = "1.3.0" }
 encoding_rs = "0.8.33"
-os_str_bytes = { version = "~6.6", optional = true }
+os_str_bytes = { version = "~6.6", optional = true, features = ["conversions"] }
 run_script = { version = "^0.10.1", optional = true}
 
 [dependencies.git2]


### PR DESCRIPTION
use of deprecated associated function `os_str_bytes::RawOsString::assert_from_raw_vec`