### PR TITLE
Add syntax mapping for paru configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## Syntaxes
 
+-  Add syntax mapping for paru configuration files #3182 (@cyqsimon)
+
 ## Themes
 
 ## `bat` as a library

--- a/src/syntax_mapping/builtins/linux/50-paru.toml
+++ b/src/syntax_mapping/builtins/linux/50-paru.toml
@@ -1,0 +1,6 @@
+# See https://github.com/Morganamilo/paru/blob/master/man/paru.conf.5
+[mappings]
+"INI" = [
+    "${PARU_CONF}",
+    "paru.conf",
+]


### PR DESCRIPTION
Paru is a widely used AUR helper. Most ArchLinux users would at minimum know about it.