### PR TITLE
fix: allow hyphen values to `-r`/`--line-range`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Bugfixes
 
+- Fix negative values of N not being parsed in <N:M> line ranges without `=` flag value separator, see #3442 (@lmmx)
+
 ## Other
 
 ## Syntaxes

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -194,6 +194,7 @@ Options:
             '--line-range :40' prints lines 1 to 40
             '--line-range 40:' prints lines 40 to the end of the file
             '--line-range 40' only prints line 40
+            '--line-range -10:' prints the last 10 lines
             '--line-range 30:+10' prints lines 30 to 40
             '--line-range 35::5' prints lines 30 to 40 (line 35 with 5 lines of context)
             '--line-range 30:40:2' prints lines 28 to 42 (range 30-40 with 2 lines of context)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -519,6 +519,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .short('r')
                 .action(ArgAction::Append)
                 .value_name("N:M")
+                .allow_hyphen_values(true)
                 .help("Only print the lines from N to M.")
                 .long_help(
                     "Only print the specified range of lines for each file. \
@@ -527,6 +528,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                      '--line-range :40' prints lines 1 to 40\n  \
                      '--line-range 40:' prints lines 40 to the end of the file\n  \
                      '--line-range 40' only prints line 40\n  \
+                     '--line-range -10:' prints the last 10 lines\n  \
                      '--line-range 30:+10' prints lines 30 to 40\n  \
                      '--line-range 35::5' prints lines 30 to 40 (line 35 with 5 lines of context)\n  \
                      '--line-range 30:40:2' prints lines 28 to 42 (range 30-40 with 2 lines of context)",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -207,10 +207,21 @@ fn line_range_from_back_last_two() {
 }
 
 #[test]
-fn line_range_from_back_last_two_single_line() {
+fn line_range_from_back_last_two_single_line_eq_sep() {
     bat()
         .arg("single-line.txt")
         .arg("--line-range=-2:")
+        .assert()
+        .success()
+        .stdout("Single Line");
+}
+
+#[test]
+fn line_range_from_back_last_two_single_line_no_sep() {
+    bat()
+        .arg("single-line.txt")
+        .arg("--line-range")
+        .arg("-2:")
         .assert()
         .success()
         .stdout("Single Line");


### PR DESCRIPTION
- via #2944

This PR adds `.allow_leading_hyphen(true)` to the line range argument parser to support the `-r -10:` syntax (with space-separated arguments).

While the functionality for negative line ranges was already implemented to satisfy #2944, the argument parser wasn't configured to accept them when passed as separate arguments like `-r -10:`. The `=` syntax (`-r=-10:` and `--line-range=-10:`) worked fine, which is why the existing tests didn't catch this: they all use the equals format.

This change allows both formats to work as expected. Added tests using the space-separated syntax via `.arg("-r").arg("-10:")` to cover this case.

- [x] Tests
  - [x] Case where `-r` and `-2:` are passed separately (matching an existing `=`-separated test case)
- [x] Docs: `docs/long-help.txt`
  - Let’s add 1 example of using negative N `-r -10:` to the help text
  - <strike>Simple docstring edit to say both/neither can be negative?</strike> No need to change short help https://github.com/sharkdp/bat/blob/c734087e1d15fb730d7653389c841fd9e3016556/doc/short-help.txt#L57-L58
- [x] Changelog entry
    `- Fix negative values of N not being parsed in <N:M> line ranges without `=` flag value separator, see #3442 (@lmmx)`

## Demo

Before:

```sh
louis 🚶 ~/dev/bat $ echo -e "hello\nworld" | bat -r -1:
error: unexpected argument '-1' found

  tip: to pass '-1' as a value, use '-- -1'

Usage: bat [OPTIONS] [FILE]...
       bat <COMMAND>

For more information, try '--help'.
```

After:

```sh
louis 🚶 ~/dev/bat $ echo -e "hello\nworld" | ./target/debug/bat -r -1: | cat
world
```

**Status:** :shipit: Ready to merge