### PR TITLE
fix: prevent Ctrl+C from killing bat when paging without `-K`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Bugfixes
 
 - Fix negative values of N not being parsed in <N:M> line ranges without `=` flag value separator, see #3442 (@lmmx)
+- Ignore SIGINT during paging to fix bug where less exited without `-K` arg, see issue #3444 and PR #3447 (@lmmx)
 
 ## Other
 - Improve README documentation on pager options passed to less, see #3443 (@injust)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "shell-words",
+ "signal-hook",
  "syn",
  "syntect",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ execute = { version = "0.2.13", optional = true }
 terminal-colorsaurus = "1.0"
 unicode-segmentation = "1.12.0"
 itertools = "0.14.0"
+signal-hook = "0.3.18"
 
 [dependencies.git2]
 version = "0.20"


### PR DESCRIPTION
- Fixes #3444 

## Bug

When `BAT_PAGER='less -R'` is set (without `-K`), pressing Ctrl-C still exits `less` immediately instead of canceling the current operation and staying open. This happens because bat receives SIGINT and begins teardown, which causes `less` to lose access to the TTY and exit with EIO.

## Solution
Use `signal-hook` to temporarily ignore SIGINT in bat while the pager is active. This allows `less` to handle Ctrl-C independently. When the pager exits, the signal handler is automatically restored via RAII.

Specifically I registered a dummy flag that's never checked. This prevents the default SIGINT handler from terminating the process, effectively ignoring the signal.

## Changes
- Added `IgnoreSigint` RAII guard that ignores SIGINT while alive
- Wrapped `Child` in `PagerProc` struct to carry the signal guard
- Signal guard is created when spawning external pagers and dropped when pager exits

Now Ctrl-C behaves correctly in `less`:
- Without `-K`: cancels search/operation, stays open
- With `-K`: exits immediately (existing behavior preserved)

## Demo

**Before:** Ctrl C closes the pager but neither does the terminal fully regain control. You have to press Ctrl + C again

```sh
for i in {0..100}; do echo $i; done | BAT_PAGER='less -R' bat
```

**After:** Ctrl + C sends SIGINT and bat actively ignores it, hence does not kill the pager process via teardown

```sh
for i in {0..100}; do echo $i; done | BAT_PAGER='less -R' ./target/debug/bat
```

## Status

- [x] Changelog entry applied
- [x] No docs, this is a fulfillment of already documented behaviour in the pager section of the README
- [x] Ready for review: yes