### PR TITLE
Add option to remove ANSI escape sequences from bat's input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `bat --squeeze-limit` to set the maximum number of empty consecutive when using `--squeeze-blank`, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
 - `PrettyPrinter::squeeze_empty_lines` to support line squeezing for bat as a library, see #1441 (@eth-p) and #2665 (@einfachIrgendwer0815)
 - Syntax highlighting for JavaScript files that start with `#!/usr/bin/env bun` #2913 (@sharunkumar)
+- `bat --strip-ansi={never,always,auto}` to remove ANSI escape sequences from bat's input, see #2999 (@eth-p)
 
 ## Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -759,8 +759,13 @@ bat() {
 
 If an input file contains color codes or other ANSI escape sequences or control characters, `bat` will have problems
 performing syntax highlighting and text wrapping, and thus the output can become garbled.
-When displaying such files it is recommended to disable both syntax highlighting and wrapping by
+
+If your version of `bat` supports the `--strip-ansi=auto` option, it can be used to remove such sequences
+before syntax highlighting. Alternatively, you may disable both syntax highlighting and wrapping by
 passing the `--color=never --wrap=never` options to `bat`.
+
+> [!NOTE]
+> The `auto` option of `--strip-ansi` avoids removing escape sequences when the syntax is plain text.
 
 ### Terminals & colors
 

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -122,6 +122,10 @@ Options:
       --squeeze-limit <squeeze-limit>
           Set the maximum number of consecutive empty lines to be printed.
 
+      --strip-ansi <when>
+          Specify when to strip ANSI escape sequences from the input. Possible values: always,
+          *never*.
+
       --style <components>
           Configure which elements (line numbers, file headers, grid borders, Git modifications, ..)
           to display in addition to the file contents. The argument is a comma-separated list of

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -123,8 +123,9 @@ Options:
           Set the maximum number of consecutive empty lines to be printed.
 
       --strip-ansi <when>
-          Specify when to strip ANSI escape sequences from the input. Possible values: always,
-          *never*.
+          Specify when to strip ANSI escape sequences from the input. The automatic mode will remove
+          escape sequences unless the syntax highlighting language is plain text. Possible values:
+          auto, always, *never*.
 
       --style <components>
           Configure which elements (line numbers, file headers, grid borders, Git modifications, ..)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -250,6 +250,7 @@ impl App {
             {
                 Some("never") => StripAnsiMode::Never,
                 Some("always") => StripAnsiMode::Always,
+                Some("auto") => StripAnsiMode::Auto,
                 _ => unreachable!("other values for --strip-ansi are not allowed"),
             },
             theme: self

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -7,6 +7,7 @@ use crate::{
     clap_app,
     config::{get_args_from_config_file, get_args_from_env_opts_var, get_args_from_env_vars},
 };
+use bat::StripAnsiMode;
 use clap::ArgMatches;
 
 use console::Term;
@@ -242,6 +243,15 @@ impl App {
                         4
                     },
                 ),
