### PR TITLE
Bump time to 0.3.36 (fixes #3043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix handling of inputs with OSC ANSI escape sequences, see #2541 and #2544 (@eth-p)
 - Fix handling of inputs with combined ANSI color and attribute sequences, see #2185 and #2856 (@eth-p)
 - Fix panel width when line 10000 wraps, see #2854 (@eth-p)
+- Fix compile issue of `time` dependency caused by standard library regression #3045 (@cyqsimon)
 
 ## Other
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -1368,9 +1368,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
Fixes #3043.

This seems to be a regression in the standard library that unfortunately they can do nothing about. See https://github.com/rust-lang/rust/issues/127343.

I'll admit this is the first time I've run into this situation where an added API breaks type inference. Seems like it's an entire category of possible regressions against which the compiler currently has no warning.