### PR TITLE
Add --wrap=word option for word wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add paging to `--list-themes`, see PR #3239 (@einfachIrgendwer0815)
 - Support negative relative line ranges, e.g. `bat -r :-10` / `bat -r='-10:'`, see #3068 (@ajesipow)
+- Add `--wrap=word` option for word wrapping to improve readability of markdown files, see #3324 (@krikera)
 
 ## Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add paging to `--list-themes`, see PR #3239 (@einfachIrgendwer0815)
 - Support negative relative line ranges, e.g. `bat -r :-10` / `bat -r='-10:'`, see #3068 (@ajesipow)
-- Add `--wrap=word` option for word wrapping to improve readability of markdown files, see #3324 (@krikera)
+- Add `--wrap=word` option for word wrapping to improve readability of markdown files, see #3352 (@krikera)
 
 ## Bugfixes
 

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -27,7 +27,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--file-name', 'file-name', [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
             [CompletionResult]::new('--diff-context', 'diff-context', [CompletionResultType]::ParameterName, 'diff-context')
             [CompletionResult]::new('--tabs', 'tabs', [CompletionResultType]::ParameterName, 'Set the tab width to T spaces.')
-            [CompletionResult]::new('--wrap', 'wrap', [CompletionResultType]::ParameterName, 'Specify the text-wrapping mode (*auto*, never, character).')
+            [CompletionResult]::new('--wrap', 'wrap', [CompletionResultType]::ParameterName, 'Specify the text-wrapping mode (*auto*, never, character, word).')
             [CompletionResult]::new('--terminal-width', 'terminal-width', [CompletionResultType]::ParameterName, 'Explicitly set the width of the terminal instead of determining it automatically. If prefixed with ''+'' or ''-'', the value will be treated as an offset to the actual terminal width. See also: ''--wrap''.')
             [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'When to use colors (*auto*, never, always).')
             [CompletionResult]::new('--italic-text', 'italic-text', [CompletionResultType]::ParameterName, 'Use italics in output (always, *never*)')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -97,7 +97,7 @@ _bat() {
 		return 0
 		;;
 	--wrap)
-		COMPREPLY=($(compgen -W "auto never character" -- "$cur"))
+		COMPREPLY=($(compgen -W "auto never character word" -- "$cur"))
 		return 0
 		;;
 	--color | --decorations | --paging)

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -117,6 +117,7 @@ set -l wrap_opts '
     auto\tdefault
     never\t
     character\t
+    word\twrap\ at\ word\ boundaries
 '
 
 # While --tabs theoretically takes any number, most people should be OK with these.

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -33,7 +33,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'
         --diff-context='[specify lines of context around added/removed/modified lines when using `--diff`]:lines'
         --tabs='[set the tab width]:tab width [4]'
-        --wrap='[specify the text-wrapping mode]:mode [auto]:(auto never character)'
+                --wrap='[specify the text-wrapping mode]:mode [auto]:(auto never character word)'
         '!(--wrap)'{-S,--chop-long-lines}
         --terminal-width='[explicitly set the width of the terminal instead of determining it automatically]:width'
         '(-n --number --diff --diff-context)'{-n,--number}'[show line numbers]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -84,7 +84,7 @@ Set the tab width to T spaces. Use a width of 0 to pass tabs through directly
 .HP
 \fB\-\-wrap\fR <mode>
 .IP
-Specify the text\-wrapping mode (*auto*, never, character). The '\-\-terminal\-width' option
+Specify the text\-wrapping mode (*auto*, never, character, word). The '\-\-terminal\-width' option
 can be used in addition to control the output width.
 .HP
 \fB\-S\fR, \fB\-\-chop\-long\-lines\fR

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -61,8 +61,8 @@ Options:
           Set the tab width to T spaces. Use a width of 0 to pass tabs through directly
 
       --wrap <mode>
-          Specify the text-wrapping mode (*auto*, never, character). The '--terminal-width' option
-          can be used in addition to control the output width.
+          Specify the text-wrapping mode (*auto*, never, character, word). The '--terminal-width'
+          option can be used in addition to control the output width.
 
   -S, --chop-long-lines
           Truncate all lines longer than screen width. Alias for '--wrap=never'.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -26,7 +26,7 @@ Options:
       --tabs <T>
           Set the tab width to T spaces.
       --wrap <mode>
