### PR TITLE
Map `*.mkd` files to `Markdown` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Associate `.aws/{config,credentials}`, see #2795 (@mxaddict)
 - Associate Wireguard config `/etc/wireguard/*.conf`, see #2874 (@cyqsimon)
 - Add support for [CFML](https://www.adobe.com/products/coldfusion-family.html), see #3031 (@brenton-at-pieces)
+- Map `*.mkd` files to `Markdown` syntax, see issue #3060 and PR #3061 (@einfachIrgendwer0815)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/common/50-markdown.toml
+++ b/src/syntax_mapping/builtins/common/50-markdown.toml
@@ -1,0 +1,2 @@
+[mappings]
+"Markdown" = ["*.mkd"]


### PR DESCRIPTION
Adds a new syntax mapping, so that `*.mkd` files will get `Markdown` syntax highlighting.

Fixes #3060.