### PR TITLE
Add RPMSpec support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Map `.kshrc` files to Bash syntax #3364 (@ritoban23)
 - Map `/var/log/dmesg` files to Syslog syntax #3412 (@keith-hall)
 - Add syntax definition and test file for Go modules(`go.mod` and `go.sum`) highlighting, see #3424 (@DarkMatter-999)
+- Add syntax definition and test file for RPM Spec(`*.spec`) highlighting, see #3431 (@DarkMatter-999)
 
 ## Themes
 

--- a/assets/syntaxes/02_Extra/RPMSpec.sublime-syntax
+++ b/assets/syntaxes/02_Extra/RPMSpec.sublime-syntax
@@ -1,0 +1,66 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/syntax.html
+name: RPM Spec
+file_extensions:
+  - spec
+scope: source.spec
+contexts:
+  main:
+    - match: '(Icon|ExclusiveOs|ExcludeOs):'
+      scope: keyword.spec
+    - match: '(BuildArch|BuildArchitectures|ExclusiveArch|ExcludeArch):'
+      captures:
+        0: keyword.spec
+      push:
+        - match: $
+          pop: true
+        - include: archs
+        - match: '[^\s,]+'
+          scope: invalid.spec
+    - match: '(Conflicts|Obsoletes|Provides|Requires|Requires\(.*\)|Enhances|Suggests|BuildConflicts|BuildRequires|Recommends|PreReq|Supplements):'
+      scope: keyword.spec
+    - match: '(Epoch|Serial|Nosource|Nopatch):'
+      scope: keyword.spec
+    - match: '(AutoReq|AutoProv|AutoReqProv):'
+      scope: keyword.spec
+    - match: '(Copyright|License|Summary|Summary\(.*\)|Distribution|Vendor|Packager|Group|Source\d*|Patch\d*|BuildRoot|Prefix):'
+      scope: keyword.spec
+    - match: '(Name|Version|Release|Url|URL):'
+      scope: keyword.spec
+    - match: ^(Source|Patch)
+      push:
+        - meta_scope: keyword.spec
+        - match: ':'
+          pop: true
+    - match: '^# norootforbuild'
+      scope: keyword.spec
+    - match: '%(ifarch|ifnarch)'
+      captures:
+        0: keyword.control.spec
+      push:
+        - match: $
+          pop: true
+        - include: archs
+        - match: '[^\s,]+'
+          scope: invalid.spec
+    - match: ^%(changelog|check$|description|files|package)
+      scope: keyword.control.spec
+    - match: ^(%(prep$|build$|install$|clean$|(pre|post)(un|trans)?|trigger(in|un|postun)|verifyscript))
+      scope: keyword.control.spec
+    - match: '%(if|else|endif|define|global|undefine|ifos|ifnos)'
+      scope: keyword.control.spec
+    - match: '%\{'
+      push:
+        - meta_scope: variable.other.spec
+        - match: '\}'
+          pop: true
+    - match: '%([A-Za-z0-9_]+)'
+      scope: variable.other.spec
+    - match: ^\s*#.*$
+      scope: comment.line.spec
+    - match: ^\* .*\)$
+      scope: meta.documentation.spec
+  archs:
+    - match: \b(i386|i486|i586|i686|athlon|ia64|alpha|alphaev5|alphaev56|alphapca56|alphaev6|alphaev67|sparc|sparcv9|sparc64armv3l|armv4b|armv4lm|ips|mipsel|ppc|ppc|iseries|ppcpseries|ppc64|m68k|m68kmint|Sgi|rs6000|i370|s390x|s390|noarch)\b
+      scope: constant.other

