### PR TITLE
Associate GeoJSON `.geojson` files with `json` syntax (fixes #3083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Associate JSON with Comments `.jsonc` with `json` syntax, see #2795 (@mxaddict)
 - Associate JSON-LD `.jsonld` files with `json` syntax, see #3037 (@vorburger)
 - Associate `.textproto` files with `ProtoBuf` syntax, see #3038 (@vorburger)
+- Associate GeoJSON `.geojson` files with `json` syntax, see #3084 (@mvaaltola)
 - Associate `.aws/{config,credentials}`, see #2795 (@mxaddict)
 - Associate Wireguard config `/etc/wireguard/*.conf`, see #2874 (@cyqsimon)
 - Add support for [CFML](https://www.adobe.com/products/coldfusion-family.html), see #3031 (@brenton-at-pieces)

--- a/src/syntax_mapping/builtins/common/50-json.toml
+++ b/src/syntax_mapping/builtins/common/50-json.toml
@@ -1,3 +1,3 @@
 # JSON Lines is a simple variation of JSON #2535
 [mappings]
-"JSON" = ["*.jsonl", "*.jsonc", "*.jsonld"]
+"JSON" = ["*.jsonl", "*.jsonc", "*.jsonld", "*.geojson"]


### PR DESCRIPTION
Fixes #3083.