### PR TITLE
Add helper scripts for testing the shell completions

### DIFF
--- a/scripts/test-completions.bash
+++ b/scripts/test-completions.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Spawns a new bash shell that's set up with a PATH that points
+# the `bat` executable and completions from the `target/` dir.
+
+# Requires https://github.com/scop/bash-completion
+
+target_dir="$(dirname "$(realpath "$0")")/../target/debug"
+completion_file=$target_dir/build/bat-*/out/assets/completions/bat.bash
+export PATH="$target_dir:$PATH"
+bash --noprofile --rcfile <(echo "source /usr/share/bash-completion/bash_completion; source $completion_file") +o history

--- a/scripts/test-completions.fish
+++ b/scripts/test-completions.fish
@@ -1,0 +1,11 @@
+#!/usr/bin/env fish
+
+# Spawns a new fish shell that's set up with a PATH that points
+# the `bat` executable and completions from the `target/` dir.
+
+set target_dir "$(dirname (realpath (status -f)))/../target/debug"
+set completion_file $target_dir/build/bat-*/out/assets/completions/bat.fish
+set --export PATH "$target_dir:$PATH"
+fish \
+    --no-config --private \
+    --init-command="set -U fish_color_command brcyan; set -U fish_pager_color_description yellow; source $completion_file"

--- a/scripts/test-completions.zsh
+++ b/scripts/test-completions.zsh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Spawns a new zsh shell that's set up with a PATH that points
+# the `bat` executable and completions from the `target/` dir.
+
+# Yes, this is a .zsh file that's executed with bash instead :)
+
+target_dir="$(dirname "$(realpath "$0")")/../target/debug"
+completion_file=$target_dir/build/bat-*/out/assets/completions/bat.zsh
+
+# Setup a temporary ZDOTDIR-
+# that's the place where ZSH looks up config files (defaults to $HOME)
+ZDOTDIR=$(mktemp -d); export ZDOTDIR
+mkdir "$ZDOTDIR/completions"
+cp $completion_file "$ZDOTDIR/completions/_bat"
+
+# Setup an RC file that adds our temporary completions dir to the autoload path
+# and initializes completions.
+echo 'fpath+=("$ZDOTDIR/completions"); autoload -U compinit; compinit' > "$ZDOTDIR/.zshrc"
+
+export PATH="$target_dir:$PATH"
+zsh --no-globalrcs
+
+rm -rf "$ZDOTDIR"


### PR DESCRIPTION
While working on #2896 I needed a way to test the shell completions.

So I put together a script for each shell (PowerShell is notably missing) that spawns the shell
with the right PATH / completions setup. It might be useful to other people too :)