### PR TITLE
Add syntax mapping for Mill build tool files to use Scala syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Add syntax test file for Odin highlighting, see #3241 (@chetanjangir0)
 - Update quadlet syntax mapping rules to cover quadlets in subdirectories #3299 (@cyqsimon)
 - Add syntax Typst #3300 (@cskeeters)
+- Map `.mill` files to Scala syntax for Mill build tool configuration files #3311 (@krikera)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/common/50-mill.toml
+++ b/src/syntax_mapping/builtins/common/50-mill.toml
@@ -1,0 +1,2 @@
+[mappings]
+"Scala" = ["*.mill"]


### PR DESCRIPTION
This change adds syntax mapping for Mill build tool files (`.mill`) to be recognized and highlighted as Scala source files.

## Changes

- Added `50-mill.toml` in `src/syntax_mapping/builtins/common/`
- Mapped `.mill` file extension to use Scala syntax highlighting

Fixes #3311
