### PR TITLE
Update terminal-colorsaurus to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Build script: replace string-based codegen with quote-based codegen #3340 (@cyqsimon)
 - Improve code coverage of `--list-languages` parameter #2942 (@sblondon)
 - Only start offload worker thread when there's more than 1 core #2956 (@cyqsimon)
+- Update terminal-colorsaurus (the library used for dark/light detection) to 1.0, see #3347 (@bash)
 
 ## Syntaxes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "terminal-colorsaurus"
-version = "0.4.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858625398bdd5da7a96e8ad33a10031a50c3a5ad50d5aaa81a2827369a9c216c"
+checksum = "3f7226dad4b1817567c1e2f5d453897ef36abe79def7783af3fa241a694e30b3"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1546,13 +1546,14 @@ dependencies = [
  "mio",
  "terminal-trx",
  "windows-sys 0.59.0",
+ "xterm-color",
 ]
 
 [[package]]
 name = "terminal-trx"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a5b836e7f4f81afe61b5cd399eee774f25edcfd47009a76e29f53bb6487833"
+checksum = "975b4233aefa1b02456d5e53b22c61653c743e308c51cf4181191d8ce41753ab"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2039,6 +2040,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xterm-color"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de5f056fb9dc8b7908754867544e26145767187aaac5a98495e88ad7cb8a80f"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ walkdir = { version = "2.5", optional = true }
 bytesize = { version = "1.3.0" }
 encoding_rs = "0.8.35"
 execute = { version = "0.2.13", optional = true }
-terminal-colorsaurus = "0.4"
+terminal-colorsaurus = "1.0"
 unicode-segmentation = "1.12.0"
 itertools = "0.13.0"
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -266,10 +266,10 @@ impl ColorSchemeDetector for TerminalColorSchemeDetector {
     }
 
     fn detect(&self) -> Option<ColorScheme> {
-        use terminal_colorsaurus::{color_scheme, ColorScheme as ColorsaurusScheme, QueryOptions};
-        match color_scheme(QueryOptions::default()).ok()? {
-            ColorsaurusScheme::Dark => Some(ColorScheme::Dark),
-            ColorsaurusScheme::Light => Some(ColorScheme::Light),
+        use terminal_colorsaurus::{theme_mode, QueryOptions, ThemeMode};
+        match theme_mode(QueryOptions::default()).ok()? {
+            ThemeMode::Dark => Some(ColorScheme::Dark),
+            ThemeMode::Light => Some(ColorScheme::Light),
         }
     }
 }


### PR DESCRIPTION
I have finally released version 1.0 of terminal-colorsaurus yesterday 🥳 
There are no behavior changes, only some minor API revisions :)