### PR TITLE
Fix name of BAT_THEME_{DARK,LIGHT} env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Bugfixes
+* Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)
 
 ## Other
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -10,9 +10,9 @@ pub mod env {
     /// See [`crate::theme::ThemeOptions::theme`].
     pub const BAT_THEME: &str = "BAT_THEME";
     /// See [`crate::theme::ThemeOptions::theme_dark`].
-    pub const BAT_THEME_DARK: &str = "BAT_THEME";
+    pub const BAT_THEME_DARK: &str = "BAT_THEME_DARK";
     /// See [`crate::theme::ThemeOptions::theme_light`].
-    pub const BAT_THEME_LIGHT: &str = "BAT_THEME";
+    pub const BAT_THEME_LIGHT: &str = "BAT_THEME_LIGHT";
 }
 
 /// Chooses an appropriate theme or falls back to a default theme

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2266,6 +2266,46 @@ fn theme_arg_overrides_env_withconfig() {
 }
 
 #[test]
+fn theme_light_env_var_is_respected() {
+    bat()
+        .env("BAT_THEME_LIGHT", "Coldark-Cold")
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=light")
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .arg("--highlight-line=1")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout("\x1B[48;2;208;218;231mLorem Ipsum\x1B[0m")
+        .stderr("");
+}
+
+#[test]
+fn theme_dark_env_var_is_respected() {
+    bat()
+        .env("BAT_THEME_DARK", "Coldark-Dark")
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=dark")
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .arg("--highlight-line=1")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout("\x1B[48;2;33;48;67mLorem Ipsum\x1B[0m")
+        .stderr("");
+}
+
+#[test]
 fn theme_env_overrides_config() {
     bat_with_config()
         .env("BAT_CONFIG_PATH", "bat-theme.conf")


### PR DESCRIPTION
*this is a bit embarrassing since I'm the person who wrote the code in the first place 😆*