### PR TITLE
Mapping .kshrc to bash for syntax highlighting #3361

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Add syntax mapping for certbot certificate configuration #3338 (@cyqsimon)
 - Update Lean syntax from Lean 3 to Lean 4 #3322 (@YDX-2147483647)
 - Map `.flatpakref` and `.flatpakrepo` files to INI syntax #3353 (@Ferenc-)
+- Add syntax highlighting support for .kshrc files using Bash syntax, see #3361  (@ritoban23)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/unix-family/50-korn-shell.toml
+++ b/src/syntax_mapping/builtins/unix-family/50-korn-shell.toml
@@ -1,3 +1,6 @@
 # KornShell is backward-compatible with the Bourne shell #2633
 [mappings]
-"Bourne Again Shell (bash)" = ["*.ksh"]
+"Bourne Again Shell (bash)" = [
+    "*.ksh",
+    "*.kshrc" 
+]


### PR DESCRIPTION
## Summary

This PR adds support for syntax highlighting of `.kshrc` files by mapping them to the Bash highlighter in `bat`.

---

## ✅ Changes Made

- Updated `50-korn-shell.toml` to include `.kshrc` 
- Rebuilt syntax assets using `bash assets/create.sh`
- Added a changelog entry for clarity and tracking

---

## 🔬 Verification

- ✅ All tests passed and code builds successfully (`cargo test`)
- ✅ Verified highlighting with a sample `.kshrc` file

---
