### PR TITLE
Work around `cargo vendor` losing syntax_mapping builtins directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Other
 
+- Work around build failures when building `bat` from vendored sources #3179 (@dtolnay)
+
 ## Syntaxes
 
 ## Themes

--- a/build/syntax_mapping.rs
+++ b/build/syntax_mapping.rs
@@ -236,8 +236,14 @@ fn get_def_paths() -> anyhow::Result<Vec<PathBuf>> {
     ];
 
     let mut toml_paths = vec![];
-    for subdir in source_subdirs {
-        let wd = WalkDir::new(Path::new("src/syntax_mapping/builtins").join(subdir));
+    for subdir_name in source_subdirs {
+        let subdir = Path::new("src/syntax_mapping/builtins").join(subdir_name);
+        if !subdir.try_exists()? {
+            // Directory might not exist due to this `cargo vendor` bug:
+            // https://github.com/rust-lang/cargo/issues/15080
+            continue;
+        }
+        let wd = WalkDir::new(subdir);
         let paths = wd
             .into_iter()
             .filter_map_ok(|entry| {


### PR DESCRIPTION
See https://github.com/rust-lang/cargo/issues/15080. This fixes:

```console
error: failed to run custom build command for `bat v0.25.0`

Caused by:
  process didn't exit successfully: `target/debug/build/bat-126fec914d2804b6/build-script-main` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=build/
  cargo:rerun-if-changed=src/syntax_mapping/builtins/

  --- stderr
  Error: IO error for operation on src/syntax_mapping/builtins/macos: No such file or directory (os error 2)

  Caused by:
      No such file or directory (os error 2)
```