### PR TITLE
Add syntax mapping for kubernetes config files

### DIFF
--- a/src/syntax_mapping/builtins/linux/50-kubernetes.toml
+++ b/src/syntax_mapping/builtins/linux/50-kubernetes.toml
@@ -1,0 +1,2 @@
+[mappings]
+"YAML" = ["/etc/kubernetes/*.conf"]


### PR DESCRIPTION
There isn't really a central place (at least that I know of) that documents all these `.conf` files, but if you run `kubeadm init` you'll see them there.

[This page](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/kubelet-integration/) for example talks about `kubelet.conf`, which is arguably the most frequently used.