### PR TITLE
Bump clircle to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Update options in shell completions and the man page of `bat`, see #2995 (@akinomyoga)
 - Update nix dev-dependency to v0.29.0, see #3112 (@decathorpe)
 - Bump MSRV to [1.74](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html), see #3154 (@keith-hall)
+- Update clircle dependency to remove winapi transitive dependency, see #3113 (@niklasmohrin)
 
 ## Syntaxes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,8 +286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d9334f725b46fb9bed8580b9b47a932587e044fadb344ed7fa98774b067ac1a"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_derive",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ serde_derive = "1.0"
 serde_yaml = "0.9.28"
 semver = "1.0"
 path_abs = { version = "0.5", default-features = false }
-clircle = "0.6"
+clircle = { version = "0.6.1", default-features = false }
 bugreport = { version = "0.5.0", optional = true }
 etcetera = { version = "0.8.0", optional = true }
 grep-cli = { version = "0.1.11", optional = true }


### PR DESCRIPTION
This includes mostly dependency updates. The most significant one is that I removed clircle's dependency on winapi. After this PR, running `cargo update` on bat will remove winapi from the lockfile.
