### PR TITLE
tests/scripts/license-checks.sh: Add MPL exception

### DIFF
--- a/tests/scripts/license-checks.sh
+++ b/tests/scripts/license-checks.sh
@@ -13,7 +13,9 @@ gpl_excludes=(
     # Contains a reference to GPL, but is not under GPL
     ":(exclude)tests/syntax-tests/source/Java Server Page (JSP)/LICENSE.md"
 )
-gpl_occurances=$(git grep --recurse-submodules "${gpl_term}" -- "${gpl_excludes[@]}" || true)
+# The line "means either the GNU General Public License" comes from MPL, and MPL
+# for syntaxes and themes is fine.
+gpl_occurances=$(git grep --recurse-submodules "${gpl_term}" -- "${gpl_excludes[@]}" | grep -v 'means either the GNU General Public License' || true)
 
 if [ -z "${gpl_occurances}" ]; then
     echo "PASS: No files under GPL were found"


### PR DESCRIPTION
Since the MPL license allows us to include syntaxes and themes without relicensing the rest of bat, it seems fine to allow MPL-licensed assets. Do that. (And if someone disagrees we can reverse this decision later.)

This unblocks https://github.com/sharkdp/bat/pull/2848.

Note: No CHANGELOG entry is needed for this particular PR.

Note: This PR might make sense to fold into the above PR. We'll see.

Note: This is untested