### PR TITLE
Update quadlet syntax mapping rules to cover quadlets in subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Add debsources syntax to highlight `/etc/apt/sources.list` files, see #3215 (@keith-hall)
 - Add syntax definition and test file for GDScript highlighting, see #3236 (@chetanjangir0)
 - Add syntax test file for Odin highlighting, see #3241 (@chetanjangir0)
+- Update quadlet syntax mapping rules to cover quadlets in subdirectories #3299 (@cyqsimon)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/linux/50-podman-quadlet.toml
+++ b/src/syntax_mapping/builtins/linux/50-podman-quadlet.toml
@@ -1,7 +1,5 @@
 # see `man quadlet`
 [mappings]
 "INI" = [
-    "**/containers/systemd/*.{container,volume,network,kube,image}",
-    "**/containers/systemd/users/*.{container,volume,network,kube,image}",
-    "**/containers/systemd/users/*/*.{container,volume,network,kube,image}",
+    "**/containers/systemd/**/*.{container,volume,network,kube,image}",
 ]


### PR DESCRIPTION
It's not really documented, but it turns out that quadlet files placed in any subdirectory of the various search paths will be picked up by podman. This PR updates the matching rules accordingly.

To verify:

```bash
cd /etc/containers/systemd/
mkdir test
cat > test/hello.container <<EOF
[Container]
Image=quay.io/podman/hello
EOF
/usr/lib/systemd/system-generators/podman-system-generator -dryrun
```

You should find that `hello.container` is getting picked up, despite this behaviour not being explicitly mentioned in the man page.