### PR TITLE
Fix clippy lint warnings

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -370,7 +370,7 @@ mod tests {
         pub temp_dir: TempDir,
     }
 
-    impl<'a> SyntaxDetectionTest<'a> {
+    impl SyntaxDetectionTest<'_> {
         fn new() -> Self {
             SyntaxDetectionTest {
                 assets: HighlightingAssets::from_binary(),

--- a/src/assets/build_assets/acknowledgements.rs
+++ b/src/assets/build_assets/acknowledgements.rs
@@ -60,7 +60,7 @@ fn to_path_and_stem(source_dir: &Path, entry: DirEntry) -> Option<PathAndStem> {
 fn handle_file(path_and_stem: &PathAndStem) -> Result<Option<String>> {
     if path_and_stem.stem == "NOTICE" {
         handle_notice(&path_and_stem.path)
-    } else if path_and_stem.stem.to_ascii_uppercase() == "LICENSE" {
+    } else if path_and_stem.stem.eq_ignore_ascii_case("LICENSE") {
         handle_license(&path_and_stem.path)
     } else {
         Ok(None)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -425,7 +425,7 @@ impl App {
             None => StyleComponents(HashSet::from_iter(
                 StyleComponent::Default
                     .components(self.interactive_output)
-                    .into_iter()
+                    .iter()
                     .cloned(),
             )),
         };

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -25,7 +25,7 @@ pub struct Controller<'a> {
     preprocessor: Option<LessOpenPreprocessor>,
 }
 
-impl<'b> Controller<'b> {
+impl Controller<'_> {
     pub fn new<'a>(config: &'a Config, assets: &'a HighlightingAssets) -> Controller<'a> {
         Controller {
             config,

--- a/src/input.rs
+++ b/src/input.rs
@@ -75,7 +75,7 @@ pub(crate) enum InputKind<'a> {
     CustomReader(Box<dyn Read + 'a>),
 }
 
-impl<'a> InputKind<'a> {
+impl InputKind<'_> {
     pub fn description(&self) -> InputDescription {
         match self {
             InputKind::OrdinaryFile(ref path) => InputDescription::new(path.to_string_lossy()),

--- a/src/lessopen.rs
+++ b/src/lessopen.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "lessopen")]
-
 use std::convert::TryFrom;
 use std::env;
 use std::fs::File;

--- a/src/lessopen.rs
+++ b/src/lessopen.rs
@@ -200,7 +200,7 @@ impl LessOpenPreprocessor {
         })
     }
 
-    fn fall_back_to_original_file(&self, lessopen_stdout: &Vec<u8>, exit_code: ExitStatus) -> bool {
+    fn fall_back_to_original_file(&self, lessopen_stdout: &[u8], exit_code: ExitStatus) -> bool {
         lessopen_stdout.is_empty()
             && (!exit_code.success() || matches!(self.kind, LessOpenKind::PipedIgnoreExitCode))
     }

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -9,8 +9,8 @@ pub struct LineRange {
 impl Default for LineRange {
     fn default() -> LineRange {
         LineRange {
-            lower: usize::min_value(),
-            upper: usize::max_value(),
+            lower: usize::MIN,
+            upper: usize::MAX,
         }
     }
 }
@@ -93,7 +93,7 @@ fn test_parse_full() {
 #[test]
 fn test_parse_partial_min() {
     let range = LineRange::from(":50").expect("Shouldn't fail on test!");
-    assert_eq!(usize::min_value(), range.lower);
+    assert_eq!(usize::MIN, range.lower);
     assert_eq!(50, range.upper);
 }
 
@@ -101,7 +101,7 @@ fn test_parse_partial_min() {
 fn test_parse_partial_max() {
     let range = LineRange::from("40:").expect("Shouldn't fail on test!");
     assert_eq!(40, range.lower);
-    assert_eq!(usize::max_value(), range.upper);
+    assert_eq!(usize::MAX, range.upper);
 }
 
 #[test]
@@ -203,11 +203,7 @@ impl LineRanges {
     }
 
     pub fn from(ranges: Vec<LineRange>) -> LineRanges {
-        let largest_upper_bound = ranges
-            .iter()
-            .map(|r| r.upper)
-            .max()
-            .unwrap_or(usize::max_value());
+        let largest_upper_bound = ranges.iter().map(|r| r.upper).max().unwrap_or(usize::MAX);
         LineRanges {
             ranges,
             largest_upper_bound,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -267,7 +267,7 @@ impl<'a> InteractivePrinter<'a> {
         let is_printing_binary = input
             .reader
             .content_type
-            .map_or(false, |c| c.is_binary() && !config.show_nonprintable);
+            .is_some_and(|c| c.is_binary() && !config.show_nonprintable);
 
         let needs_to_match_syntax = (!is_printing_binary
             || matches!(config.binary, BinaryBehavior::AsText))
@@ -544,7 +544,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
             })?;
 
         if self.config.style_components.grid() {
-            if self.content_type.map_or(false, |c| c.is_text())
+            if self.content_type.is_some_and(|c| c.is_text())
                 || self.config.show_nonprintable
                 || matches!(self.config.binary, BinaryBehavior::AsText)
             {
@@ -559,7 +559,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
 
     fn print_footer(&mut self, handle: &mut OutputHandle, _input: &OpenedInput) -> Result<()> {
         if self.config.style_components.grid()
-            && (self.content_type.map_or(false, |c| c.is_text())
+            && (self.content_type.is_some_and(|c| c.is_text())
                 || self.config.show_nonprintable
                 || matches!(self.config.binary, BinaryBehavior::AsText))
         {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -144,7 +144,7 @@ impl<'a> Printer for SimplePrinter<'a> {
         // Skip squeezed lines.
         if let Some(squeeze_limit) = self.config.squeeze_lines {
             if String::from_utf8_lossy(line_buffer)
-                .trim_end_matches(|c| c == '\r' || c == '\n')
+                .trim_end_matches(['\r', '\n'])
                 .is_empty()
             {
                 self.consecutive_empty_lines += 1;
@@ -644,7 +644,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
 
         // Skip squeezed lines.
         if let Some(squeeze_limit) = self.config.squeeze_lines {
-            if line.trim_end_matches(|c| c == '\r' || c == '\n').is_empty() {
+            if line.trim_end_matches(['\r', '\n']).is_empty() {
                 self.consecutive_empty_lines += 1;
                 if self.consecutive_empty_lines > squeeze_limit {
                     return Ok(());
@@ -697,7 +697,7 @@ impl<'a> Printer for InteractivePrinter<'a> {
                         // Regular text.
                         EscapeSequence::Text(text) => {
                             let text = self.preprocess(text, &mut cursor_total);
-                            let text_trimmed = text.trim_end_matches(|c| c == '\r' || c == '\n');
+                            let text_trimmed = text.trim_end_matches(['\r', '\n']);
 
                             write!(
                                 handle,
@@ -751,10 +751,8 @@ impl<'a> Printer for InteractivePrinter<'a> {
                     match chunk {
                         // Regular text.
                         EscapeSequence::Text(text) => {
-                            let text = self.preprocess(
-                                text.trim_end_matches(|c| c == '\r' || c == '\n'),
-                                &mut cursor_total,
-                            );
+                            let text = self
+                                .preprocess(text.trim_end_matches(['\r', '\n']), &mut cursor_total);
 
                             let mut max_width = cursor_max - cursor;
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -432,7 +432,7 @@ impl<'a> InteractivePrinter<'a> {
             .highlight_line(for_highlighting, highlighter_from_set.syntax_set)?;
 
         if too_long {
-            highlighted_line[0].1 = &line;
+            highlighted_line[0].1 = line;
         }
 
         Ok(highlighted_line)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -73,7 +73,7 @@ pub enum OutputHandle<'a> {
     FmtWrite(&'a mut dyn fmt::Write),
 }
 
-impl<'a> OutputHandle<'a> {
+impl OutputHandle<'_> {
     fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> Result<()> {
         match self {
             Self::IoWrite(handle) => handle.write_fmt(args).map_err(Into::into),
@@ -116,7 +116,7 @@ impl<'a> SimplePrinter<'a> {
     }
 }
 
-impl<'a> Printer for SimplePrinter<'a> {
+impl Printer for SimplePrinter<'_> {
     fn print_header(
         &mut self,
         _handle: &mut OutputHandle,
@@ -448,7 +448,7 @@ impl<'a> InteractivePrinter<'a> {
     }
 }
 
-impl<'a> Printer for InteractivePrinter<'a> {
+impl Printer for InteractivePrinter<'_> {
     fn print_header(
         &mut self,
         handle: &mut OutputHandle,

--- a/src/style.rs
+++ b/src/style.rs
@@ -225,7 +225,7 @@ impl FromStr for StyleComponentList {
     fn from_str(s: &str) -> Result<Self> {
         Ok(StyleComponentList(
             s.split(",")
-                .map(|s| ComponentAction::extract_from_str(s)) // If the component starts with "-", it's meant to be removed
+                .map(ComponentAction::extract_from_str) // If the component starts with "-", it's meant to be removed
                 .map(|(a, s)| Ok((a, StyleComponent::from_str(s)?)))
                 .collect::<Result<Vec<(ComponentAction, StyleComponent)>>>()?,
         ))

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -153,7 +153,7 @@ impl<'a> SyntaxMapping<'a> {
             if glob.is_match_candidate(&candidate)
                 || candidate_filename
                     .as_ref()
-                    .map_or(false, |filename| glob.is_match_candidate(filename))
+                    .is_some_and(|filename| glob.is_match_candidate(filename))
             {
                 return Some(*syntax);
             }

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -61,7 +61,7 @@ pub struct SyntaxMapping<'a> {
     halt_glob_build: Arc<AtomicBool>,
 }
 
-impl<'a> Drop for SyntaxMapping<'a> {
+impl Drop for SyntaxMapping<'_> {
     fn drop(&mut self) {
         // signal the offload thread to halt early
         self.halt_glob_build.store(true, Ordering::Relaxed);

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -383,7 +383,6 @@ mod tests {
                         theme: ThemePreference::Fixed(ThemeName::Named("Theme".to_string())),
                         theme_dark: Some(ThemeName::Named("Dark Theme".to_string())),
                         theme_light: Some(ThemeName::Named("Light Theme".to_string())),
-                        ..Default::default()
                     },
                 ] {
                     let detector = ConstantDetector(color_scheme);

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -509,7 +509,7 @@ mod tests {
                 ThemePreference::Light,
             ];
             for pref in prefs {
-                assert_eq!(pref, ThemePreference::new(&pref.to_string()));
+                assert_eq!(pref, ThemePreference::new(pref.to_string()));
             }
         }
     }

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -539,7 +539,7 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
     }
 }
 
-impl<'a> Iterator for EscapeSequenceOffsetsIterator<'a> {
+impl Iterator for EscapeSequenceOffsetsIterator<'_> {
     type Item = EscapeSequenceOffsets;
     fn next(&mut self) -> Option<Self::Item> {
         match self.chars.peek() {

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -360,10 +360,10 @@ pub struct EscapeSequenceOffsetsIterator<'a> {
 
 impl<'a> EscapeSequenceOffsetsIterator<'a> {
     pub fn new(text: &'a str) -> EscapeSequenceOffsetsIterator<'a> {
-        return EscapeSequenceOffsetsIterator {
+        EscapeSequenceOffsetsIterator {
             text,
             chars: text.char_indices().peekable(),
-        };
+        }
     }
 
     /// Takes values from the iterator while the predicate returns true.
@@ -564,10 +564,10 @@ pub struct EscapeSequenceIterator<'a> {
 
 impl<'a> EscapeSequenceIterator<'a> {
     pub fn new(text: &'a str) -> EscapeSequenceIterator<'a> {
-        return EscapeSequenceIterator {
+        EscapeSequenceIterator {
             text,
             offset_iter: EscapeSequenceOffsetsIterator::new(text),
-        };
+        }
     }
 }
 

--- a/tests/github-actions.rs
+++ b/tests/github-actions.rs
@@ -35,13 +35,7 @@ fn all_jobs_not_missing_any_jobs() {
         .as_mapping()
         .unwrap()
         .keys()
-        .filter_map(|k| {
-            if exceptions.contains(&k.as_str().unwrap_or_default()) {
-                None
-            } else {
-                Some(k)
-            }
-        })
+        .filter(|k| !exceptions.contains(&k.as_str().unwrap_or_default()))
         .map(ToOwned::to_owned)
         .collect::<Vec<_>>();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1832,7 +1832,7 @@ fn do_not_panic_regression_tests() {
     ] {
         bat()
             .arg("--color=always")
-            .arg(&format!("regression_tests/{filename}"))
+            .arg(format!("regression_tests/{filename}"))
             .assert()
             .success();
     }
@@ -1845,7 +1845,7 @@ fn do_not_detect_different_syntax_for_stdin_and_files() {
     let cmd_for_file = bat()
         .arg("--color=always")
         .arg("--map-syntax=*.js:Markdown")
-        .arg(&format!("--file-name={file}"))
+        .arg(format!("--file-name={file}"))
         .arg("--style=plain")
         .arg(file)
         .assert()
@@ -1855,7 +1855,7 @@ fn do_not_detect_different_syntax_for_stdin_and_files() {
         .arg("--color=always")
         .arg("--map-syntax=*.js:Markdown")
         .arg("--style=plain")
-        .arg(&format!("--file-name={file}"))
+        .arg(format!("--file-name={file}"))
         .pipe_stdin(Path::new(EXAMPLES_DIR).join(file))
         .unwrap()
         .assert()
@@ -1874,7 +1874,7 @@ fn no_first_line_fallback_when_mapping_to_invalid_syntax() {
     bat()
         .arg("--color=always")
         .arg("--map-syntax=*.invalid-syntax:InvalidSyntax")
-        .arg(&format!("--file-name={file}"))
+        .arg(format!("--file-name={file}"))
         .arg("--style=plain")
         .arg(file)
         .assert()


### PR DESCRIPTION
Fixes warnings of the following clippy lints (which are warn-by-default):

- `style` lints
  - [clippy::ptr_arg](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg)
  - [clippy::into_iter_on_ref](https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_ref)
  - [clippy::manual_pattern_char_comparison](https://rust-lang.github.io/rust-clippy/master/index.html#manual_pattern_char_comparison)
  - [clippy::legacy_numeric_constants](https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants)
  - [clippy::redundant_closure](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure)
  - [clippy::unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or)
  - [clippy::needless_borrow](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)
  - [clippy::needless_return](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return)
  - [clippy::needless_borrows_for_generic_args](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args)
- `perf` lints
  - [clippy::manual_ignore_case_cmp](https://rust-lang.github.io/rust-clippy/master/index.html#manual_ignore_case_cmp)
- `complexity` lints
  - [clippy::unnecessary_filter_map](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_filter_map)
  - [clippy::needless_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes)
  - [clippy::needless_update](https://rust-lang.github.io/rust-clippy/master/index.html#needless_update)
- `suspicious` lints
  - [clippy::duplicated_attributes](https://rust-lang.github.io/rust-clippy/master/index.html#duplicated_attributes)