### PR TITLE
Use `-o fullquote` and `-o noquote` for more robust escaping in Bash completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Other
 
+- Use more robust approach to escaping in Bash completions, see #3448 (@akinomyoga)
+
 ## Syntaxes
 
 ## Themes

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -14,18 +14,36 @@ __bat_escape_completions()
 {
 	# Do not escape if completing a quoted value.
 	[[ $cur == [\"\']* ]] && return 0
-	# printf -v to an array index is available in bash >= 4.1.
-	# Use it if available, as -o filenames is semantically incorrect if
-	# we are not actually completing filenames, and it has side effects
-	# (e.g. adds trailing slash to candidates matching present dirs).
 	if ((
+		BASH_VERSINFO[0] > 5 || \
+		BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 3
+	)); then
+		# bash >= 5.3 has "compopt -o fullquote", which exactly does
+		# what this function tries to do.
+		compopt -o fullquote
+	elif ((
 		BASH_VERSINFO[0] > 4 || \
 		BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] > 0
 	)); then
+		# printf -v to an array index is available in bash >= 4.1.
+		# Use it if available, as -o filenames is semantically
+		# incorrect if we are not actually completing filenames, and it
+		# has side effects (e.g. adds trailing slash to candidates
+		# matching present dirs).
 		local i
 		for i in ${!COMPREPLY[*]}; do
 			printf -v "COMPREPLY[i]" %q "${COMPREPLY[i]}"
 		done
+
+		# We can use "compopt -o noquote" available in bash >= 4.3 to
+		# prevent further quoting by the shell, which would be
+		# unexpectedly applied when a quoted result matches a filename.
+		if ((
+			BASH_VERSINFO[0] > 4 || \
+			BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3
+		)); then
+			compopt -o noquote
+		fi
 	else
 		compopt -o filenames
 	fi


### PR DESCRIPTION
This PR adds improvements to the shell function `__bat_escape_completions()`, which is used to quote the non-filename completion candidates.

- The current approach of `__bat_escape_completions` still gets unwanted quoting when *the quoted result* accidentally matches a filename visible from the current working directory. To suppress this behavior of Readline, we should actually specify `compopt -o noquote` (which is available in Bash >= 4.3).
- Furthermore, the feature `__bat_escape_completions` tries to provide is actually implemented in Bash 5.3 as `compopt -o fullquote`, so in Bash >= 5.3, we can simply use it instead of quoting the candidates ourselves.
- This PR also includes the fixes for indentation. The indentation is basically made with tabs in this file, but several lines are indented by a random number of spaces. The first commit fixes this.

I've tested the behavior with Bash 5.2 (where `noquote` is used) and Bash 5.3 (where `fullquote` is used).