### PR TITLE
Bump nix from 0.26.4 to 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Use bat's ANSI iterator during tab expansion, see #2998 (@eth-p)
 - Support 'statically linked binary' for aarch64 in 'Release' page, see #2992 (@tzq0301)
 - Update options in shell completions and the man page of `bat`, see #2995 (@akinomyoga)
+- Update nix dev-dependency to v0.29.0, see #3112 (@decathorpe)
 
 ## Syntaxes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,9 +694,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libgit2-sys"
@@ -761,12 +767,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ tempfile = "3.8.1"
 serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = { version = "0.26.4", default-features = false, features = ["term"] }
+nix = { version = "0.29", default-features = false, features = ["term"] }
 
 [build-dependencies]
 anyhow = "1.0.86"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -9,7 +9,6 @@ use tempfile::tempdir;
 mod unix {
     pub use std::fs::File;
     pub use std::io::{self, Write};
-    pub use std::os::unix::io::FromRawFd;
     pub use std::path::PathBuf;
     pub use std::process::Stdio;
     pub use std::thread;
@@ -416,8 +415,8 @@ fn no_args_doesnt_break() {
     // not exit, because in this case it is safe to read and write to the same fd, which is why
     // this test exists.
     let OpenptyResult { master, slave } = openpty(None, None).expect("Couldn't open pty.");
-    let mut master = unsafe { File::from_raw_fd(master) };
-    let stdin_file = unsafe { File::from_raw_fd(slave) };
+    let mut master = File::from(master);
+    let stdin_file = File::from(slave);
     let stdout_file = stdin_file.try_clone().unwrap();
     let stdin = Stdio::from(stdin_file);
     let stdout = Stdio::from(stdout_file);


### PR DESCRIPTION
This supersedes https://github.com/sharkdp/bat/pull/3089 and makes the necessary code changes to compile with nix 0.29. This actually makes it possible to drop the `unsafe` usage, because a `File` can be constructed from `OwnedFd` safely and without failing.