### PR TITLE
Add x86_64 Assembly to x86 sublime syntax file

### DIFF
--- a/assets/syntaxes/02_Extra/Assembly (x86_64).sublime-syntax
+++ b/assets/syntaxes/02_Extra/Assembly (x86_64).sublime-syntax
@@ -1,5 +1,6 @@
 %YAML 1.2
 ---
+name: x86_64 Assembly
 file_extensions: [yasm, nasm, asm, inc, mac]
 scope: source.asm.x86_64
 

--- a/assets/syntaxes/02_Extra/Assembly (x86_64).sublime-syntax
+++ b/assets/syntaxes/02_Extra/Assembly (x86_64).sublime-syntax
@@ -1365,4 +1365,3 @@ contexts:
       scope: invalid.keyword.operator.word.mnemonic.sse5.packed-arithmetic
     - match: '(?i)\b(pcmov|permp[ds]|pperm|prot[bdqw]|psh[al][bdqw])\b'
       scope: invalid.keyword.operator.word.mnemonic.sse5.simd-integer
-...


### PR DESCRIPTION
* Using ARM Assembly with the bat library works with .language("ARM Assembly"), while x86 has no name. Add name to sublime syntax file.