### PR TITLE
Fix for multibyte characters in file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)
 - Prevent `--list-themes` from outputting default theme info to stdout when it is piped, see #3189 (@einfachIrgendwer0815)
 - Rename some submodules to fix Dependabot submodule updates, see issue #3198 and PR #3201 (@victor-gp)
+- Fix crash for multibyte characters in file path, see #3230 (@HSM95)
 
 ## Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)
 - Prevent `--list-themes` from outputting default theme info to stdout when it is piped, see #3189 (@einfachIrgendwer0815)
 - Rename some submodules to fix Dependabot submodule updates, see issue #3198 and PR #3201 (@victor-gp)
-- Fix crash for multibyte characters in file path, see #3230 (@HSM95)
+- Fix crash for multibyte characters in file path, see issue #3230 and PR #3245 (@HSM95)
 
 ## Other
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "terminal-colorsaurus",
  "thiserror 2.0.11",
  "toml",
+ "unicode-segmentation",
  "unicode-width 0.1.14",
  "wait-timeout",
  "walkdir",
@@ -1677,6 +1678,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ bytesize = { version = "1.3.0" }
 encoding_rs = "0.8.35"
 execute = { version = "0.2.13", optional = true }
 terminal-colorsaurus = "0.4"
+unicode-segmentation = "1.12.0"
 
 [dependencies.git2]
 version = "0.20"

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -17,6 +17,7 @@ use content_inspector::ContentType;
 
 use encoding_rs::{UTF_16BE, UTF_16LE};
 
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthChar;
 
 use crate::assets::{HighlightingAssets, SyntaxReferenceInSet};
@@ -403,14 +404,14 @@ impl<'a> InteractivePrinter<'a> {
         handle: &mut OutputHandle,
         content: &str,
     ) -> Result<()> {
-        let mut content = content;
         let content_width = self.config.term_width - self.get_header_component_indent_length();
-        while content.len() > content_width {
-            let (content_line, remaining) = content.split_at(content_width);
-            self.print_header_component_with_indent(handle, content_line)?;
-            content = remaining;
+        let mut content_graphemes: Vec<&str> = content.graphemes(true).collect();
+        while content_graphemes.len() > content_width {
+            let (content_line, remaining) = content_graphemes.split_at(content_width);
+            self.print_header_component_with_indent(handle, content_line.join("").as_str())?;
+            content_graphemes = remaining.iter().cloned().collect();
         }
-        self.print_header_component_with_indent(handle, content)
+        self.print_header_component_with_indent(handle, content_graphemes.join("").as_str())
     }
 
     fn highlight_regions_for_line<'b>(

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -405,6 +405,10 @@ impl<'a> InteractivePrinter<'a> {
         content: &str,
     ) -> Result<()> {
         let content_width = self.config.term_width - self.get_header_component_indent_length();
+        if content.chars().count() <= content_width {
+            return self.print_header_component_with_indent(handle, content);
+        }
+
         let mut content_graphemes: Vec<&str> = content.graphemes(true).collect();
         while content_graphemes.len() > content_width {
             let (content_line, remaining) = content_graphemes.split_at(content_width);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1601,6 +1601,17 @@ oken
 }
 
 #[test]
+fn header_narrow_terminal_with_multibyte_chars() {
+    bat()
+        .arg("--terminal-width=30")
+        .arg("--decorations=always")
+        .arg("test.A—B가")
+        .assert()
+        .success()
+        .stderr("");
+}
+
+#[test]
 #[cfg(feature = "git")] // Expected output assumes git is enabled
 fn header_default() {
     bat()


### PR DESCRIPTION
Partial fix for #3230.

Bat will no longer crash when multibyte characters are in the file path. However, there may still be misformatting of the header in the output.