### PR TITLE
[3040]: Add Alias hint on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ mkdir -p ~/.local/bin
 ln -s /usr/bin/batcat ~/.local/bin/bat
 ```
 
+an example alias for `batcat` as `bat`:
+```bash
+alias bat="batcat"
+```
+
 ### On Ubuntu (using most recent `.deb` packages)
 *... and other Debian-based Linux distributions.*
 


### PR DESCRIPTION
There isn't a simple example for aliasing for users who don't want to use symlinks so just added that.