### PR TITLE
fix: switch to fancy regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Make highlight tests fail when new syntaxes don't have fixtures PR #3255 (@dan-hipschman)
 - Fix crash for multibyte characters in file path, see issue #3230 and PR #3245 (@HSM95)
 - Add missing mappings for various bash/zsh files, see PR #3262 (@AdamGaskins)
+- Fix compile errors with `oniguruma` by switching to `fancy-regex`, see #3234 (@perobertson)
 
 ## Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Make highlight tests fail when new syntaxes don't have fixtures PR #3255 (@dan-hipschman)
 - Fix crash for multibyte characters in file path, see issue #3230 and PR #3245 (@HSM95)
 - Add missing mappings for various bash/zsh files, see PR #3262 (@AdamGaskins)
-- Fix compile errors with `oniguruma` by switching to `fancy-regex`, see #3234 (@perobertson)
+- Fix compile errors with `oniguruma` by switching to `fancy-regex`, see issue #3234 and PR #3274 (@perobertson)
 
 ## Other
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ minimal-application = [
     "clap",
     "etcetera",
     "paging",
-    "regex-onig",
+    "regex-fancy",
     "wild",
 ]
 git = ["git2"] # Support indicating git modifications


### PR DESCRIPTION
Related: https://github.com/sharkdp/bat/issues/3234

This switches to using fancy-regex from oniguruma so that the app can compile on more systems.

It also appears that https://github.com/kkos/oniguruma has been archived so it may be some time before the compile errors are fixed with that project or a fork of it.