### PR TITLE
Update ps1 completion

### DIFF
--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -2,96 +2,194 @@
 using namespace System.Management.Automation
 using namespace System.Management.Automation.Language
 
-Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
+Register-ArgumentCompleter -Native -CommandName 'bat' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
+
+    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
+    $ArrayCompletion = @('bash', 'fish', 'zsh', 'ps1')
+    $ArrayWhen       = @('auto', 'never', 'always')
+    $ArrayYesNo      = @('never', 'always')
+    $ArrayWrap       = @('always', 'never', 'character')
+    $ArrayBinary     = @('no-printing', 'as-text')
+    $ArrayPrint      = @('unicode', 'caret')
+
+    function Get-MyThemes(){
+        $themes = bat --list-themes | ForEach-Object {$_  -replace "^(.*)$", '''$1'''} | select-object
+        return $themes
+    }
+
+    function Get-MyLanguages(){
+        $themes = bat --list-languages | ForEach-Object{[pscustomobject]@{MyParameter=$_.Substring(0,$_.IndexOf(":")).Trim();MyDescription=$_.Substring($_.IndexOf(":")+1)}} | select-object
+        return $themes
+    }
+    
 
     $commandElements = $commandAst.CommandElements
     $command = @(
-        '{{PROJECT_EXECUTABLE}}'
+        'bat'
         for ($i = 1; $i -lt $commandElements.Count; $i++) {
             $element = $commandElements[$i]
             if ($element -isnot [StringConstantExpressionAst] -or
                 $element.StringConstantType -ne [StringConstantType]::BareWord -or
-                $element.Value.StartsWith('-')) {
+                $element.Value -eq $wordToComplete) {
+                #-or $element.Value.StartsWith('-')
                 break
         }
         $element.Value
     }) -join ';'
 
