### PR TITLE
Dom/all themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Update the Lisp syntax, see #2970 (@ccqpein)
 - Use bat's ANSI iterator during tab expansion, see #2998 (@eth-p)
 - Support 'statically linked binary' for aarch64 in 'Release' page, see #2992 (@tzq0301)
+- `--theme` option now provides a short list of all themes if the given theme does not exist (@monkeydom)
 
 ## Syntaxes
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -245,7 +245,12 @@ impl HighlightingAssets {
                     return self.get_theme("ansi");
                 }
                 if !theme.is_empty() {
-                    bat_warning!("Unknown theme '{}', using default.", theme)
+                    let all_themes: Vec<&str> = self.get_theme_set().themes().collect();
+                    bat_warning!(
+                        "Unknown theme '{}', using default. (Available themes: {})",
+                        theme,
+                        all_themes.join(", ")
+                    );
                 }
                 self.get_theme_set()
                     .get(self.fallback_theme.unwrap_or_else(Self::default_theme))


### PR DESCRIPTION
This turns: 
```console
[bat warning]: Unknown theme 'SolarizedDark', using default.
```

Into a more actionable:
```console
[bat warning]: Unknown theme 'SolarizedDark', using default. (Available themes: 1337, Coldark-Cold, Coldark-Dark, DarkNeon, Dracula, GitHub, Monokai Extended, Monokai Extended Bright, Monokai Extended Light, Monokai Extended Origin, Nord, OneHalfDark, OneHalfLight, Solarized (dark), Solarized (light), Sublime Snazzy, TwoDark, Visual Studio Dark+, ansi, base16, base16-256, gruvbox-dark, gruvbox-light, zenburn)
```

Might be worth doing a fuzzy prefix match too maybe?