### PR TITLE
Create sparql.sublime-syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Automatically choose theme based on the terminal's color scheme, see #2896 (@bash)
 - Add option `--binary=as-text` for printing binary content, see issue #2974 and PR #2976 (@einfachIrgendwer0815)
 - Make shell completions available via `--completion <shell>`, see issue #2057 and PR #3126 (@einfachIrgendwer0815)
+- Add support for SPARQL Syntax #3142 (@RoiEXLab)
 
 ## Bugfixes
 

--- a/assets/syntaxes/02_Extra/sparql.sublime-syntax
+++ b/assets/syntaxes/02_Extra/sparql.sublime-syntax
@@ -1,0 +1,140 @@
+%YAML 1.2
+---
+# Based on https://github.com/stardog-union/stardog-vsc/tree/0ce931c26529fdaf5c6dd58d91e589bbd6944a1d/stardog-rdf-grammars/syntaxes
+name: SPARQL
+file_extensions:
+  - rq
+  - sparql
+scope: source.sparql
+contexts:
+  main:
+    - include: rule-constraint
+    - include: iriref
+    - include: prefix
+    - include: prefixed-name
+    - include: comment
+    - include: special-predicate
+    - include: literals
+    - include: language-tag
+    - include: query-keyword-operators
+    - include: functions
+    - include: variables
+    - include: expression-operators
+  comment:
+    - match: "#.*$"
+      scope: comment.line.number-sign.turtle
+  boolean:
+    - match: \b(?i:true|false)\b
+      scope: constant.language.sparql
+  expression-operators:
+    - match: (?:\|\||&&|=|!=|<|>|<=|>=|\*|/|\+|-|\||\^|\?|\!)
+      scope: support.class.sparql
+  functions:
+    - match: \b(?i:concat|regex|asc|desc|bound|isiri|isuri|isblank|isliteral|isnumeric|str|lang|datatype|sameterm|langmatches|avg|count|group_concat|separator|max|min|sample|sum|iri|uri|bnode|strdt|uuid|struuid|strlang|strlen|substr|ucase|lcase|strstarts|strends|contains|strbefore|strafter|encode_for_uri|replace|abs|round|ceil|floor|rand|now|year|month|day|hours|minutes|seconds|timezone|tz|md5|sha1|sha256|sha384|sha512|coalesce|if)\b
+      scope: support.function.sparql
+  integer:
+    - match: '[+-]?(?:\d+|[0-9]+\.[0-9]*|\.[0-9]+(?:[eE][+-]?\d+)?)'
+      scope: constant.numeric.turtle
+  iriref:
+    - match: '<[^\x20-\x20<>"{}|^`\\]*>'
+      scope: entity.name.type.iriref.turtle
+  language-tag:
+    - match: '@(\w+)'
+      scope: meta.string-literal-language-tag.turtle
+      captures:
+        "1": entity.name.class.turtle
+  literals:
+    - include: string
+    - include: numeric
+    - include: boolean
+  numeric:
+    - include: integer
+  prefix:
+    - match: (?i:@?base|@?prefix)\s
+      scope: keyword.operator.turtle
+  prefixed-name:
+    - match: (\w*:)(\w*)
+      scope: constant.complex.turtle
+      captures:
+        "1": storage.type.PNAME_NS.turtle
+        "2": support.variable.PN_LOCAL.turtle
+  query-keyword-operators:
+    - match: \b(?i:define|select|distinct|reduced|from|named|construct|ask|describe|where|graph|having|bind|as|filter|optional|union|order|by|group|limit|offset|values|insert data|delete data|with|delete|insert|clear|silent|default|all|create|drop|copy|move|add|to|using|service|not exists|exists|not in|in|minus|load)\b
+      scope: keyword.control.sparql
+  rule-constraint:
+    - match: (rule:content) (""")
+      captures:
+        "2": string.quoted.triple.turtle
+      push:
+        - meta_scope: meta.rule-constraint.turtle
+        - match: '"""'
+          pop: true
+        - include: rule-constraint
+        - include: iriref
+        - include: prefix
+        - include: prefixed-name
+        - include: comment
+        - include: special-predicate
+        - include: literals
+        - include: language-tag
+        - include: query-keyword-operators
+        - include: functions
+        - include: variables
+        - include: expression-operators
+        - match: \b(?i:if|then)\b
+          scope: keyword.control.srs
+  single-dquote-string-literal:
+    - match: '"'
+      push:
+        - meta_scope: string.quoted.double.turtle
+        - match: '"'
+          pop: true
+        - include: string-character-escape
+  single-squote-string-literal:
+    - match: "'"
+      push:
+        - meta_scope: string.quoted.single.turtle
+        - match: "'"
+          captures:
+            "1": punctuation.definition.string.end.turtle
+            "2": invalid.illegal.newline.turtle
+          pop: true
+        - include: string-character-escape
+  special-predicate:
+    - match: \s(a)\s
+      scope: meta.specialPredicate.turtle
+      captures:
+        "1": keyword.control.turtle
+  string:
+    - include: triple-squote-string-literal
+    - include: triple-dquote-string-literal
+    - include: single-squote-string-literal
+    - include: single-dquote-string-literal
+    - include: triple-tick-string-literal
+  string-character-escape:
+    - match: '\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)'
+      scope: constant.character.escape.turtle
+  triple-dquote-string-literal:
+    - match: '"""'
+      push:
+        - meta_scope: string.quoted.triple.turtle
+        - match: '"""'
+          pop: true
+        - include: string-character-escape
+  triple-squote-string-literal:
+    - match: "'''"
+      push:
+        - meta_scope: string.quoted.triple.turtle
+        - match: "'''"
+          pop: true
+        - include: string-character-escape
+  triple-tick-string-literal:
+    - match: "```"
+      push:
+        - meta_scope: string.quoted.triple.turtle
+        - match: "```"
+          pop: true
+        - include: string-character-escape
+  variables:
+    - match: '(?<!\w)[?$]\w+'
+      scope: constant.variable.sparql.turtle


### PR DESCRIPTION
Hi,
I just had to create my own Variant of a `.sublime-syntax` for the SPARQL language and thought: Maybe I can submit it here so it helps other people in the future.
Disclaimer: I don't know shit about the sublime-syntax Format, I just used https://github.com/stardog-union/stardog-vsc/blob/0ce931c26529fdaf5c6dd58d91e589bbd6944a1d/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json (thus the comment because I'm not sure if the licensing applies in this case) merged a bunch of files together after doing some research how includes work, and then used a converter to get the sublime-syntax file out of it.
As I see it, it seems to work rather well even though I'm pretty sure it is not completely compliant with the official https://www.w3.org/TR/sparql11-query/#rQueryUnit grammar specification.

If there are any issues with this file, feel free to nudge me in the right direction.