### PR TITLE
Update README.md: Add x-cmd method to install bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,16 @@ You can install `bat` using [Flox](https://flox.dev)
 flox install bat
 ```
 
+### Via x-cmd
+
+You can install `bat` using [x-cmd](https://www.x-cmd.com/)
+
+```bash
+x env use bat
+# or
+x bat
+```
+
 ### On openSUSE
 
 You can install `bat` with zypper:

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -273,6 +273,24 @@ make install
 nix-env -i bat
 ```
 
+### Via flox
+
+`bat` を [flox](https://flox.dev) 経由でインストールすることができます:
+
+```bash
+flox install bat
+```
+
+### Via x-cmd
+
+`bat` を [x-cmd](https://www.x-cmd.com) 経由でインストールすることができます:
+
+```bash
+x env use bat
+# or
+x bat
+```
+
 ### On openSUSE
 
 `bat` をzypperでインストールすることができます:

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -340,6 +340,26 @@ make install
 nix-env -i bat
 ```
 
+### flox를 써서
+
+[flox](https://flox.dev)를 이용해 `bat`을 설치할 수
+있습니다:
+
+```bash
+flox install bat
+```
+
+### x-cmd를 써서
+
+[x-cmd](https://www.x-cmd.com)를 이용해 `bat`을 설치할 수
+있습니다:
+
+```bash
+x env use bat
+# or
+x bat
+```
+
 ### openSUSE에서
 
 zypper를 이용해 `bat`을 설치할 수 있습니다:

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -253,6 +253,24 @@ make install
 nix-env -i bat
 ```
 
+### С помощью flox
+
+Вы можете установить `bat`, используя [flox](https://flox.dev):
+
+```bash
+flox install bat
+```
+
+### С помощью x-cmd
+
+Вы можете установить `bat`, используя [x-cmd](https://www.x-cmd.com):
+
+```bash
+x env use bat
+# or
+x bat
+```
+
 ### openSUSE
 
 Вы можете установить `bat` с помощью `zypper`:

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -310,6 +310,24 @@ pkg_add bat
 nix-env -i bat
 ```
 
+### 通过 flox
+
+你可以用 [flox](https://flox.dev) 安装`bat`：
+
+```bash
+flox install bat
+```
+
+### 通过 x-cmd
+
+你可以用 [x-cmd](https://cn.x-cmd.com) 安装`bat`：
+
+```bash
+x env use bat
+# or
+x bat
+```
+
 ### openSUSE
 
 你可以用 zypper 安装`bat`：


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.. It helps you download bat release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the bat installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use bat
  # or
  x bat
  ```
  
- We wrote a [bat introduction article](https://www.x-cmd.com/pkg/bat) and a [demo](https://www.x-cmd.com/1min/bat)