### PR TITLE
Fix: Don't output default theme info to piped stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Features
 
 ## Bugfixes
-* Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)
+- Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)
+- Prevent `--list-themes` from outputting default theme info to stdout when it is piped, see #3189 (@einfachIrgendwer0815)
 
 ## Other
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -210,7 +210,7 @@ pub fn list_themes(
 
     let default_theme_name = default_theme(color_scheme(detect_color_scheme).unwrap_or_default());
     for theme in assets.themes() {
-        let default_theme_info = if !config.loop_through && default_theme_name == theme {
+        let default_theme_info = if default_theme_name == theme {
             " (default)"
         } else if default_theme(ColorScheme::Dark) == theme {
             " (default dark)"
@@ -231,6 +231,8 @@ pub fn list_themes(
                 .run(vec![theme_preview_file()], None)
                 .ok();
             writeln!(stdout)?;
+        } else if config.loop_through {
+            writeln!(stdout, "{theme}")?;
         } else {
             writeln!(stdout, "{theme}{default_theme_info}")?;
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -305,11 +305,12 @@ fn list_themes_without_colors() {
 
 #[test]
 fn list_themes_to_piped_output() {
-    bat()
-        .arg("--list-themes")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("(default)").not());
+    bat().arg("--list-themes").assert().success().stdout(
+        predicate::str::contains("(default)")
+            .not()
+            .and(predicate::str::contains("(default light)").not())
+            .and(predicate::str::contains("(default dark)").not()),
+    );
 }
 
 #[test]


### PR DESCRIPTION
As described in issue #3188, PR #2896 reintroduced the behaviour described in issue #3073 which had previously been fixed with PR #3075. This PR fixes the issue again.

Fixes #3188.