### PR TITLE
📔 docs: mention `BAT_CONFIG_DIR` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,10 +693,11 @@ on your operating system. To get the default path for your system, call
 bat --config-file
 ```
 
-Alternatively, you can use the `BAT_CONFIG_PATH` environment variable to point `bat` to a
-non-default location of the configuration file:
+Alternatively, you can use `BAT_CONFIG_PATH` or `BAT_CONFIG_DIR` environment variables to point `bat`
+to a non-default location of the configuration file or the configuration directory respectively:
 ```bash
-export BAT_CONFIG_PATH="/path/to/bat.conf"
+export BAT_CONFIG_PATH="/path/to/bat/bat.conf"
+export BAT_CONFIG_DIR="/path/to/bat"
 ```
 
 A default configuration file can be created with the `--generate-config-file` option.


### PR DESCRIPTION
Resolves #2890

As stated in the issue liked above, the `README.md` makes [changing the default config path](https://github.com/sharkdp/bat?tab=readme-ov-file#configuration-file) a bit confusing when it comes to `BAT_CONFIG_PATH` and `BAT_CONFIG_DIR` variables.

This PR adds a mention about how `BAT_CONFIG_DIR` can be used.
