### PR TITLE
Cargo.toml: Document that MSRV can be bumped if there is a reason for it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.25.0"
 exclude = ["assets/syntaxes/*", "assets/themes/*"]
 build = "build/main.rs"
 edition = '2021'
+# You are free to bump MSRV as soon as a reason for bumping emerges.
 rust-version = "1.74"
 
 [features]


### PR DESCRIPTION
To the best of my knowledge our current MSRV rule is that we can bump MSRV whenever there is a reason for it. Let's document it.

Downstream packagers seem to agree: https://github.com/sharkdp/bat/pull/3216#issuecomment-2781035085
