### PR TITLE
Fix ctrl-c fails in powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,8 +674,8 @@ The `-F` option instructs `less` to exit immediately if the output size is small
 the vertical size of the terminal. This is convenient for small files because you do not
 have to press `q` to quit the pager.
 
-The `-K` option instructs `less` to exit immediately when an interrupt character is received.
-This is useful to ensure that `less` quits together with `bat` on interrupt characters.
+The `-K` option instructs `less` to exit immediately when an interrupt signal is received.
+This is useful to ensure that `less` quits together with `bat` on SIGINT.
 
 The `-X` option is needed to fix a bug with the `--quit-if-one-screen` feature in versions
 of `less` older than version 530. Unfortunately, it also breaks mouse-wheel support in `less`.

--- a/src/output.rs
+++ b/src/output.rs
@@ -94,7 +94,7 @@ impl OutputType {
                 }
 
                 // Ensures that 'less' quits together with 'bat'
-                p.arg("-K"); // Sort version of ' --quit-on-intr'
+                p.arg("-K"); // Short version of '--quit-on-intr'
 
                 // Passing '--no-init' fixes a bug with '--quit-if-one-screen' in older
                 // versions of 'less'. Unfortunately, it also breaks mouse-wheel support.


### PR DESCRIPTION
Fixes #3229

Ensures that the pager `less` is closed when `ctrl-c` is received.

The current behaviour is that pressing `ctrl-c` terminates `bat`.
This causes an issue on Windows with PowerShell, where the subprocess for `less` is not terminated correctly.
As a result 'less' tries to write to the terminal, which breaks the terminal.

The extra argument `-K` ensures that `less` terminates along with `bat`.
