### PR TITLE
Update documentation for git diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ You can combine `bat` with `git diff` to view lines around code changes with pro
 highlighting:
 ```bash
 batdiff() {
-    git diff --name-only --relative --diff-filter=d | xargs bat --diff
+    git diff --name-only --relative --diff-filter=d -z | xargs --null bat --diff
 }
 ```
 If you prefer to use this as a separate tool, check out `batdiff` in [`bat-extras`](https://github.com/eth-p/bat-extras).

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -163,7 +163,7 @@ git show v0.6.0:src/main.rs | bat -l rs
 볼 수 있습니다:
 ```bash
 batdiff() {
-    git diff --name-only --diff-filter=d | xargs bat --diff
+    git diff --name-only --diff-filter=d -z | xargs --null bat --diff
 }
 ```
 이것을 별도의 도구로 쓰고 싶다면

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -150,7 +150,7 @@ git show v0.6.0:src/main.rs | bat -l rs
 
 ```bash
 batdiff() {
-    git diff --name-only --diff-filter=d | xargs bat --diff
+    git diff --name-only --diff-filter=d -z | xargs --null bat --diff
 }
 ```
 


### PR DESCRIPTION
Updated documentation for the `git diff` section.

Currently if (for whatever reason) a file in the repo has special characters in its name, including space, new line, etc., batdiff would malfunction. With filenames being handled in form of NULL-terminated strings, the issue is resolved. (delta does not have this problem)

I noticed that this section is not present in Japanese/Russian version of the doc, not sure how to deal with them :P

see also: eth-p/bat-extras#124