### PR TITLE
Only start offload worker thread when there's more than 1 core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - CICD:  CICD: replace windows-2019 runners with windows-2025 #3339 (@cyqsimon)
 - Build script: replace string-based codegen with quote-based codegen #3340 (@cyqsimon)
 - Improve code coverage of `--list-languages` parameter #2942 (@sblondon)
+- Only start offload worker thread when there's more than 1 core #2956 (@cyqsimon)
 
 ## Syntaxes
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::thread::available_parallelism;
 
 use crate::{
     clap_app,
@@ -149,7 +150,9 @@ impl App {
         // start building glob matchers for builtin mappings immediately
         // this is an appropriate approach because it's statistically likely that
         // all the custom mappings need to be checked
-        syntax_mapping.start_offload_build_all();
+        if available_parallelism()?.get() > 1 {
+            syntax_mapping.start_offload_build_all();
+        }
 
         if let Some(values) = self.matches.get_many::<String>("ignored-suffix") {
             for suffix in values {


### PR DESCRIPTION
An oversight on my part that only came to mind when I'm working on a single core transit VPS today.