### PR TITLE
Add paging to `--list-themes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Add paging to `--list-themes`, see PR #3239 (@einfachIrgendwer0815)
+
 ## Bugfixes
 
 - Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)

--- a/examples/buffer.rs
+++ b/examples/buffer.rs
@@ -1,4 +1,6 @@
-use bat::{assets::HighlightingAssets, config::Config, controller::Controller, Input};
+use bat::{
+    assets::HighlightingAssets, config::Config, controller::Controller, output::OutputHandle, Input,
+};
 
 fn main() {
     let mut buffer = String::new();
@@ -10,7 +12,10 @@ fn main() {
     let controller = Controller::new(&config, &assets);
     let input = Input::from_file(file!());
     controller
-        .run(vec![input.into()], Some(&mut buffer))
+        .run(
+            vec![input.into()],
+            Some(OutputHandle::FmtWrite(&mut buffer)),
+        )
         .unwrap();
 
     println!("{buffer}");

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -124,7 +124,10 @@ impl App {
                 // If we have -pp as an option when in auto mode, the pager should be disabled.
                 if extra_plain || self.matches.get_flag("no-paging") {
                     PagingMode::Never
-                } else if inputs.iter().any(Input::is_stdin) {
+                } else if inputs.iter().any(Input::is_stdin)
+                    // ignore stdin when --list-themes is used because in that case no input will be read anyways
+                    && !self.matches.get_flag("list-themes")
+                {
                     // If we are reading from stdin, only enable paging if we write to an
                     // interactive terminal and if we do not *read* from an interactive
                     // terminal.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod less;
 mod lessopen;
 pub mod line_range;
 pub(crate) mod nonprintable_notation;
-mod output;
+pub mod output;
 #[cfg(feature = "paging")]
 mod pager;
 #[cfg(feature = "paging")]

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::io::{self, Write};
 #[cfg(feature = "paging")]
 use std::process::Child;
@@ -159,6 +160,20 @@ impl Drop for OutputType {
     fn drop(&mut self) {
         if let OutputType::Pager(ref mut command) = *self {
             let _ = command.wait();
+        }
+    }
+}
+
+pub enum OutputHandle<'a> {
+    IoWrite(&'a mut dyn io::Write),
+    FmtWrite(&'a mut dyn fmt::Write),
+}
+
+impl OutputHandle<'_> {
+    pub fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> Result<()> {
+        match self {
+            Self::IoWrite(handle) => handle.write_fmt(args).map_err(Into::into),
+            Self::FmtWrite(handle) => handle.write_fmt(args).map_err(Into::into),
         }
     }
 }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -10,6 +10,7 @@ use crate::{
     error::Result,
     input,
     line_range::{HighlightedLineRanges, LineRange, LineRanges},
+    output::OutputHandle,
     style::StyleComponent,
     StripAnsiMode, SyntaxMapping, WrappingMode,
 };
@@ -325,7 +326,10 @@ impl<'a> PrettyPrinter<'a> {
 
         // If writer is provided, pass it to the controller, otherwise pass None
         if let Some(mut w) = writer {
-            controller.run(inputs.into_iter().map(|i| i.into()).collect(), Some(&mut w))
+            controller.run(
+                inputs.into_iter().map(|i| i.into()).collect(),
+                Some(OutputHandle::FmtWrite(&mut w)),
+            )
         } else {
             controller.run(inputs.into_iter().map(|i| i.into()).collect(), None)
         }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-use std::io;
 use std::vec::Vec;
 
 use nu_ansi_term::Color::{Fixed, Green, Red, Yellow};
@@ -29,6 +27,7 @@ use crate::diff::LineChanges;
 use crate::error::*;
 use crate::input::OpenedInput;
 use crate::line_range::RangeCheckResult;
+use crate::output::OutputHandle;
 use crate::preprocessor::strip_ansi;
 use crate::preprocessor::{expand_tabs, replace_nonprintable};
 use crate::style::StyleComponent;
@@ -67,20 +66,6 @@ const EMPTY_SYNTECT_STYLE: syntect::highlighting::Style = syntect::highlighting:
     },
     font_style: FontStyle::empty(),
 };
-
-pub enum OutputHandle<'a> {
-    IoWrite(&'a mut dyn io::Write),
-    FmtWrite(&'a mut dyn fmt::Write),
-}
-
-impl OutputHandle<'_> {
-    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> Result<()> {
-        match self {
-            Self::IoWrite(handle) => handle.write_fmt(args).map_err(Into::into),
-            Self::FmtWrite(handle) => handle.write_fmt(args).map_err(Into::into),
-        }
-    }
-}
 
 pub(crate) trait Printer {
     fn print_header(


### PR DESCRIPTION
This allows to use `--list-themes` with paging by passing all theme sample outputs to the pager as a whole.


Alternative to #3238
(Closes #3238)