### PR TITLE
Significantly improve performance by using a buffered writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Use bat's ANSI iterator during tab expansion, see #2998 (@eth-p)
 - Support 'statically linked binary' for aarch64 in 'Release' page, see #2992 (@tzq0301)
 - Update options in shell completions and the man page of `bat`, see #2995 (@akinomyoga)
+- Significantly improve performance by using a buffered writer, see #3101 (@MoSal)
 
 ## Syntaxes
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -338,6 +338,8 @@ impl App {
             return Err("Must be one file name per input type.".into());
         }
 
+        let stdin_is_terminal = || std::io::stdin().is_terminal();
+
         let mut filenames_or_none: Box<dyn Iterator<Item = Option<&Path>>> = match filenames {
             Some(filenames) => Box::new(filenames.into_iter().map(Some)),
             None => Box::new(std::iter::repeat(None)),
@@ -345,6 +347,7 @@ impl App {
         if files.is_none() {
             return Ok(vec![new_stdin_input(
                 filenames_or_none.next().unwrap_or(None),
+                stdin_is_terminal(),
             )]);
         }
         let files_or_none: Box<dyn Iterator<Item = _>> = match files {
@@ -356,7 +359,7 @@ impl App {
         for (filepath, provided_name) in files_or_none.zip(filenames_or_none) {
             if let Some(filepath) = filepath {
                 if filepath.to_str().unwrap_or_default() == "-" {
-                    file_input.push(new_stdin_input(provided_name));
+                    file_input.push(new_stdin_input(provided_name, stdin_is_terminal()));
                 } else {
                     file_input.push(new_file_input(filepath, provided_name));
                 }

--- a/src/bin/bat/input.rs
+++ b/src/bin/bat/input.rs
@@ -5,8 +5,8 @@ pub fn new_file_input<'a>(file: &'a Path, name: Option<&'a Path>) -> Input<'a> {
     named(Input::ordinary_file(file), name.or(Some(file)))
 }
 
-pub fn new_stdin_input(name: Option<&Path>) -> Input {
-    named(Input::stdin(), name)
+pub fn new_stdin_input(name: Option<&Path>, is_terminal: bool) -> Input {
+    named(Input::stdin(is_terminal), name)
 }
 
 fn named<'a>(input: Input<'a>, name: Option<&Path>) -> Input<'a> {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -230,7 +230,13 @@ impl<'b> Controller<'b> {
                 }
             };
 
-            self.print_file_ranges(printer, writer, &mut input.reader, &line_ranges)?;
+            self.print_file_ranges(
+                printer,
+                writer,
+                &mut input.reader,
+                &line_ranges,
+                input.is_terminal,
+            )?;
         }
         printer.print_footer(writer, input)?;
 
@@ -243,6 +249,7 @@ impl<'b> Controller<'b> {
         writer: &mut OutputHandle<W>,
         reader: &mut InputReader,
         line_ranges: &LineRanges,
+        input_is_terminal: bool,
     ) -> Result<()> {
         let mut line_buffer = Vec::new();
         let mut line_number: usize = 1;
@@ -281,6 +288,11 @@ impl<'b> Controller<'b> {
 
             line_number += 1;
             line_buffer.clear();
+
+            // flush per line if input is terminal to allow interactive use
+            if input_is_terminal {
+                writer.flush()?;
+            }
         }
         writer.flush()?;
         Ok(())

--- a/src/input.rs
+++ b/src/input.rs
@@ -94,6 +94,7 @@ pub(crate) struct InputMetadata {
 pub struct Input<'a> {
     pub(crate) kind: InputKind<'a>,
     pub(crate) metadata: InputMetadata,
+    pub(crate) is_terminal: bool,
     pub(crate) description: InputDescription,
 }
 
@@ -106,6 +107,7 @@ pub(crate) enum OpenedInputKind {
 pub(crate) struct OpenedInput<'a> {
     pub(crate) kind: OpenedInputKind,
     pub(crate) metadata: InputMetadata,
+    pub(crate) is_terminal: bool,
     pub(crate) reader: InputReader<'a>,
     pub(crate) description: InputDescription,
 }
@@ -141,15 +143,17 @@ impl<'a> Input<'a> {
             description: kind.description(),
             metadata,
             kind,
+            is_terminal: false,
         }
     }
 
-    pub fn stdin() -> Self {
+    pub fn stdin(is_terminal: bool) -> Self {
         let kind = InputKind::StdIn;
         Input {
             description: kind.description(),
             metadata: InputMetadata::default(),
             kind,
+            is_terminal,
         }
     }
 
@@ -159,6 +163,7 @@ impl<'a> Input<'a> {
             description: kind.description(),
             metadata: InputMetadata::default(),
             kind,
+            is_terminal: false,
         }
     }
 
@@ -207,6 +212,7 @@ impl<'a> Input<'a> {
                     kind: OpenedInputKind::StdIn,
                     description,
                     metadata: self.metadata,
+                    is_terminal: self.is_terminal,
                     reader: InputReader::new(stdin),
                 })
             }
@@ -215,6 +221,7 @@ impl<'a> Input<'a> {
                 kind: OpenedInputKind::OrdinaryFile(path.clone()),
                 description,
                 metadata: self.metadata,
+                is_terminal: self.is_terminal,
                 reader: {
                     let mut file = File::open(&path)
                         .map_err(|e| format!("'{}': {}", path.to_string_lossy(), e))?;
@@ -243,6 +250,7 @@ impl<'a> Input<'a> {
                 description,
                 kind: OpenedInputKind::CustomReader,
                 metadata: self.metadata,
+                is_terminal: self.is_terminal,
                 reader: InputReader::new(BufReader::new(reader)),
             }),
         }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -348,7 +348,7 @@ impl<'a> Input<'a> {
 
     /// A new input from STDIN.
     pub fn from_stdin() -> Self {
-        input::Input::stdin().into()
+        input::Input::stdin(true).into()
     }
 
     /// The filename of the input.


### PR DESCRIPTION
Before

```
Benchmark 1: seq 10000000 | bat
  Time (mean ± σ):      6.235 s ±  0.052 s    [User: 3.664 s, System: 2.714 s]
  Range (min … max):    6.172 s …  6.355 s    10 runs
```

After

```
Benchmark 1: seq 10000000 | ./target/release/bat
  Time (mean ± σ):     215.9 ms ±   5.1 ms    [User: 275.4 ms, System: 38.8 ms]
  Range (min … max):   210.3 ms … 224.9 ms    10 runs
```

Using `less` for comparison

```
Benchmark 1: seq 10000000 | less
  Time (mean ± σ):     637.3 ms ±  43.3 ms    [User: 642.1 ms, System: 95.6 ms]
  Range (min … max):   584.5 ms … 700.1 ms    10 runs
```

And raw

```
Benchmark 1: seq 10000000
  Time (mean ± σ):      63.1 ms ±   1.3 ms    [User: 57.1 ms, System: 5.9 ms]
  Range (min … max):    62.1 ms …  66.0 ms    10 runs
```