### PR TITLE
Fix UTF-8 BOM file type detection for first-line syntax patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Bugfixes
 
+- Fix UTF-8 BOM not being stripped for syntax detection, see #3314 (@krikera)
 - Fix `BAT_THEME_DARK` and `BAT_THEME_LIGHT` being ignored, see issue #3171 and PR #3168 (@bash)
 - Prevent `--list-themes` from outputting default theme info to stdout when it is piped, see #3189 (@einfachIrgendwer0815)
 - Rename some submodules to fix Dependabot submodule updates, see issue #3198 and PR #3201 (@victor-gp)


### PR DESCRIPTION
This fix strips the UTF-8 BOM character from the first line before performing syntax detection using `strip_prefix('\u{feff}')`, ensuring that files with BOM are handled correctly.

## Changes

- Modified `get_first_line_syntax` in `src/assets.rs` to strip BOM before pattern matching
- Added comprehensive test coverage for XML, shell scripts, and PHP files with BOM
- Updated CHANGELOG.md

Fixes #3314