### PR TITLE
Don't output default theme info to piped stdout

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -202,7 +202,7 @@ pub fn list_themes(cfg: &Config, config_dir: &Path, cache_dir: &Path) -> Result<
 
     let default_theme = HighlightingAssets::default_theme();
     for theme in assets.themes() {
-        let default_theme_info = if default_theme == theme {
+        let default_theme_info = if !config.loop_through && default_theme == theme {
             " (default)"
         } else {
             ""

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -300,11 +300,21 @@ fn list_themes_without_colors() {
 
     bat()
         .arg("--color=never")
+        .arg("--decorations=always") // trick bat into setting `Config::loop_through` to false
         .arg("--list-themes")
         .assert()
         .success()
         .stdout(predicate::str::contains("DarkNeon").normalize())
         .stdout(predicate::str::contains(default_theme_chunk).normalize());
+}
+
+#[test]
+fn list_themes_to_piped_output() {
+    bat()
+        .arg("--list-themes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(default)").not());
 }
 
 #[test]


### PR DESCRIPTION
#2937 introduced the `(default)` suffix to the output of `--list-themes`, which breaks completion scripts. This PR tries to solve that by not printing the `(default)` suffix when stdout is piped.

Fixes #3073.