-          Specify the text-wrapping mode (*auto*, never, character).
+          Specify the text-wrapping mode (*auto*, never, character, word).
   -S, --chop-long-lines
           Truncate all lines longer than screen width. Alias for '--wrap=never'.
   -n, --number

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -227,6 +227,7 @@ impl App {
                 if !self.matches.get_flag("chop-long-lines") {
                     match self.matches.get_one::<String>("wrap").map(|s| s.as_str()) {
                         Some("character") => WrappingMode::Character,
+                        Some("word") => WrappingMode::Word,
                         Some("never") => WrappingMode::NoWrapping(true),
                         Some("auto") | None => {
                             if style_components.plain() {
@@ -261,7 +262,10 @@ impl App {
                     .get_one::<String>("decorations")
                     .map(|s| s.as_str())
                     == Some("always")
-                || self.matches.get_flag("force-colorization")),
+                || self.matches.get_flag("force-colorization")
+                || maybe_term_width.is_some()  // Use InteractivePrinter when terminal width is explicitly set
+                || matches!(self.matches.get_one::<String>("wrap").map(|s| s.as_str()), 
+                           Some("word") | Some("character"))), // Use InteractivePrinter for explicit wrapping modes
             tab_width: self
                 .matches
                 .get_one::<String>("tabs")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -211,11 +211,11 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long("wrap")
                 .overrides_with("wrap")
                 .value_name("mode")
-                .value_parser(["auto", "never", "character"])
+                .value_parser(["auto", "never", "character", "word"])
                 .default_value("auto")
                 .hide_default_value(true)
-                .help("Specify the text-wrapping mode (*auto*, never, character).")
-                .long_help("Specify the text-wrapping mode (*auto*, never, character). \
+                .help("Specify the text-wrapping mode (*auto*, never, character, word).")
+                .long_help("Specify the text-wrapping mode (*auto*, never, character, word). \
                            The '--terminal-width' option can be used in addition to \
                            control the output width."),
         )

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WrappingMode {
     Character,
+    Word,
     // The bool specifies whether wrapping has been explicitly disabled by the user via --wrap=never
     NoWrapping(bool),
 }

--- a/tests/examples/long-word-line.txt
+++ b/tests/examples/long-word-line.txt
@@ -1,0 +1,1 @@
+word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12 word13 word14

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2298,6 +2298,38 @@ fn no_wrapping_with_chop_long_lines() {
 }
 
 #[test]
+fn word_wrapping() {
+    // Test word wrapping vs character wrapping with a line that contains words
+    bat()
+        .arg("--wrap=word")
+        .arg("--style=plain")
+        .arg("--color=never")
+        .arg("--decorations=never")
+        .arg("--terminal-width=25")
+        .arg("long-word-line.txt")
+        .assert()
+        .success()
+        .stdout("word1 word2 word3 word4\nword5 word6 word7 word8\nword9 word10 word11\nword12 word13 word14\n")
+        .stderr("");
+}
+
+#[test]
+fn character_wrapping() {
+    // Test character wrapping with the same content for comparison
+    bat()
+        .arg("--wrap=character")
+        .arg("--style=plain")
+        .arg("--color=never")
+        .arg("--decorations=never")
+        .arg("--terminal-width=25")
+        .arg("long-word-line.txt")
+        .assert()
+        .success()
+        .stdout("word1 word2 word3 word4 w\nord5 word6 word7 word8 wo\nrd9 word10 word11 word12 \nword13 word14\n")
+        .stderr("");
+}
+
+#[test]
 fn theme_arg_overrides_env() {
     bat()
         .env("BAT_THEME", "TwoDark")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2330,6 +2330,21 @@ fn character_wrapping() {
 }
 
 #[test]
+fn word_wrapping_with_decorations() {
+    // Test word wrapping with decorations (line numbers) enabled
+    bat()
+        .arg("--wrap=word")
+        .arg("--number")
+        .arg("--color=never")
+        .arg("--terminal-width=35")
+        .arg("long-word-line.txt")
+        .assert()
+        .success()
+        .stdout("   1 word1 word2 word3 word4 word5\n     word6 word7 word8 word9\n     word10 word11 word12 word13\n     word14\n")
+        .stderr("");
+}
+
+#[test]
 fn theme_arg_overrides_env() {
     bat()
         .env("BAT_THEME", "TwoDark")


### PR DESCRIPTION
Implements word wrapping functionality that splits text at word boundaries instead of character boundaries, improving readability especially for markdown files.

Changes:
- Add WrappingMode::Word enum variant
- Update clap argument parser to accept 'word' as wrap mode
- Implement word wrapping logic in InteractivePrinter
- Fix printer selection to use InteractivePrinter for explicit wrap modes
- Add comprehensive tests for word vs character wrapping
- Update documentation, help text, and shell completions
- Add changelog entry

Fixes #3324