-    $completions = @(switch ($command) {
-        '{{PROJECT_EXECUTABLE}}' {
-            [CompletionResult]::new('-l', 'l', [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
-            [CompletionResult]::new('--language', 'language', [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
-            [CompletionResult]::new('-H', 'H', [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
-            [CompletionResult]::new('--highlight-line', 'highlight-line', [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
-            [CompletionResult]::new('--file-name', 'file-name', [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
-            [CompletionResult]::new('--diff-context', 'diff-context', [CompletionResultType]::ParameterName, 'diff-context')
-            [CompletionResult]::new('--tabs', 'tabs', [CompletionResultType]::ParameterName, 'Set the tab width to T spaces.')
-            [CompletionResult]::new('--wrap', 'wrap', [CompletionResultType]::ParameterName, 'Specify the text-wrapping mode (*auto*, never, character).')
-            [CompletionResult]::new('--terminal-width', 'terminal-width', [CompletionResultType]::ParameterName, 'Explicitly set the width of the terminal instead of determining it automatically. If prefixed with ''+'' or ''-'', the value will be treated as an offset to the actual terminal width. See also: ''--wrap''.')
-            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'When to use colors (*auto*, never, always).')
-            [CompletionResult]::new('--italic-text', 'italic-text', [CompletionResultType]::ParameterName, 'Use italics in output (always, *never*)')
-            [CompletionResult]::new('--decorations', 'decorations', [CompletionResultType]::ParameterName, 'When to show the decorations (*auto*, never, always).')
-            [CompletionResult]::new('--paging', 'paging', [CompletionResultType]::ParameterName, 'Specify when to use the pager, or use `-P` to disable (*auto*, never, always).')
-            [CompletionResult]::new('--pager', 'pager', [CompletionResultType]::ParameterName, 'Determine which pager to use.')
-            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
-            [CompletionResult]::new('--map-syntax', 'map-syntax', [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
-            [CompletionResult]::new('--theme', 'theme', [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
-            [CompletionResult]::new('--theme-dark', 'theme', [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
-            [CompletionResult]::new('--theme-light', 'theme', [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
-            [CompletionResult]::new('--style', 'style', [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
-            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
-            [CompletionResult]::new('--line-range', 'line-range', [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
-            [CompletionResult]::new('-A', 'A', [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')
-            [CompletionResult]::new('--show-all', 'show-all', [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')
-            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Show plain style (alias for ''--style=plain'').')
-            [CompletionResult]::new('--plain', 'plain', [CompletionResultType]::ParameterName, 'Show plain style (alias for ''--style=plain'').')
-            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Only show lines that have been added/removed/modified.')
-            [CompletionResult]::new('--diff', 'diff', [CompletionResultType]::ParameterName, 'Only show lines that have been added/removed/modified.')
-            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Show line numbers (alias for ''--style=numbers'').')
-            [CompletionResult]::new('--number', 'number', [CompletionResultType]::ParameterName, 'Show line numbers (alias for ''--style=numbers'').')
-            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'f')
-            [CompletionResult]::new('--force-colorization', 'force-colorization', [CompletionResultType]::ParameterName, 'force-colorization')
-            [CompletionResult]::new('-P', 'P', [CompletionResultType]::ParameterName, 'Alias for ''--paging=never''')
-            [CompletionResult]::new('--no-paging', 'no-paging', [CompletionResultType]::ParameterName, 'Alias for ''--paging=never''')
-            [CompletionResult]::new('--list-themes', 'list-themes', [CompletionResultType]::ParameterName, 'Display all supported highlighting themes.')
-            [CompletionResult]::new('-L', 'L', [CompletionResultType]::ParameterName, 'Display all supported languages.')
-            [CompletionResult]::new('--list-languages', 'list-languages', [CompletionResultType]::ParameterName, 'Display all supported languages.')
-            [CompletionResult]::new('-u', 'u', [CompletionResultType]::ParameterName, 'u')
-            [CompletionResult]::new('--unbuffered', 'unbuffered', [CompletionResultType]::ParameterName, 'unbuffered')
-            [CompletionResult]::new('--no-config', 'no-config', [CompletionResultType]::ParameterName, 'Do not use the configuration file')
-            [CompletionResult]::new('--no-custom-assets', 'no-custom-assets', [CompletionResultType]::ParameterName, 'Do not load custom assets')
-            [CompletionResult]::new('--lessopen', 'lessopen', [CompletionResultType]::ParameterName, 'Enable the $LESSOPEN preprocessor')
-            [CompletionResult]::new('--no-lessopen', 'no-lessopen', [CompletionResultType]::ParameterName, 'Disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)')
-            [CompletionResult]::new('--config-file', 'config-file', [CompletionResultType]::ParameterName, 'Show path to the configuration file.')
-            [CompletionResult]::new('--generate-config-file', 'generate-config-file', [CompletionResultType]::ParameterName, 'Generates a default configuration file.')
-            [CompletionResult]::new('--config-dir', 'config-dir', [CompletionResultType]::ParameterName, 'Show bat''s configuration directory.')
-            [CompletionResult]::new('--cache-dir', 'cache-dir', [CompletionResultType]::ParameterName, 'Show bat''s cache directory.')
-            [CompletionResult]::new('--diagnostic', 'diagnostic', [CompletionResultType]::ParameterName, 'Show diagnostic information for bug reports.')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print this help message.')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print this help message.')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Show version information.')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Show version information.')
-            ## Completion of the 'cache' command itself is removed for better UX
-            ## See https://github.com/sharkdp/bat/issues/2085#issuecomment-1271646802
+    $completions = @(switch -Wildcard ($command) {
+        '*;--help' {
             break
         }
-        '{{PROJECT_EXECUTABLE}};cache' {
-            [CompletionResult]::new('--source', 'source', [CompletionResultType]::ParameterName, 'Use a different directory to load syntaxes and themes from.')
-            [CompletionResult]::new('--target', 'target', [CompletionResultType]::ParameterName, 'Use a different directory to store the cached syntax and theme set.')
-            [CompletionResult]::new('-b', 'b', [CompletionResultType]::ParameterName, 'Initialize (or update) the syntax/theme cache.')
-            [CompletionResult]::new('--build', 'build', [CompletionResultType]::ParameterName, 'Initialize (or update) the syntax/theme cache.')
-            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Remove the cached syntax definitions and themes.')
-            [CompletionResult]::new('--clear', 'clear', [CompletionResultType]::ParameterName, 'Remove the cached syntax definitions and themes.')
-            [CompletionResult]::new('--blank', 'blank', [CompletionResultType]::ParameterName, 'Create completely new syntax and theme sets (instead of appending to the default sets).')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+        '*;--version' {
+            break
+        }
+        '*;--acknowledgements' {
+            break
+        }'*;--language' {
+            Get-MyLanguages |
+            ForEach-Object {[CompletionResult]::new(($_.MyParameter -replace "^(.*)$", '''$1'''), $_.MyParameter, [CompletionResultType]::ParameterName, $_.MyDescription ?? '_no value_')}
+            break
+        }
+        '*;--theme' {
+            Get-MyThemes |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterName, $_)}
+            break
+        }
+        '*;--binary' {
+            $ArrayBinary |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }'*;--style' {
+            $ArrayStyle |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--wrap' {
+            $ArrayWrap |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--color' {
+            $ArrayStyle |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--italic-text' {
+            $ArrayYesNo |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--paging' {
+            $ArrayWhen |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--decorations' {
+            $ArrayWhen |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--completion' {
+            $ArrayCompletion |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--strip-ansi' {
+            $ArrayWhen |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--nonprintable-notation' {
+            $ArrayPrint |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
+        '*;--generate-config-file' {
+            break
+        }
+        'bat;cache' {
+            [CompletionResult]::new('--source'                , 'source'                , [CompletionResultType]::ParameterName, 'Use a different directory to load syntaxes and themes from.')
+            [CompletionResult]::new('--target'                , 'target'                , [CompletionResultType]::ParameterName, 'Use a different directory to store the cached syntax and theme set.')
+        #   [CompletionResult]::new('-b'                      , 'b'                     , [CompletionResultType]::ParameterName, 'Initialize (or update) the syntax/theme cache.')
+            [CompletionResult]::new('--build'                 , 'build'                 , [CompletionResultType]::ParameterName, 'Initialize (or update) the syntax/theme cache.')
+        #   [CompletionResult]::new('-c'                      , 'c'                     , [CompletionResultType]::ParameterName, 'Remove the cached syntax definitions and themes.')
+            [CompletionResult]::new('--clear'                 , 'clear'                 , [CompletionResultType]::ParameterName, 'Remove the cached syntax definitions and themes.')
+            [CompletionResult]::new('--blank'                 , 'blank'                 , [CompletionResultType]::ParameterName, 'Create completely new syntax and theme sets (instead of appending to the default sets).')
+        #   [CompletionResult]::new('-h'                      , 'h'                     , [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('--help'                  , 'help'                  , [CompletionResultType]::ParameterName, 'Prints help information')
+        #   [CompletionResult]::new('-V'                      , 'V'                     , [CompletionResultType]::ParameterName, 'Prints version information')
+        #   [CompletionResult]::new('--version'               , 'version'               , [CompletionResultType]::ParameterName, 'Prints version information')
+            break
+        }
+        default {
+        #   [CompletionResult]::new('-l'                      , 'l'                     , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
+            [CompletionResult]::new('--language'              , 'language'              , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
+        #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+            [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+            [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
+            [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')
+            [CompletionResult]::new('--tabs'                  , 'tabs'                  , [CompletionResultType]::ParameterName, 'Set the tab width to T spaces.')
+            [CompletionResult]::new('--wrap'                  , 'wrap'                  , [CompletionResultType]::ParameterName, 'Specify the text-wrapping mode (*auto*, character).')
+            [CompletionResult]::new('--terminal-width'        , 'terminal-width'        , [CompletionResultType]::ParameterName, 'Explicitly set the width of the terminal instead of determining it automatically. If prefixed with ''+'' or ''-'', the value will be treated as an offset to the actual terminal width. See also: ''--wrap''.')
+            [CompletionResult]::new('--color'                 , 'color'                 , [CompletionResultType]::ParameterName, 'When to use colors (*auto*, never, always).')
+            [CompletionResult]::new('--italic-text'           , 'italic-text'           , [CompletionResultType]::ParameterName, 'Use italics in output (always, *never*)')
+            [CompletionResult]::new('--decorations'           , 'decorations'           , [CompletionResultType]::ParameterName, 'When to show the decorations (*auto*, never, always).')
+            [CompletionResult]::new('--paging'                , 'paging'                , [CompletionResultType]::ParameterName, 'Specify when to use the pager, or use ''-P'' to disable (*auto*, never, always).')
+            [CompletionResult]::new('--pager'                 , 'pager'                 , [CompletionResultType]::ParameterName, 'Determine which pager to use.')
+        #   [CompletionResult]::new('-m'                      , 'm'                     , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
+            [CompletionResult]::new('--map-syntax'            , 'map-syntax'            , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
+            [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
+            [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
+            [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
+            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+        #   [CompletionResult]::new('-r'                      , 'r'                     , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
+            [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
+        #   [CompletionResult]::new('-A'                      , 'A'                     , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')
+            [CompletionResult]::new('--show-all'              , 'show-all'              , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')
+            [CompletionResult]::new('--nonprintable-notation' , 'nonprintable-notation' , [CompletionResultType]::ParameterName, 'Set notation for non-printable characters. (unicode, caret)')
+            [CompletionResult]::new('--chop-long-lines'       , 'chop-long-lines'       , [CompletionResultType]::ParameterName, 'Truncate all lines longer than screen width. Alias for ''--wrap=never''.')
+            [CompletionResult]::new('--binary'                , 'binary'                , [CompletionResultType]::ParameterName, 'How to treat binary content. (*no-printing*, as-text)')
+            [CompletionResult]::new('--ignored-suffix'        , 'ignored-suffix'        , [CompletionResultType]::ParameterName, 'Ignore extension. For example: ''bat --ignored-suffix ".dev" my_file.json.dev'' will use JSON syntax, and ignore ''.dev''')
+            [CompletionResult]::new('--squeeze-blank'         , 'squeeze-blank'         , [CompletionResultType]::ParameterName, 'Squeeze consecutive empty lines into a single empty line.')
+            [CompletionResult]::new('--squeeze-limit'         , 'squeeze-limit'         , [CompletionResultType]::ParameterName, 'Set the maximum number of consecutive empty lines to be printed.')
+            [CompletionResult]::new('--strip-ansi'            , 'strip-ansi'            , [CompletionResultType]::ParameterName, 'Specify when to strip ANSI escape sequences from the input. The automatic mode will remove escape sequences unless the syntax highlighting language is plain text. (auto, always, *never*).')
+        #   [CompletionResult]::new('-p'                      , 'p'                     , [CompletionResultType]::ParameterName, 'Show plain style (alias for ''--style=plain'').')
+            [CompletionResult]::new('--plain'                 , 'plain'                 , [CompletionResultType]::ParameterName, 'Show plain style (alias for ''--style=plain'').')
+        #   [CompletionResult]::new('-d'                      , 'd'                     , [CompletionResultType]::ParameterName, 'Only show lines that have been added/removed/modified.')
+            [CompletionResult]::new('--diff'                  , 'diff'                  , [CompletionResultType]::ParameterName, 'Only show lines that have been added/removed/modified.')
+        #   [CompletionResult]::new('-n'                      , 'n'                     , [CompletionResultType]::ParameterName, 'Show line numbers (alias for ''--style=numbers'').')
+            [CompletionResult]::new('--number'                , 'number'                , [CompletionResultType]::ParameterName, 'Show line numbers (alias for ''--style=numbers'').')
+        #   [CompletionResult]::new('-f'                      , 'f'                     , [CompletionResultType]::ParameterName, 'f')
+            [CompletionResult]::new('--force-colorization'    , 'force-colorization'    , [CompletionResultType]::ParameterName, 'force-colorization')
+        #   [CompletionResult]::new('-P'                      , 'P'                     , [CompletionResultType]::ParameterName, 'Alias for ''--paging=never''')
+            [CompletionResult]::new('--no-paging'             , 'no-paging'             , [CompletionResultType]::ParameterName, 'Alias for ''--paging=never''')
+            [CompletionResult]::new('--list-themes'           , 'list-themes'           , [CompletionResultType]::ParameterName, 'Display all supported highlighting themes.')
+        #   [CompletionResult]::new('-L'                      , 'L'                     , [CompletionResultType]::ParameterName, 'Display all supported languages.')
+            [CompletionResult]::new('--list-languages'        , 'list-languages'        , [CompletionResultType]::ParameterName, 'Display all supported languages.')
+        #   [CompletionResult]::new('-u'                      , 'u'                     , [CompletionResultType]::ParameterName, 'u')
+            [CompletionResult]::new('--unbuffered'            , 'unbuffered'            , [CompletionResultType]::ParameterName, 'unbuffered')
+            [CompletionResult]::new('--completion'            , 'completion'            , [CompletionResultType]::ParameterName, 'Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]')
+            [CompletionResult]::new('--no-config'             , 'no-config'             , [CompletionResultType]::ParameterName, 'Do not use the configuration file')
+            [CompletionResult]::new('--no-custom-assets'      , 'no-custom-assets'      , [CompletionResultType]::ParameterName, 'Do not load custom assets')
+            [CompletionResult]::new('--lessopen'              , 'lessopen'              , [CompletionResultType]::ParameterName, 'Enable the $LESSOPEN preprocessor')
+            [CompletionResult]::new('--no-lessopen'           , 'no-lessopen'           , [CompletionResultType]::ParameterName, 'Disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)')
+            [CompletionResult]::new('--config-file'           , 'config-file'           , [CompletionResultType]::ParameterName, 'Show path to the configuration file.')
+            [CompletionResult]::new('--generate-config-file'  , 'generate-config-file'  , [CompletionResultType]::ParameterName, 'Generates a default configuration file.')
+            [CompletionResult]::new('--config-dir'            , 'config-dir'            , [CompletionResultType]::ParameterName, 'Show bat''s configuration directory.')
+            [CompletionResult]::new('--cache-dir'             , 'cache-dir'             , [CompletionResultType]::ParameterName, 'Show bat''s cache directory.')
+            [CompletionResult]::new('--acknowledgements'      , 'acknowledgements'      , [CompletionResultType]::ParameterName, 'Show acknowledgements.')
+            [CompletionResult]::new('--set-terminal-title'    , 'set-terminal-title'    , [CompletionResultType]::ParameterName, 'Sets terminal title to filenames when using a pager.')
+            [CompletionResult]::new('--diagnostic'            , 'diagnostic'            , [CompletionResultType]::ParameterName, 'Show diagnostic information for bug reports.')
+        #   [CompletionResult]::new('-h'                      , 'h'                     , [CompletionResultType]::ParameterName, 'Print this help message.')
+            [CompletionResult]::new('--help'                  , 'help'                  , [CompletionResultType]::ParameterName, 'Print this help message.')
+        #   [CompletionResult]::new('-V'                      , 'V'                     , [CompletionResultType]::ParameterName, 'Show version information.')
+            [CompletionResult]::new('--version'               , 'version'               , [CompletionResultType]::ParameterName, 'Show version information.')
             break
         }
     })
 
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
-        Sort-Object -Property ListItemText
+        Sort-Object -Property CompletionText
 }

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -14,25 +14,24 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
     $ArrayPrint      = @('unicode', 'caret')
 
     function Get-MyThemes(){
-        $themes = bat --list-themes | ForEach-Object {$_  -replace "^(.*)$", '''$1'''} | select-object
+        $themes = {{PROJECT_EXECUTABLE}} --list-themes | ForEach-Object {$_  -replace "^(.*)$", '''$1'''} | select-object
         return $themes
     }
 
     function Get-MyLanguages(){
-        $themes = bat --list-languages | ForEach-Object{[pscustomobject]@{MyParameter=$_.Substring(0,$_.IndexOf(":")).Trim();MyDescription=$_.Substring($_.IndexOf(":")+1)}} | select-object
+        $themes = {{PROJECT_EXECUTABLE}} --list-languages | ForEach-Object{[pscustomobject]@{MyParameter=$_.Substring(0,$_.IndexOf(":")).Trim();MyDescription=$_.Substring($_.IndexOf(":")+1)}} | select-object
         return $themes
     }
-    
 
     $commandElements = $commandAst.CommandElements
     $command = @(
-        'bat'
+        '{{PROJECT_EXECUTABLE}}'
         for ($i = 1; $i -lt $commandElements.Count; $i++) {
             $element = $commandElements[$i]
             if ($element -isnot [StringConstantExpressionAst] -or
                 $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                #$element.Value.StartsWith('-') -or
                 $element.Value -eq $wordToComplete) {
-                #-or $element.Value.StartsWith('-')
                 break
         }
         $element.Value
@@ -47,7 +46,8 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         }
         '*;--acknowledgements' {
             break
-        } '*;--language' {
+        }
+        '*;--language' {
             Get-MyLanguages |
             ForEach-Object {[CompletionResult]::new(($_.MyParameter -replace "^(.*)$", '''$1'''), $_.MyParameter, [CompletionResultType]::ParameterName, $_.MyDescription ?? '_no value_')}
             break
@@ -61,7 +61,8 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             $ArrayBinary |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
             break
-        } '*;--style' {
+        }
+        '*;--style' {
             $ArrayStyle |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
             break
@@ -109,7 +110,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         '*;--generate-config-file' {
             break
         }
-        'bat;cache' {
+        '{{PROJECT_EXECUTABLE}};cache' {
             [CompletionResult]::new('--source'                , 'source'                , [CompletionResultType]::ParameterName, 'Use a different directory to load syntaxes and themes from.')
             [CompletionResult]::new('--target'                , 'target'                , [CompletionResultType]::ParameterName, 'Use a different directory to store the cached syntax and theme set.')
         #   [CompletionResult]::new('-b'                      , 'b'                     , [CompletionResultType]::ParameterName, 'Initialize (or update) the syntax/theme cache.')

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -47,7 +47,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         }
         '*;--acknowledgements' {
             break
-        }'*;--language' {
+        } '*;--language' {
             Get-MyLanguages |
             ForEach-Object {[CompletionResult]::new(($_.MyParameter -replace "^(.*)$", '''$1'''), $_.MyParameter, [CompletionResultType]::ParameterName, $_.MyDescription ?? '_no value_')}
             break

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -61,7 +61,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             $ArrayBinary |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
             break
-        }'*;--style' {
+        } '*;--style' {
             $ArrayStyle |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
             break

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -72,7 +72,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             break
         }
         '*;--color' {
-            $ArrayStyle |
+            $ArrayWhen |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
             break
         }

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -2,7 +2,7 @@
 using namespace System.Management.Automation
 using namespace System.Management.Automation.Language
 
-Register-ArgumentCompleter -Native -CommandName 'bat' -ScriptBlock {
+Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
     $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')


### PR DESCRIPTION
Hi all,

Made an update to the default completion for ps1

1. Removed shortcut entries
Code completion, in powershell, should be more descriptive. 
2. Added completions with individual values for
** Language
** Theme
** Other argument with options

Works with Powershell Core 7