### PR TITLE
Add syntax mapping for `nix`s `flake.lock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Add syntax mapping for `paru` configuration files #3182 (@cyqsimon)
 - Add support for [Idris 2 programming language](https://www.idris-lang.org/) #3150 (@buzden)
+- Add syntax mapping for `nix`'s '`flake.lock` lockfiles #3196 (@odilf)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/common/50-nix.toml
+++ b/src/syntax_mapping/builtins/common/50-nix.toml
@@ -1,0 +1,2 @@
+[mappings]
+"JSON" = ["flake.lock"]


### PR DESCRIPTION
This PR adds a syntax mapping for `flake.lock`, which is JSON. 

As far as lockfiles go, `flake.lock`s are usually pretty readable and it's not too uncommon to inspect it manually (specifically, to compare hashes and to make sure there aren't multiple copies of the same flake in your flake). Therefore I think it's a worthwhile addition to have by default. 

