### PR TITLE
Update the man page of bat (`assets/manual/bat.1.in`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Update the Lisp syntax, see #2970 (@ccqpein)
 - Use bat's ANSI iterator during tab expansion, see #2998 (@eth-p)
 - Support 'statically linked binary' for aarch64 in 'Release' page, see #2992 (@tzq0301)
+- Update options in shell completions and the man page of `bat`, see #2995 (@akinomyoga)
 
 ## Syntaxes
 

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -76,6 +76,7 @@ _bat() {
 	-m | --map-syntax | \
 	--ignored-suffix | \
 	--list-themes | \
+	--squeeze-limit | \
 	--line-range | \
 	-L | --list-languages | \
 	--lessopen | \
@@ -157,6 +158,7 @@ _bat() {
 			--diff-context
 			--tabs
 			--wrap
+			--chop-long-lines
 			--terminal-width
 			--number
 			--color
@@ -169,12 +171,15 @@ _bat() {
 			--ignored-suffix
 			--theme
 			--list-themes
+			--squeeze-blank
+			--squeeze-limit
 			--style
 			--line-range
 			--list-languages
 			--lessopen
 			--diagnostic
 			--acknowledgements
+			--set-terminal-title
 			--help
 			--version
 			--cache-dir

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -186,6 +186,9 @@ _bat() {
 			--config-dir
 			--config-file
 			--generate-config-file
+			--no-config
+			--no-custom-assets
+			--no-lessopen
 		" -- "$cur"))
 		return 0
 	fi

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -133,6 +133,8 @@ set -l tabs_opts '
 
 complete -c $bat -l acknowledgements -d "Print acknowledgements" -n __fish_is_first_arg
 
+complete -c $bat -l cache-dir -f -d "Show bat's cache directory" -n __fish_is_first_arg
+
 complete -c $bat -l color -x -a "$color_opts" -d "When to use colored output" -n __bat_no_excl_args
 
 complete -c $bat -l config-dir -f -d "Display location of configuration directory" -n __fish_is_first_arg

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -48,6 +48,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
             default auto full plain changes header header-filename header-filesize grid rule numbers snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
         '(* -)'{-L,--list-languages}'[display all supported languages]'
+        -P'[disable paging]'
         "--no-config[don't use the configuration file]"
         "--no-custom-assets[don't load custom assets]"
         '(--no-lessopen)'--lessopen'[enable the $LESSOPEN preprocessor]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -201,6 +201,18 @@ Display a list of supported languages for syntax highlighting.
 This option exists for POSIX\-compliance reasons ('u' is for 'unbuffered'). The output is
 always unbuffered \- this option is simply ignored.
 .HP
+\fB\-\-no\-custom\-assets\fR
+.IP
+Do not load custom assets.
+.HP
+\fB\-\-config\-dir\fR
+.IP
+Show bat's configuration directory.
+.HP
+\fB\-\-cache\-dir\fR
+.IP
+Show bat's cache directory.
+.HP
 \fB\-\-diagnostic\fR
 .IP
 Show diagnostic information for bug reports.
@@ -241,6 +253,20 @@ location of the configuration file.
 To generate a default configuration file, call:
 
 \fB{{PROJECT_EXECUTABLE}} --generate-config-file\fR
+
+These are related options:
+.HP
+\fB\-\-config\-file\fR
+.IP
+Show path to the configuration file.
+.HP
+\fB\-\-generate-config\-file\fR
+.IP
+Generates a default configuration file.
+.HP
+\fB\-\-no\-config\fR
+.IP
+Do not use the configuration file.
 .SH "ADDING CUSTOM LANGUAGES"
 {{PROJECT_EXECUTABLE}} supports Sublime Text \fB.sublime-syntax\fR language files, and can be
 customized to add additional languages to your local installation. To do this, add the \fB.sublime-syntax\fR language
@@ -287,6 +313,16 @@ To temporarily disable the preprocessor if it is enabled by default, call:
 
 \fB{{PROJECT_EXECUTABLE}} --no-lessopen\fR
 
+These are related options:
+.HP
+\fB\-\-lessopen\fR
+.IP
+Enable the $LESSOPEN preprocessor.
+.HP
+\fB\-\-no\-lessopen\fR
+.IP
+Disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)
+.PP
 For more information, see the "INPUT PREPROCESSOR" section of less(1).  
 
 .SH "MORE INFORMATION"

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -87,6 +87,10 @@ Set the tab width to T spaces. Use a width of 0 to pass tabs through directly
 Specify the text\-wrapping mode (*auto*, never, character). The '\-\-terminal\-width' option
 can be used in addition to control the output width.
 .HP
+\fB\-S\fR, \fB\-\-chop\-long\-lines\fR
+.IP
+Truncate all lines longer than screen width. Alias for '\-\-wrap=never'.
+.HP
 \fB\-\-terminal\-width\fR <width>
 .IP
 Explicitly set the width of the terminal instead of determining it automatically. If
@@ -141,6 +145,11 @@ use -m '*.build:Python'. To highlight files named '.myignore' with the Git Ignor
 syntax, use -m '.myignore:Git Ignore'.
 Note that the right-hand side is the *name* of the syntax, not a file extension.
 .HP
+\fB\-\-ignored\-suffix\fR <ignored-suffix>
+.IP
+Ignore extension. For example: 'bat \-\-ignored-suffix ".dev" my_file.json.dev'
+will use JSON syntax, and ignore '.dev'
+.HP
 \fB\-\-theme\fR <theme>
 .IP
 Set the theme for syntax highlighting. Use '\-\-list\-themes' to see all available themes.
@@ -150,6 +159,14 @@ export the BAT_THEME environment variable (e.g.: export BAT_THEME="...").
 \fB\-\-list\-themes\fR
 .IP
 Display a list of supported themes for syntax highlighting.
+.HP
+\fB\-s\fR, \fB\-\-squeeze\-blank\fR
+.IP
+Squeeze consecutive empty lines into a single empty line.
+.HP
+\fB\-\-squeeze\-limit\fR <squeeze-limit>
+.IP
+Set the maximum number of consecutive empty lines to be printed.
 .HP
 \fB\-\-style\fR <style\-components>
 .IP
@@ -183,6 +200,18 @@ Display a list of supported languages for syntax highlighting.
 .IP
 This option exists for POSIX\-compliance reasons ('u' is for 'unbuffered'). The output is
 always unbuffered \- this option is simply ignored.
+.HP
+\fB\-\-diagnostic\fR
+.IP
+Show diagnostic information for bug reports.
+.HP
+\fB\-\-acknowledgements\fR
+.IP
+Show acknowledgements.
+.HP
+\fB\-\-set\-terminal\-title\fR
+.IP
+Sets terminal title to filenames when using a pager.
 .HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP


### PR DESCRIPTION
The man page of `bat` (`assets/manual/bat.1.in`) doesn't seem to be up-to-date compared to the output obtained by `bat --help` and the options completed by `assets/completion/bat.bash.in`.

----

Originally reported by https://github.com/akinomyoga/ble.sh/issues/458#issuecomment-2156378867. A Bash interactive setting `ble.sh` extracts the descriptions of the options generated by programmable completions from the man page, but the discrepancy between the programmable completion `assets/completion/bat.bash.in` and the man page `assets/manual/bat.1.in` causes missing descriptions for some options.

However, I still see discrepancies between different files:

- `doc/long-help.txt` and `bat --help`
- `doc/short-help.txt` and `bat -h`
- `assets/completion/bat.bash.in`
- `assets/completion/bat.fish.in`
- `assets/completion/bat.zsh.in`
- `assets/manual/bat.1.in`

Not a single one out of the above list matches another, which means that there are six different sets of options. Also, some options appearing in several files have different descriptions in the above files. Which one would be considered the up-to-date information that reflects the public interface? Or may all of the options defined in `src/bin/bat/clap_app.rs` be used by the users (i.e., there are no hidden options)?

----

Fixes: #2996 ... I initially didn't include the fix for #2996, but I decided to include also the fix for #2996 in this PR cf https://github.com/sharkdp/bat/pull/2995#issuecomment-2156815629.
