### PR TITLE
Add flox install

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,14 @@ You can install `bat` using the [nix package manager](https://nixos.org/nix):
 nix-env -i bat
 ```
 
+### Via flox
+
+You can install `bat` using [Flox](https://flox.dev)
+
+```bash
+flox install bat
+```
+
 ### On openSUSE
 
 You can install `bat` with zypper:


### PR DESCRIPTION
`bat` is available in Flox, and seems to be working today!
Since Flox and Nix are related, I added the Flox install section below that of Nix.
If you have any questions about Flox, please let me know. 😊