### PR TITLE
Support 'statically linked binary' for aarch64 in 'Release' page

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -163,6 +163,7 @@ jobs:
       fail-fast: false
       matrix:
         job:
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-20.04, dpkg_arch: arm64,            use-cross: true }
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04, dpkg_arch: arm64,            use-cross: true }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04, dpkg_arch: armhf,            use-cross: true }
           - { target: arm-unknown-linux-musleabihf, os: ubuntu-20.04, dpkg_arch: musl-linux-armhf, use-cross: true }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Add aarch64-apple-darwin ("Apple Silicon") binary tarballs to releases, see #2967 (@someposer)
 - Update the Lisp syntax, see #2970 (@ccqpein)
 - Use bat's ANSI iterator during tab expansion, see #2998 (@eth-p)
+- Support 'statically linked binary' for aarch64 in 'Release' page, see #2992 (@tzq0301)
 
 ## Syntaxes
 


### PR DESCRIPTION
There is an artifact built by CI of my repo: https://github.com/tzq0301/bat/actions/runs/9400304021/artifacts/1574889384 (open this link in a new tab, and it will begin to download)

The output can be worked well in my Debian VM on MacBook Pro (M1), and `file` command shows that it is statically linked:

```bash
$ file ./bat
./bat: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
```