### PR TITLE
Update bat's tab expansion preprocessor to use bat's ANSI escape sequence iterator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Display which theme is the default one in colored output, see #2838 (@sblondon)
 - Add aarch64-apple-darwin ("Apple Silicon") binary tarballs to releases, see #2967 (@someposer)
 - Update the Lisp syntax, see #2970 (@ccqpein)
+- Use bat's ANSI iterator during tab expansion, see #2998 (@eth-p)
 
 ## Syntaxes
 

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -285,7 +285,7 @@ fn join(
 
 /// A range of indices for a raw ANSI escape sequence.
 #[derive(Debug, PartialEq)]
-enum EscapeSequenceOffsets {
+pub enum EscapeSequenceOffsets {
     Text {
         start: usize,
         end: usize,
@@ -320,6 +320,32 @@ enum EscapeSequenceOffsets {
     },
 }
 
+impl EscapeSequenceOffsets {
+    /// Returns the byte-index of the first character in the escape sequence.
+    pub fn index_of_start(&self) -> usize {
+        use EscapeSequenceOffsets::*;
+        match self {
+            Text { start, .. } => *start,
+            Unknown { start, .. } => *start,
+            NF { start_sequence, .. } => *start_sequence,
+            OSC { start_sequence, .. } => *start_sequence,
+            CSI { start_sequence, .. } => *start_sequence,
+        }
+    }
+
+    /// Returns the byte-index past the last character in the escape sequence.
+    pub fn index_past_end(&self) -> usize {
+        use EscapeSequenceOffsets::*;
+        match self {
+            Text { end, .. } => *end,
+            Unknown { end, .. } => *end,
+            NF { end, .. } => *end,
+            OSC { end, .. } => *end,
+            CSI { end, .. } => *end,
+        }
+    }
+}
+
 /// An iterator over the offests of ANSI/VT escape sequences within a string.
 ///
 /// ## Example
@@ -327,7 +353,7 @@ enum EscapeSequenceOffsets {
 /// ```ignore
 /// let iter = EscapeSequenceOffsetsIterator::new("\x1B[33mThis is yellow text.\x1B[m");
 /// ```
-struct EscapeSequenceOffsetsIterator<'a> {
+pub struct EscapeSequenceOffsetsIterator<'a> {
     text: &'a str,
     chars: Peekable<CharIndices<'a>>,
 }


### PR DESCRIPTION
This pull request updates `bat`'s tab expansion preprocessing function to use `bat`'s `vscreen::EscapeSequenceOffsetsIterator` instead of `console::AnsiCodeIterator`.

## Benchmarks

When running against a file with no tabs, there are no observable differences:

<img width="1480" alt="image" src="https://github.com/sharkdp/bat/assets/32112321/54328b28-6eb5-4603-a70e-db3113425c2f">

And when running against a file[^1] with 34443 tab characters, the difference is negligible:

<img width="1537" alt="image" src="https://github.com/sharkdp/bat/assets/32112321/4a324161-6a97-4836-ab7a-e100afa0d77a">

However, it did trim a little over 16 KiB off the file size:

```bash
stat bat-master target/release/bat -c "%-20n %s"
# bat-master           5241880
# target/release/bat   5225368
```

[^1]: Command to create the file: `file fd --glob '*.rs' --exec-batch sh -c 'cat "$@" > lots-of.rs' {} && sed -i "s/    /\t/g" lots-of.rs`