### PR TITLE
Make highlight tests fail when new syntaxes don't have fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)
 - Prevent `--list-themes` from outputting default theme info to stdout when it is piped, see #3189 (@einfachIrgendwer0815)
 - Rename some submodules to fix Dependabot submodule updates, see issue #3198 and PR #3201 (@victor-gp)
+- Make highlight tests fail when new syntaxes don't have fixtures PR #3255 (@dan-hipschman)
 
 ## Other
 

--- a/tests/syntax-tests/compare_highlighted_versions.py
+++ b/tests/syntax-tests/compare_highlighted_versions.py
@@ -12,13 +12,15 @@ def compare_highlighted_versions(root_old, root_new):
     print(" -", root_old)
     print(" -", root_new)
     has_changes = False
+    # Used to check for newly added files that don't have a test
+    unknown_files = {strip_root(p) for p in glob.glob(path.join(root_new, "*", "*"))}
+
     for path_old in glob.glob(path.join(root_old, "*", "*")):
-        filename = path.basename(path_old)
-        dirname = path.basename(path.dirname(path_old))
+        rel_path = strip_root(path_old)
+        unknown_files.discard(rel_path)
+        path_new = path.join(root_new, rel_path)
 
-        path_new = path.join(root_new, dirname, filename)
-
-        print("\n========== {}/{}".format(dirname, filename))
+        print("\n========== {}".format(rel_path))
 
         with open(path_old) as file_old:
             lines_old = file_old.readlines()
@@ -39,9 +41,19 @@ def compare_highlighted_versions(root_old, root_new):
             has_changes = True
         else:
             print("No changes")
-    print()
 
+    for f in unknown_files:
+        print("\n========== {}: No fixture for this language, run update.sh".format(f))
+        has_changes = True
+
+    print()
     return has_changes
+
+
+def strip_root(p: str) -> str:
+    filename = path.basename(p)
+    dirname = path.basename(path.dirname(p))
+    return path.join(dirname, filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I stumbled across https://github.com/sharkdp/bat/pull/3236#issuecomment-2746349454 and wanted to fix it.

For more context, a new language was added but the author forgot to run `update.sh` to add a test fixture for it. This should have caused CI to fail, but it passed. The reason is that the highlighting regression test scripts iterate over existing fixtures, and hence don't catch newly added languages that haven't added a fixture.