### PR TITLE
🌟 (assets/themes/Vacme): add new theme Vacme to the project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -278,3 +278,6 @@
 [submodule "assets/syntaxes/02_Extra/hosts"]
 	path = assets/syntaxes/02_Extra/hosts
 	url = https://github.com/tijn/hosts.tmLanguage
+[submodule "assets/themes/Vacme"]
+	path = assets/themes/Vacme
+	url = git@github.com:newptcai/vacme-for-bat.git


### PR DESCRIPTION
This PR adds the **Vacme** color theme for bat.

* Introduced as a new submodule under `assets/themes/Vacme`
* Ships one `.tmTheme` file (`Vacme.tmTheme`)
* Licensed under **MIT** (see `LICENSE` in theme repo)
* Includes README with screenshots and installation instructions

Vacme is a light theme originally designed for [[kitty](https://sw.kovidgoyal.net/kitty/)](https://sw.kovidgoyal.net/kitty/) and now ported to bat. It provides a softer, higher-contrast alternative to Solarized Light.

I’ve tested locally with:

```bash
bat cache --build
bat --list-themes
```

and confirmed the colors render correctly.