+            strip_ansi: match self
+                .matches
+                .get_one::<String>("strip-ansi")
+                .map(|s| s.as_str())
+            {
+                Some("never") => StripAnsiMode::Never,
+                Some("always") => StripAnsiMode::Always,
+                _ => unreachable!("other values for --strip-ansi are not allowed"),
+            },
             theme: self
                 .matches
                 .get_one::<String>("theme")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -403,6 +403,18 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .hide_short_help(true)
         )
         .arg(
+            Arg::new("strip-ansi")
+                .long("strip-ansi")
+                .overrides_with("strip-ansi")
+                .value_name("when")
+                .value_parser(["always", "never"])
+                .default_value("never")
+                .hide_default_value(true)
+                .help("Strip colors from the input (always, *never*)")
+                .long_help("Specify when to strip ANSI escape sequences from the input. Possible values: always, *never*.")
+                .hide_short_help(true)
+        )
+        .arg(
             Arg::new("style")
                 .long("style")
                 .value_name("components")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -407,11 +407,13 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long("strip-ansi")
                 .overrides_with("strip-ansi")
                 .value_name("when")
-                .value_parser(["always", "never"])
+                .value_parser(["auto", "always", "never"])
                 .default_value("never")
                 .hide_default_value(true)
-                .help("Strip colors from the input (always, *never*)")
-                .long_help("Specify when to strip ANSI escape sequences from the input. Possible values: always, *never*.")
+                .help("Strip colors from the input (auto, always, *never*)")
+                .long_help("Specify when to strip ANSI escape sequences from the input. \
+                The automatic mode will remove escape sequences unless the syntax highlighting \
+                language is plain text. Possible values: auto, always, *never*.")
                 .hide_short_help(true)
         )
         .arg(

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use crate::paging::PagingMode;
 use crate::style::StyleComponents;
 use crate::syntax_mapping::SyntaxMapping;
 use crate::wrapping::WrappingMode;
+use crate::StripAnsiMode;
 
 #[derive(Debug, Clone)]
 pub enum VisibleLines {
@@ -100,6 +101,9 @@ pub struct Config<'a> {
 
     /// The maximum number of consecutive empty lines to display
     pub squeeze_lines: Option<usize>,
+
+    // Weather or not to set terminal title when using a pager
+    pub strip_ansi: StripAnsiMode,
 }
 
 #[cfg(all(feature = "minimal-application", feature = "paging"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ mod vscreen;
 pub(crate) mod wrapping;
 
 pub use nonprintable_notation::NonprintableNotation;
+pub use preprocessor::StripAnsiMode;
 pub use pretty_printer::{Input, PrettyPrinter, Syntax};
 pub use syntax_mapping::{MappingTarget, SyntaxMapping};
 pub use wrapping::WrappingMode;

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -136,6 +136,26 @@ pub fn replace_nonprintable(
     output
 }
 
+/// Strips ANSI escape sequences from the input.
+pub fn strip_ansi(line: &str) -> String {
+    let mut buffer = String::with_capacity(line.len());
+
+    for seq in EscapeSequenceOffsetsIterator::new(line) {
+        if let EscapeSequenceOffsets::Text { .. } = seq {
+            buffer.push_str(&line[seq.index_of_start()..seq.index_past_end()]);
+        }
+    }
+
+    buffer
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub enum StripAnsiMode {
+    #[default]
+    Never,
+    Always,
+}
+
 #[test]
 fn test_try_parse_utf8_char() {
     assert_eq!(try_parse_utf8_char(&[0x20]), Some((' ', 1)));
@@ -178,4 +198,15 @@ fn test_try_parse_utf8_char() {
     assert_eq!(try_parse_utf8_char(&[0xef]), None);
     assert_eq!(try_parse_utf8_char(&[0xef, 0x20]), None);
     assert_eq!(try_parse_utf8_char(&[0xf0, 0xf0]), None);
+}
+
+#[test]
+fn test_strip_ansi() {
+    // The sequence detection is covered by the tests in the vscreen module.
+    assert_eq!(strip_ansi("no ansi"), "no ansi");
+    assert_eq!(strip_ansi("\x1B[33mone"), "one");
+    assert_eq!(
+        strip_ansi("\x1B]1\x07multiple\x1B[J sequences"),
+        "multiple sequences"
+    );
 }

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -154,6 +154,7 @@ pub enum StripAnsiMode {
     #[default]
     Never,
     Always,
+    Auto,
 }
 
 #[test]

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -11,7 +11,7 @@ use crate::{
     input,
     line_range::{HighlightedLineRanges, LineRange, LineRanges},
     style::StyleComponent,
-    SyntaxMapping, WrappingMode,
+    StripAnsiMode, SyntaxMapping, WrappingMode,
 };
 
 #[cfg(feature = "paging")]
@@ -179,6 +179,15 @@ impl<'a> PrettyPrinter<'a> {
     /// Whether to show "snip" markers between visible line ranges (default: no)
     pub fn snip(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.snip = yes;
+        self
+    }
+
+    /// Whether to remove ANSI escape sequences from the input (default: never)
+    ///
+    /// If `Auto` is used, escape sequences will only be removed when the input
+    /// is not plain text.
+    pub fn strip_ansi(&mut self, mode: StripAnsiMode) -> &mut Self {
+        self.config.strip_ansi = mode;
         self
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -268,26 +268,40 @@ impl<'a> InteractivePrinter<'a> {
             .content_type
             .map_or(false, |c| c.is_binary() && !config.show_nonprintable);
 
-        let highlighter_from_set = if is_printing_binary || !config.colored_output {
-            None
-        } else {
-            // Determine the type of syntax for highlighting
-            let syntax_in_set =
-                match assets.get_syntax(config.language, input, &config.syntax_mapping) {
-                    Ok(syntax_in_set) => syntax_in_set,
-                    Err(Error::UndetectedSyntax(_)) => assets
-                        .find_syntax_by_name("Plain Text")?
-                        .expect("A plain text syntax is available"),
-                    Err(e) => return Err(e),
-                };
+        let needs_to_match_syntax = !is_printing_binary
+            && (config.colored_output || config.strip_ansi == StripAnsiMode::Auto);
 
-            Some(HighlighterFromSet::new(syntax_in_set, theme))
+        let (is_plain_text, highlighter_from_set) = if needs_to_match_syntax {
+            // Determine the type of syntax for highlighting
+            const PLAIN_TEXT_SYNTAX: &str = "Plain Text";
+            match assets.get_syntax(config.language, input, &config.syntax_mapping) {
+                Ok(syntax_in_set) => (
+                    syntax_in_set.syntax.name == PLAIN_TEXT_SYNTAX,
+                    Some(HighlighterFromSet::new(syntax_in_set, theme)),
+                ),
+
+                Err(Error::UndetectedSyntax(_)) => (
+                    true,
+                    Some(
+                        assets
+                            .find_syntax_by_name(PLAIN_TEXT_SYNTAX)?
+                            .map(|s| HighlighterFromSet::new(s, theme))
+                            .expect("A plain text syntax is available"),
+                    ),
+                ),
+
+                Err(e) => return Err(e),
+            }
+        } else {
+            (false, None)
         };
 
         // Determine when to strip ANSI sequences
         let strip_ansi = match config.strip_ansi {
             _ if config.show_nonprintable => false,
             StripAnsiMode::Always => true,
+            StripAnsiMode::Auto if is_plain_text => false, // Plain text may already contain escape sequences.
+            StripAnsiMode::Auto => true,
             _ => false,
         };
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2666,3 +2666,77 @@ fn highlighting_independant_from_map_syntax_case() {
         .stdout(expected)
         .stderr("");
 }
+
+#[test]
+fn strip_ansi_always_strips_ansi() {
+    bat()
+        .arg("--style=plain")
+        .arg("--decorations=always")
+        .arg("--color=never")
+        .arg("--strip-ansi=always")
+        .write_stdin("\x1B[33mYellow\x1B[m")
+        .assert()
+        .success()
+        .stdout("Yellow");
+}
+
+#[test]
+fn strip_ansi_never_does_not_strip_ansi() {
+    let output = String::from_utf8(
+        bat()
+            .arg("--style=plain")
+            .arg("--decorations=always")
+            .arg("--color=never")
+            .arg("--strip-ansi=never")
+            .write_stdin("\x1B[33mYellow\x1B[m")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .expect("valid utf8");
+
+    assert!(output.contains("\x1B[33mYellow"))
+}
+
+#[test]
+fn strip_ansi_does_not_affect_simple_printer() {
+    let output = String::from_utf8(
+        bat()
+            .arg("--style=plain")
+            .arg("--decorations=never")
+            .arg("--color=never")
+            .arg("--strip-ansi=always")
+            .write_stdin("\x1B[33mYellow\x1B[m")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .expect("valid utf8");
+
+    assert!(output.contains("\x1B[33mYellow"))
+}
+
+#[test]
+fn strip_ansi_does_not_strip_when_show_nonprintable() {
+    let output = String::from_utf8(
+        bat()
+            .arg("--style=plain")
+            .arg("--decorations=never")
+            .arg("--color=always")
+            .arg("--strip-ansi=always")
+            .arg("--show-nonprintable")
+            .write_stdin("\x1B[33mY")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .expect("valid utf8");
+
+    assert!(output.contains("␛"))
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2740,3 +2740,73 @@ fn strip_ansi_does_not_strip_when_show_nonprintable() {
 
     assert!(output.contains("␛"))
 }
+
+#[test]
+fn strip_ansi_auto_strips_ansi_when_detected_syntax_by_filename() {
+    bat()
+        .arg("--style=plain")
+        .arg("--decorations=always")
+        .arg("--color=never")
+        .arg("--strip-ansi=auto")
+        .arg("--file-name=test.rs")
+        .write_stdin("fn \x1B[33mYellow\x1B[m() -> () {}")
+        .assert()
+        .success()
+        .stdout("fn Yellow() -> () {}");
+}
+
+#[test]
+fn strip_ansi_auto_strips_ansi_when_provided_syntax_by_option() {
+    bat()
+        .arg("--style=plain")
+        .arg("--decorations=always")
+        .arg("--color=never")
+        .arg("--strip-ansi=auto")
+        .arg("--language=rust")
+        .write_stdin("fn \x1B[33mYellow\x1B[m() -> () {}")
+        .assert()
+        .success()
+        .stdout("fn Yellow() -> () {}");
+}
+
+#[test]
+fn strip_ansi_auto_does_not_strip_when_plain_text_by_filename() {
+    let output = String::from_utf8(
+        bat()
+            .arg("--style=plain")
+            .arg("--decorations=always")
+            .arg("--color=never")
+            .arg("--strip-ansi=auto")
+            .arg("--file-name=ansi.txt")
+            .write_stdin("\x1B[33mYellow\x1B[m")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .expect("valid utf8");
+
+    assert!(output.contains("\x1B[33mYellow"))
+}
+
+#[test]
+fn strip_ansi_auto_does_not_strip_ansi_when_plain_text_by_option() {
+    let output = String::from_utf8(
+        bat()
+            .arg("--style=plain")
+            .arg("--decorations=always")
+            .arg("--color=never")
+            .arg("--strip-ansi=auto")
+            .arg("--language=txt")
+            .write_stdin("\x1B[33mYellow\x1B[m")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .expect("valid utf8");
+
+    assert!(output.contains("\x1B[33mYellow"))
+}


### PR DESCRIPTION
This pull request introduces a new `--strip-ansi` option to `bat`.

This option tells `bat` whether to strip ANSI/VT escape sequences from the input file. The following values are supported:
 - `always`: Always strip escape sequences.
 - `never`: Never strip escape sequences. (default)
 - `auto`: Strip escape sequences when printing any language that is *not* "Plain Text".  
    This preserves bat's ability to print piped commands (or pre-highlighted files) and keep their existing colors.

## Benchmarks

### Disabled, Regular File

<img width="999" alt="image" src="https://github.com/sharkdp/bat/assets/32112321/81f7a737-16e1-4d81-8699-780b79358622">

No significant difference.

### Enabled, Regular File

<img width="1149" alt="image" src="https://github.com/sharkdp/bat/assets/32112321/ef8665fa-57cf-4de9-baac-e88ddade727d">

A minor reduction in performance.

### Disabled, Pre-highlighted File

<img width="1267" alt="image" src="https://github.com/sharkdp/bat/assets/32112321/e53026e3-cabb-4aa3-b49d-c6832a8f4a71">

No significant difference.

### Enabled, Pre-highlighted File

<img width="1276" alt="image" src="https://github.com/sharkdp/bat/assets/32112321/29b4726e-0042-433e-b3b5-3dbe82e1682d">

It's certainly an improvement.

### Auto Mode

<img width="1243" alt="image" src="https://github.com/sharkdp/bat/assets/32112321/ac4851f2-533f-4b95-9118-30ac61338566">

The detection part of `--strip-ansi=auto` causes no significant difference when syntax highlighting is used.

*However*, it does add a few milliseconds of startup time when used with `--color=never`. This is because `--strip-ansi=auto` relies on detecting the syntax in order to determine if a file is plain text or not (and thus whether to strip the ANSI sequences).

<img width="1108" alt="image" src="https://github.com/sharkdp/bat/assets/32112321/3bb1c79a-9b7b-4216-92ef-1cda10d43111">


## TODO

 - Support stripping sequences in `SimplePrinter` (maybe. thoughts?)
 - ~~Wait for #2998.
    It contains the changes made in b4fe182960e45d4fd9ebd5ac2c4d2e4b4522b144, which this PR depends on.~~ 
 - ~~Update `long_help` integration test~~
 - ~~Write tests~~
 - ~~Benchmarks~~
 - ~~Run `cargo fmt`~~
 - ~~Allow `--strip-ansi` to be passed multiple times (so it can be set to auto in config and overridden on the cli)~~