### PR TITLE
Always disable paging when listing themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)
 - Prevent `--list-themes` from outputting default theme info to stdout when it is piped, see #3189 (@einfachIrgendwer0815)
 - Rename some submodules to fix Dependabot submodule updates, see issue #3198 and PR #3201 (@victor-gp)
+- - Always disable paging when listing themes, see #3238 (@Sky9x)
 
 ## Other
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -204,6 +204,10 @@ pub fn list_themes(
     style.insert(StyleComponent::Plain);
     config.language = Some("Rust");
     config.style_components = StyleComponents(style);
+    #[cfg(feature = "paging")]
+    {
+        config.paging_mode = bat::PagingMode::Never; // don't page our very short preview file
+    }
 
     let stdout = io::stdout();
     let mut stdout = stdout.lock();


### PR DESCRIPTION
I have `--paging=always` in my `.config/bat/config` which makes `bat --list-themes` very not helpful (without doing `bat --list-themes --no-pager`). This force disables paging when listing themes.