### PR TITLE
Make batdiff more portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ You can combine `bat` with `git diff` to view lines around code changes with pro
 highlighting:
 ```bash
 batdiff() {
-    git diff --name-only --relative --diff-filter=d -z | xargs --null bat --diff
+    git diff --name-only --relative --diff-filter=d -z | xargs -0 bat --diff
 }
 ```
 If you prefer to use this as a separate tool, check out `batdiff` in [`bat-extras`](https://github.com/eth-p/bat-extras).

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -163,7 +163,7 @@ git show v0.6.0:src/main.rs | bat -l rs
 볼 수 있습니다:
 ```bash
 batdiff() {
-    git diff --name-only --diff-filter=d -z | xargs --null bat --diff
+    git diff --name-only --relative --diff-filter=d -z | xargs -0 bat --diff
 }
 ```
 이것을 별도의 도구로 쓰고 싶다면

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -145,7 +145,7 @@ git show v0.6.0:src/main.rs | bat -l rs
 Вы можете использовать `bat` с `git diff` для просмотра строк кода вокруг изменений с подсветкой синтаксиса:
 ```bash
 batdiff() {
-    git diff --name-only --relative --diff-filter=d | xargs bat --diff
+    git diff --name-only --relative --diff-filter=d -z | xargs -0 bat --diff
 }
 ```
 Если вы хотите использовать это как отдельную программу, посмотрите `batdiff` из [`bat-extras`](https://github.com/eth-p/bat-extras).

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -150,7 +150,7 @@ git show v0.6.0:src/main.rs | bat -l rs
 
 ```bash
 batdiff() {
-    git diff --name-only --diff-filter=d -z | xargs --null bat --diff
+    git diff --name-only --relative --diff-filter=d -z | xargs -0 bat --diff
 }
 ```
 


### PR DESCRIPTION
- Use `-0` instead of `--null` for xargs to work on most systems (e.g., `--null` doesn't work on macOS and OpenBSD);
- Add missing `--relative` and `-z` options for git diff.