### PR TITLE
dependabot: Stop updating submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,6 @@ updates:
   - dependency-name: git2
     versions:
     - 0.13.17
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "04:00"
-    timezone: Europe/Berlin
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
I personally find dependabot updating submodules to be more annoying than helpful. It is better to let humans do when someone comes around that has an actual problem to solve.

This will make it easier to keep the PR inbox trimmed.