### PR TITLE
Fix syntax highlighting for bash/zsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Prevent `--list-themes` from outputting default theme info to stdout when it is piped, see #3189 (@einfachIrgendwer0815)
 - Rename some submodules to fix Dependabot submodule updates, see issue #3198 and PR #3201 (@victor-gp)
 - Make highlight tests fail when new syntaxes don't have fixtures PR #3255 (@dan-hipschman)
+- Fix bash/zsh file highlighting, see PR #3262 (@AdamGaskins)
 
 ## Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Prevent `--list-themes` from outputting default theme info to stdout when it is piped, see #3189 (@einfachIrgendwer0815)
 - Rename some submodules to fix Dependabot submodule updates, see issue #3198 and PR #3201 (@victor-gp)
 - Make highlight tests fail when new syntaxes don't have fixtures PR #3255 (@dan-hipschman)
-- Fix bash/zsh file highlighting, see PR #3262 (@AdamGaskins)
+- Add missing mappings for various bash/zsh files, see PR #3262 (@AdamGaskins)
 
 ## Other
 

--- a/src/syntax_mapping/builtins/unix-family/50-shell.toml
+++ b/src/syntax_mapping/builtins/unix-family/50-shell.toml
@@ -2,4 +2,24 @@
 "Bourne Again Shell (bash)" = [
     # used by lots of shells
     "/etc/profile",
+
+    "bashrc",
+    "*.bashrc",
+    "bash_profile",
+    "*.bash_profile",
+    "bash_login",
+    "*.bash_login",
+    "bash_logout",
+    "*.bash_logout",
+
+    "zshrc",
+    "*.zshrc",
+    "zprofile",
+    "*.zprofile",
+    "zlogin",
+    "*.zlogin",
+    "zlogout",
+    "*.zlogout",
+    "zshenv",
+    "*.zshenv"
 ]


### PR DESCRIPTION
Fixes #3231, fixes #3145.

Any files named (or with the extensions):
* bashrc
* bash_profile
* bash_login
* bash_logout
* zshrc
* zprofile
* zlogin
* zlogout
* zshenv

Will now be correctly highlighted.

Based off of the recommendation of [this comment](https://github.com/sharkdp/bat/issues/3145#issuecomment-2540502205), but let me know if there's a better way to go about this.