### PR TITLE
Add CI build for windows/ARM64

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -174,6 +174,7 @@ jobs:
           - { target: x86_64-apple-darwin         , os: macos-13,                                                  }
           - { target: aarch64-apple-darwin        , os: macos-14,                                                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2025,                                              }
+          - { target: aarch64-pc-windows-msvc     , os: windows-11-arm,                                            }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest, dpkg_arch: amd64,            use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest, dpkg_arch: musl-linux-amd64, use-cross: true }
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
 ## Features
+- Add build for windows/ARM64 platform. #3190 (@alcroito)
 
 - Add paging to `--list-themes`, see PR #3239 (@einfachIrgendwer0815)
 - Support negative relative line ranges, e.g. `bat -r :-10` / `bat -r='-10:'`, see #3068 (@ajesipow)


### PR DESCRIPTION
Tests and other steps that execute the binary are skipped, because the project is built on an x86_64 Windows host machine and thus can't run arm64 instructions.

Fixes: #2644