### PR TITLE
CICD: Stop building for x86_64-pc-windows-gnu which fails

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -173,7 +173,6 @@ jobs:
           - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, dpkg_arch: musl-linux-i686,  use-cross: true }
           - { target: x86_64-apple-darwin         , os: macos-13,                                                  }
           - { target: aarch64-apple-darwin        , os: macos-14,                                                  }
-          - { target: x86_64-pc-windows-gnu       , os: windows-2019,                                              }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019,                                              }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, dpkg_arch: amd64,            use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, dpkg_arch: musl-linux-amd64, use-cross: true }

--- a/.github/workflows/require-changelog-for-PRs.yml
+++ b/.github/workflows/require-changelog-for-PRs.yml
@@ -30,4 +30,4 @@ jobs:
           echo "Added lines in CHANGELOG.md:"
           echo "$ADDED"
           echo "Grepping for PR info (see CONTRIBUTING.md):"
-          grep "#${PR_NUMBER}\\b.*@${PR_SUBMITTER}\\b" <<< "$ADDED"
+          grep "#${PR_NUMBER}\\b.*${PR_SUBMITTER}\\b" <<< "$ADDED"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Other
 
 - Work around build failures when building `bat` from vendored sources #3179 (@dtolnay)
+- CICD: Stop building for x86_64-pc-windows-gnu which fails #3261 (Enselic)
 
 ## Syntaxes
 


### PR DESCRIPTION
Let's not build for platforms that are broken. If someone fixes the build we can of course add it back later.

![image](https://github.com/user-attachments/assets/d1018f05-db9f-464d-9694-a3a78b1fb15a)
