### PR TITLE
CICD: replace windows-2019 runners with windows-2025

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -168,12 +168,12 @@ jobs:
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-latest, dpkg_arch: arm64,            use-cross: true }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest, dpkg_arch: armhf,            use-cross: true }
           - { target: arm-unknown-linux-musleabihf, os: ubuntu-latest, dpkg_arch: musl-linux-armhf, use-cross: true }
-          - { target: i686-pc-windows-msvc        , os: windows-2019,                                              }
+          - { target: i686-pc-windows-msvc        , os: windows-2025,                                              }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-latest, dpkg_arch: i686,             use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-latest, dpkg_arch: musl-linux-i686,  use-cross: true }
           - { target: x86_64-apple-darwin         , os: macos-13,                                                  }
           - { target: aarch64-apple-darwin        , os: macos-14,                                                  }
-          - { target: x86_64-pc-windows-msvc      , os: windows-2019,                                              }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2025,                                              }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest, dpkg_arch: amd64,            use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest, dpkg_arch: musl-linux-amd64, use-cross: true }
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Update base16 README links to community driven base16 work #2871 (@JamyGolden)
 - Work around build failures when building `bat` from vendored sources #3179 (@dtolnay)
 - CICD: Stop building for x86_64-pc-windows-gnu which fails #3261 (Enselic)
+- CICD:  CICD: replace windows-2019 runners with windows-2025 #3339 (@cyqsimon)
 
 ## Syntaxes
 


### PR DESCRIPTION
CI runs are failing due to `windows-2019` runners being no longer available ([example](https://github.com/sharkdp/bat/actions/runs/16134652467/job/45528489069)). This PR migrates to `windows-2025` runners.

See https://github.com/actions/runner-images/issues/12045