### PR TITLE
Update syntax mapping for Apache Conf

### DIFF
--- a/src/syntax_mapping/builtins/unix-family/50-apache.toml
+++ b/src/syntax_mapping/builtins/unix-family/50-apache.toml
@@ -1,2 +1,2 @@
 [mappings]
-"Apache Conf" = ["/etc/apache2/**/*.conf", "/etc/apache2/sites-*/**/*"]
+"Apache Conf" = ["/etc/apache2/**/*.conf", "/etc/apache2/sites-*/**/*", "/etc/httpd/conf/**/*.conf"]


### PR DESCRIPTION
The configuration files of Apache HTTP Server on distros other than Debian and its variants are lived in `/etc/httpd/conf/**/*.conf`, (i.e. any file ends with `.conf` in directory `/etc/httpd`) according to `config.layout` file in httpd's repository and httpd's source packages from multiple distros.

This path should also be added to possible path of *Apache Conf* syntax.

Reference:

- [`config.layout` from `httpd` 2.4](https://github.com/apache/httpd/blob/2.4.x/config.layout#L110)
- [`httpd`'s source package from Arch Linux](https://gitlab.archlinux.org/archlinux/packaging/packages/apache/-/blob/2.4.62-1/arch.layout)\
- [`httpd`'s source package from Fedora](https://src.fedoraproject.org/rpms/httpd/blob/rawhide/f/config.layout)