### PR TITLE
Build with MacOS 13 instead of 12

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -170,7 +170,7 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-2019,                                              }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04, dpkg_arch: i686,             use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, dpkg_arch: musl-linux-i686,  use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-12,                                                  }
+          - { target: x86_64-apple-darwin         , os: macos-13,                                                  }
           - { target: aarch64-apple-darwin        , os: macos-14,                                                  }
           - { target: x86_64-pc-windows-gnu       , os: windows-2019,                                              }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019,                                              }


### PR DESCRIPTION
MacOS 12 is deprecated in GitHub Actions and no longer usable