--- a/tests/syntax-tests/highlighted/RPMSpec/bat.spec
+++ b/tests/syntax-tests/highlighted/RPMSpec/bat.spec
@@ -1,0 +1,104 @@
+[38;2;117;113;94m#[0m
+[38;2;117;113;94m# spec file for package bat[0m
+[38;2;117;113;94m#[0m
+[38;2;117;113;94m# Copyright (c) 2025 SUSE LLC[0m
+[38;2;117;113;94m#[0m
+[38;2;117;113;94m# All modifications and additions to the file contributed by third parties[0m
+[38;2;117;113;94m# remain the property of their copyright owners, unless otherwise agreed[0m
+[38;2;117;113;94m# upon. The license for this file, and modifications and additions to the[0m
+[38;2;117;113;94m# file, is the same license as for the pristine package itself (unless the[0m
+[38;2;117;113;94m# license for the pristine package is not an Open Source License, in which[0m
+[38;2;117;113;94m# case the license is the MIT License). An "Open Source License" is a[0m
+[38;2;117;113;94m# license that conforms to the Open Source Definition (Version 1.9)[0m
+[38;2;117;113;94m# published by the Open Source Initiative.[0m
+
+[38;2;117;113;94m# Please submit bugfixes or comments via https://bugs.opensuse.org/[0m
+[38;2;117;113;94m#[0m
+
+
+[38;2;249;38;114mName:[0m[38;2;248;248;242m           bat[0m
+[38;2;249;38;114mVersion:[0m[38;2;248;248;242m        0.25.0[0m
+[38;2;249;38;114mRelease:[0m[38;2;248;248;242m        0[0m
+[38;2;249;38;114mSummary:[0m[38;2;248;248;242m        A cat(1) clone with syntax highlighting and Git integration[0m
+[38;2;249;38;114mLicense:[0m[38;2;248;248;242m        Apache-2.0 OR MIT[0m
+[38;2;249;38;114mGroup:[0m[38;2;248;248;242m          Productivity/Text/Utilities[0m
+[38;2;249;38;114mURL:[0m[38;2;248;248;242m            https://github.com/sharkdp/bat[0m
+[38;2;249;38;114mSource0:[0m[38;2;248;248;242m        [0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m-[0m[38;2;255;255;255m%{version}[0m[38;2;248;248;242m.tar.xz[0m
+[38;2;249;38;114mSource1:[0m[38;2;248;248;242m        vendor.tar.xz[0m
+[38;2;249;38;114mBuildRequires:[0m[38;2;248;248;242m  cargo-packaging[0m
+[38;2;117;113;94m# weak-dep-features introduced in 1.60 and already used by libgit2-sys[0m
+[38;2;117;113;94m# https://github.com/rust-lang/git2-rs/commit/d8ee105a8f3ce4d5c57cd091b67943aab86b176a[0m
+[38;2;249;38;114mBuildRequires:[0m[38;2;248;248;242m  rust >= 1.60[0m
+[38;2;249;38;114mExclusiveArch:[0m[38;2;248;248;242m  [0m[38;2;248;248;240m%{rust_arches}[0m
+
+[38;2;249;38;114m%description[0m
+[38;2;248;248;242mA cat(1) clone which supports syntax highlighting for a large number of[0m
+[38;2;248;248;242mprogramming and markup languages. It has git integration and automatic paging.[0m
+
+[38;2;249;38;114m%package[0m[38;2;248;248;242m bash-completion[0m
+[38;2;249;38;114mSummary:[0m[38;2;248;248;242m        Bash completion for [0m[38;2;255;255;255m%{name}[0m
+[38;2;249;38;114mRequires:[0m[38;2;248;248;242m       [0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m = [0m[38;2;255;255;255m%{version}[0m
+[38;2;249;38;114mSupplements:[0m[38;2;248;248;242m    ([0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m and bash-completion)[0m
+[38;2;249;38;114mBuildArch:[0m[38;2;248;248;242m      [0m[38;2;190;132;255mnoarch[0m
+
+[38;2;249;38;114m%description[0m[38;2;248;248;242m bash-completion[0m
+[38;2;248;248;242mBash command line completion support for [0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.[0m
+
+[38;2;249;38;114m%package[0m[38;2;248;248;242m fish-completion[0m
+[38;2;249;38;114mSummary:[0m[38;2;248;248;242m        Fish completion for [0m[38;2;255;255;255m%{name}[0m
+[38;2;249;38;114mRequires:[0m[38;2;248;248;242m       [0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m = [0m[38;2;255;255;255m%{version}[0m
+[38;2;249;38;114mSupplements:[0m[38;2;248;248;242m    ([0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m and fish)[0m
+[38;2;249;38;114mBuildArch:[0m[38;2;248;248;242m      [0m[38;2;190;132;255mnoarch[0m
+
+[38;2;249;38;114m%description[0m[38;2;248;248;242m fish-completion[0m
+[38;2;248;248;242mFish command line completion support for [0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.[0m
+
+[38;2;249;38;114m%package[0m[38;2;248;248;242m zsh-completion[0m
+[38;2;249;38;114mSummary:[0m[38;2;248;248;242m        Zsh completion for [0m[38;2;255;255;255m%{name}[0m
+[38;2;249;38;114mRequires:[0m[38;2;248;248;242m       [0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m = [0m[38;2;255;255;255m%{version}[0m
+[38;2;249;38;114mSupplements:[0m[38;2;248;248;242m    ([0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m and zsh)[0m
+[38;2;249;38;114mBuildArch:[0m[38;2;248;248;242m      [0m[38;2;190;132;255mnoarch[0m
+
+[38;2;249;38;114m%description[0m[38;2;248;248;242m zsh-completion[0m
+[38;2;248;248;242mZsh command line completion support for [0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.[0m
+
+[38;2;249;38;114m%prep[0m
+[38;2;255;255;255m%setup[0m[38;2;248;248;242m -qa1[0m
+
+[38;2;249;38;114m%build[0m
+[38;2;255;255;255m%{cargo_build}[0m
+
+[38;2;249;38;114m%install[0m
+[38;2;248;248;242minstall -D -m 0755 target/release/[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m [0m[38;2;255;255;255m%{buildroot}[0m[38;2;255;255;255m%{_bindir}[0m[38;2;248;248;242m/[0m[38;2;255;255;255m%{name}[0m
+
+[38;2;248;248;242minstall -D -m 0644 $(find target/release/build -name "[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.1") "[0m[38;2;255;255;255m%{buildroot}[0m[38;2;248;248;242m/[0m[38;2;255;255;255m%{_mandir}[0m[38;2;248;248;242m/man1/[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.1"[0m
+
+[38;2;248;248;242minstall -D -m 0644 $(find target/release/build -name "[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.bash") "[0m[38;2;255;255;255m%{buildroot}[0m[38;2;248;248;242m/[0m[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/bash-completion/completions/[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m"[0m
+[38;2;248;248;242minstall -D -m 0644 $(find target/release/build -name "[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.fish") "[0m[38;2;255;255;255m%{buildroot}[0m[38;2;248;248;242m/[0m[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/fish/vendor_completions.d/[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.fish"[0m
+[38;2;248;248;242minstall -D -m 0644 $(find target/release/build -name "[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.zsh")  "[0m[38;2;255;255;255m%{buildroot}[0m[38;2;248;248;242m/[0m[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/zsh/site-functions/_[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m"[0m
+
+[38;2;249;38;114m%if[0m[38;2;248;248;242m [0m[38;2;255;255;255m%{with check}[0m
+[38;2;249;38;114m%check[0m
+[38;2;255;255;255m%{cargo_test}[0m
+[38;2;249;38;114m%endif[0m
+
+[38;2;249;38;114m%files[0m
+[38;2;255;255;255m%doc[0m[38;2;248;248;242m README.md CONTRIBUTING.md CHANGELOG.md[0m
+[38;2;255;255;255m%license[0m[38;2;248;248;242m LICENSE-MIT LICENSE-APACHE[0m
+[38;2;255;255;255m%{_bindir}[0m[38;2;248;248;242m/[0m[38;2;255;255;255m%{name}[0m
+[38;2;255;255;255m%{_mandir}[0m[38;2;248;248;242m/man1/[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.1[0m[38;2;255;255;255m%{ext_man}[0m
+
+[38;2;249;38;114m%files[0m[38;2;248;248;242m bash-completion[0m
+[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/bash-completion/completions/[0m[38;2;255;255;255m%{name}[0m
+
+[38;2;249;38;114m%files[0m[38;2;248;248;242m fish-completion[0m
+[38;2;255;255;255m%dir[0m[38;2;248;248;242m [0m[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/fish[0m
+[38;2;255;255;255m%dir[0m[38;2;248;248;242m [0m[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/fish/vendor_completions.d[0m
+[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/fish/vendor_completions.d/[0m[38;2;255;255;255m%{name}[0m[38;2;248;248;242m.fish[0m
+
+[38;2;249;38;114m%files[0m[38;2;248;248;242m zsh-completion[0m
+[38;2;255;255;255m%dir[0m[38;2;248;248;242m [0m[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/zsh[0m
+[38;2;255;255;255m%dir[0m[38;2;248;248;242m [0m[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/zsh/site-functions[0m
+[38;2;255;255;255m%{_datadir}[0m[38;2;248;248;242m/zsh/site-functions/_[0m[38;2;255;255;255m%{name}[0m
+
+[38;2;249;38;114m%changelog[0m

--- a/tests/syntax-tests/source/RPMSpec/bat.spec
+++ b/tests/syntax-tests/source/RPMSpec/bat.spec
@@ -1,0 +1,104 @@
+#
+# spec file for package bat
+#
+# Copyright (c) 2025 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:           bat
+Version:        0.25.0
+Release:        0
+Summary:        A cat(1) clone with syntax highlighting and Git integration
+License:        Apache-2.0 OR MIT
+Group:          Productivity/Text/Utilities
+URL:            https://github.com/sharkdp/bat
+Source0:        %{name}-%{version}.tar.xz
+Source1:        vendor.tar.xz
+BuildRequires:  cargo-packaging
+# weak-dep-features introduced in 1.60 and already used by libgit2-sys
+# https://github.com/rust-lang/git2-rs/commit/d8ee105a8f3ce4d5c57cd091b67943aab86b176a
+BuildRequires:  rust >= 1.60
+ExclusiveArch:  %{rust_arches}
+
+%description
+A cat(1) clone which supports syntax highlighting for a large number of
+programming and markup languages. It has git integration and automatic paging.
+
+%package bash-completion
+Summary:        Bash completion for %{name}
+Requires:       %{name} = %{version}
+Supplements:    (%{name} and bash-completion)
+BuildArch:      noarch
+
+%description bash-completion
+Bash command line completion support for %{name}.
+
+%package fish-completion
+Summary:        Fish completion for %{name}
+Requires:       %{name} = %{version}
+Supplements:    (%{name} and fish)
+BuildArch:      noarch
+
+%description fish-completion
+Fish command line completion support for %{name}.
+
+%package zsh-completion
+Summary:        Zsh completion for %{name}
+Requires:       %{name} = %{version}
+Supplements:    (%{name} and zsh)
+BuildArch:      noarch
+
+%description zsh-completion
+Zsh command line completion support for %{name}.
+
+%prep
+%setup -qa1
+
+%build
+%{cargo_build}
+
+%install
+install -D -m 0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
+
+install -D -m 0644 $(find target/release/build -name "%{name}.1") "%{buildroot}/%{_mandir}/man1/%{name}.1"
+
+install -D -m 0644 $(find target/release/build -name "%{name}.bash") "%{buildroot}/%{_datadir}/bash-completion/completions/%{name}"
+install -D -m 0644 $(find target/release/build -name "%{name}.fish") "%{buildroot}/%{_datadir}/fish/vendor_completions.d/%{name}.fish"
+install -D -m 0644 $(find target/release/build -name "%{name}.zsh")  "%{buildroot}/%{_datadir}/zsh/site-functions/_%{name}"
+
+%if %{with check}
+%check
+%{cargo_test}
+%endif
+
+%files
+%doc README.md CONTRIBUTING.md CHANGELOG.md
+%license LICENSE-MIT LICENSE-APACHE
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1%{ext_man}
+
+%files bash-completion
+%{_datadir}/bash-completion/completions/%{name}
+
+%files fish-completion
+%dir %{_datadir}/fish
+%dir %{_datadir}/fish/vendor_completions.d
+%{_datadir}/fish/vendor_completions.d/%{name}.fish
+
+%files zsh-completion
+%dir %{_datadir}/zsh
+%dir %{_datadir}/zsh/site-functions
+%{_datadir}/zsh/site-functions/_%{name}
+
+%changelog


### PR DESCRIPTION
closes #2605 
supersedes #2931 

This PR adds syntax definitions for RPM `.spec` files (located at assets/syntaxes/02_Extra/RPMSpec.sublime-syntax).

It also includes tests for syntax highlighting.

ref: https://github.com/dreadatour/RPMSpec