### PR TITLE
Send errors to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-- Send all bat errors to stderr by default, see #3336
+- Send all bat errors to stderr by default, see #3336 (@JerryImMouse)
 ## Features
 
 - Add paging to `--list-themes`, see PR #3239 (@einfachIrgendwer0815)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-- Send all bat errors to stderr by default, see #3334
+- Send all bat errors to stderr by default, see #3336
 ## Features
 
 - Add paging to `--list-themes`, see PR #3239 (@einfachIrgendwer0815)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-
+- Send all bat errors to stderr by default, see #3334
 ## Features
 
 - Add paging to `--list-themes`, see PR #3239 (@einfachIrgendwer0815)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-- Send all bat errors to stderr by default, see #3336 (@JerryImMouse)
+
 ## Features
 
 - Add paging to `--list-themes`, see PR #3239 (@einfachIrgendwer0815)
@@ -14,6 +14,7 @@
 - Make highlight tests fail when new syntaxes don't have fixtures PR #3255 (@dan-hipschman)
 - Fix crash for multibyte characters in file path, see issue #3230 and PR #3245 (@HSM95)
 - Add missing mappings for various bash/zsh files, see PR #3262 (@AdamGaskins)
+- Send all bat errors to stderr by default, see #3336 (@JerryImMouse)
 
 ## Other
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,7 +67,7 @@ pub fn default_error_handler(error: &Error, output: &mut dyn Write) {
             .ok();
         }
         _ => {
-            writeln!(output, "{}: {}", Red.paint("[bat error]"), error).ok();
+            writeln!(&mut std::io::stderr().lock(), "{}: {}", Red.paint("[bat error]"), error).ok();
         }
     };
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,7 +67,13 @@ pub fn default_error_handler(error: &Error, output: &mut dyn Write) {
             .ok();
         }
         _ => {
-            writeln!(&mut std::io::stderr().lock(), "{}: {}", Red.paint("[bat error]"), error).ok();
+            writeln!(
+                &mut std::io::stderr().lock(),
+                "{}: {}",
+                Red.paint("[bat error]"),
+                error
+            )
+            .ok();
         }
     };
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -452,6 +452,16 @@ fn stdin_to_stdout_cycle() -> io::Result<()> {
 
 #[cfg(unix)]
 #[test]
+fn bat_error_to_stderr() {
+    bat()
+        .arg("/tmp")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("[bat error]"));
+}
+
+#[cfg(unix)]
+#[test]
 fn no_args_doesnt_break() {
     // To simulate bat getting started from the shell, a process is created with stdin and stdout
     // as the slave end of a pseudo terminal. Although both point to the same "file", bat should


### PR DESCRIPTION
Resolves #2561

I thought how it can be done better. But the most simple solution for now is this.
The best solution in my opinion is dividing default handle for errors and normal output. But this behaviour will require changing a lot of stuff. 
If this is required - I can do it.