### PR TITLE
Allow printing binary content by treating it the same as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Syntax highlighting for JavaScript files that start with `#!/usr/bin/env bun` #2913 (@sharunkumar)
 - `bat --strip-ansi={never,always,auto}` to remove ANSI escape sequences from bat's input, see #2999 (@eth-p)
 - Add or remove individual style components without replacing all styles #2929 (@eth-p)
+- Add option `--binary=as-text` for printing binary content, see issue #2974 and PR #2976 (@einfachIrgendwer0815)
 
 ## Bugfixes
 

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -20,6 +20,13 @@ Options:
             * unicode (␇, ␊, ␀, ..)
             * caret   (^G, ^J, ^@, ..)
 
+      --binary <behavior>
+          How to treat binary content. (default: no-printing)
+          
+          Possible values:
+            * no-printing: do not print any binary content
+            * as-text: treat binary content as normal text
+
   -p, --plain...
           Only show plain style, no decorations. This is an alias for '--style=plain'. When '-p' is
           used twice ('-pp'), it also disables automatic paging (alias for '--style=plain

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -11,6 +11,8 @@ Options:
           Show non-printable characters (space, tab, newline, ..).
       --nonprintable-notation <notation>
           Set notation for non-printable characters.
+      --binary <behavior>
+          How to treat binary content. (default: no-printing)
   -p, --plain...
           Show plain style (alias for '--style=plain').
   -l, --language <language>

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -9,6 +9,7 @@ use crate::{
     config::{get_args_from_config_file, get_args_from_env_opts_var, get_args_from_env_vars},
 };
 use bat::style::StyleComponentList;
+use bat::BinaryBehavior;
 use bat::StripAnsiMode;
 use clap::ArgMatches;
 
@@ -192,6 +193,11 @@ impl App {
                 Some("unicode") => NonprintableNotation::Unicode,
                 Some("caret") => NonprintableNotation::Caret,
                 _ => unreachable!("other values for --nonprintable-notation are not allowed"),
+            },
+            binary: match self.matches.get_one::<String>("binary").map(|s| s.as_str()) {
+                Some("as-text") => BinaryBehavior::AsText,
+                Some("no-printing") => BinaryBehavior::NoPrinting,
+                _ => unreachable!("other values for --binary are not allowed"),
             },
             wrapping_mode: if self.interactive_output || maybe_term_width.is_some() {
                 if !self.matches.get_flag("chop-long-lines") {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -78,6 +78,22 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("binary")
+                .long("binary")
+                .action(ArgAction::Set)
+                .default_value("no-printing")
+                .value_parser(["no-printing", "as-text"])
+                .value_name("behavior")
+                .hide_default_value(true)
+                .help("How to treat binary content. (default: no-printing)")
+                .long_help(
+                    "How to treat binary content. (default: no-printing)\n\n\
+                    Possible values:\n  \
+                    * no-printing: do not print any binary content\n  \
+                    * as-text: treat binary content as normal text",
+                ),
+        )
+        .arg(
             Arg::new("plain")
                 .overrides_with("plain")
                 .overrides_with("number")

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::line_range::{HighlightedLineRanges, LineRanges};
-use crate::nonprintable_notation::NonprintableNotation;
+use crate::nonprintable_notation::{BinaryBehavior, NonprintableNotation};
 #[cfg(feature = "paging")]
 use crate::paging::PagingMode;
 use crate::style::StyleComponents;
@@ -43,6 +43,9 @@ pub struct Config<'a> {
 
     /// The configured notation for non-printable characters
     pub nonprintable_notation: NonprintableNotation,
+
+    /// How to treat binary content
+    pub binary: BinaryBehavior,
 
     /// The character width of the terminal
     pub term_width: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod terminal;
 mod vscreen;
 pub(crate) mod wrapping;
 
-pub use nonprintable_notation::NonprintableNotation;
+pub use nonprintable_notation::{BinaryBehavior, NonprintableNotation};
 pub use preprocessor::StripAnsiMode;
 pub use pretty_printer::{Input, PrettyPrinter, Syntax};
 pub use syntax_mapping::{MappingTarget, SyntaxMapping};

--- a/src/nonprintable_notation.rs
+++ b/src/nonprintable_notation.rs
@@ -10,3 +10,15 @@ pub enum NonprintableNotation {
     #[default]
     Unicode,
 }
+
+/// How to treat binary content
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BinaryBehavior {
+    /// Do not print any binary content
+    #[default]
+    NoPrinting,
+
+    /// Treat binary content as normal text
+    AsText,
+}

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -269,7 +269,8 @@ impl<'a> InteractivePrinter<'a> {
             .content_type
             .map_or(false, |c| c.is_binary() && !config.show_nonprintable);
 
-        let needs_to_match_syntax = !is_printing_binary
+        let needs_to_match_syntax = (!is_printing_binary
+            || matches!(config.binary, BinaryBehavior::AsText))
             && (config.colored_output || config.strip_ansi == StripAnsiMode::Auto);
 
         let (is_plain_text, highlighter_from_set) = if needs_to_match_syntax {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1930,6 +1930,16 @@ fn show_all_with_unicode() {
 }
 
 #[test]
+fn binary_as_text() {
+    bat()
+        .arg("--binary=as-text")
+        .arg("control_characters.txt")
+        .assert()
+        .stdout("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x7F")
+        .stderr("");
+}
+
+#[test]
 fn no_paging_arg() {
     bat()
         .arg("--no-paging")


### PR DESCRIPTION
Adds a CLI option called `--binary` which controls how binary content is handled. Possible values:
  * `no-printing`: do not print any content from a binary file (default; basically what bat currently does)
  * `as-text`: treat the binary as if it was text -> it will get printed as is

Fixes #2974.
Fixes #2709.