### PR TITLE
added Base2Tone-bat duotone colorscheme repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -263,3 +263,6 @@
 [submodule "assets/syntaxes/02_Extra/CFML"]
 	path = assets/syntaxes/02_Extra/CFML
 	url = https://github.com/jcberquist/sublimetext-cfml.git
+[submodule "assets/themes/Base2Tone"]
+	path = assets/themes/Base2Tone
+	url = https://github.com/atelierbram/Base2Tone-bat


### PR DESCRIPTION
I would like to see duotone color themes included in bat. These are only dark versions of [Base2Tone colorschemes](https://base2t.one). Because these colorschemes have such a limited color palette, but come in lots of variations, it will make the choice for people to find something that they like and/or matches the look of their terminal emulator much easier imo.