### PR TITLE
Add go.mod and go.sum Syntax Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -278,3 +278,6 @@
 [submodule "assets/syntaxes/02_Extra/hosts"]
 	path = assets/syntaxes/02_Extra/hosts
 	url = https://github.com/tijn/hosts.tmLanguage
+[submodule "assets/syntaxes/02_Extra/Gomod"]
+	path = assets/syntaxes/02_Extra/Gomod
+	url = https://github.com/mitranim/sublime-gomod

--- a/tests/syntax-tests/highlighted/Go/go.mod
+++ b/tests/syntax-tests/highlighted/Go/go.mod
@@ -1,0 +1,5 @@
+[38;2;248;248;242mmodule hugeparam[0m
+
+[38;2;248;248;242mgo 1.25.1[0m
+
+[38;2;248;248;242mrequire golang.org/x/tools v0.37.0[0m

--- a/tests/syntax-tests/highlighted/Go/go.sum
+++ b/tests/syntax-tests/highlighted/Go/go.sum
@@ -1,0 +1,6 @@
+[38;2;248;248;242mgolang.org/x/mod v0.28.0 h1:gQBtGhjxykdjY9YhZpSlZIsbnaE2+PgjfLWUQTnoZ1U=[0m
+[38;2;248;248;242mgolang.org/x/mod v0.28.0/go.mod h1:yfB/L0NOf/kmEbXjzCPOx1iK1fRutOydrCMsqRhEBxI=[0m
+[38;2;248;248;242mgolang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=[0m
+[38;2;248;248;242mgolang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=[0m
+[38;2;248;248;242mgolang.org/x/tools v0.37.0 h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=[0m
+[38;2;248;248;242mgolang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=[0m

--- a/tests/syntax-tests/source/Go/go.mod
+++ b/tests/syntax-tests/source/Go/go.mod
@@ -1,0 +1,5 @@
+module hugeparam
+
+go 1.25.1
+
+require golang.org/x/tools v0.37.0

--- a/tests/syntax-tests/source/Go/go.sum
+++ b/tests/syntax-tests/source/Go/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/mod v0.28.0 h1:gQBtGhjxykdjY9YhZpSlZIsbnaE2+PgjfLWUQTnoZ1U=
+golang.org/x/mod v0.28.0/go.mod h1:yfB/L0NOf/kmEbXjzCPOx1iK1fRutOydrCMsqRhEBxI=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/tools v0.37.0 h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=
+golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=


### PR DESCRIPTION
closes #3271 

This PR adds a new submodule for Go module(`go.mod` and `go.sum` files) syntax definitions (located at `assets/syntaxes/02_Extra/Gomod`).

It also includes tests for syntax highlighting.

