### PR TITLE
Add colors to --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Improve README documentation on pager options passed to less, see #3443 (@injust)
 
 - Use more robust approach to escaping in Bash completions, see #3448 (@akinomyoga)
+- Add colors to `--help` command, see #3494 (@starsep)
 
 ## Syntaxes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -120,6 +120,7 @@ dependencies = [
  "bugreport",
  "bytesize",
  "clap",
+ "clap-cargo",
  "clircle",
  "console",
  "content_inspector",
@@ -253,24 +254,47 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap-cargo"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
+dependencies = [
+ "anstyle",
+ "clap",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -720,6 +744,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collections"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ execute = { version = "0.2.13", optional = true }
 terminal-colorsaurus = "1.0"
 unicode-segmentation = "1.12.0"
 itertools = "0.14.0"
+clap-cargo = "0.18.3"
 
 [dependencies.git2]
 version = "0.20"

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -30,6 +30,7 @@ pub fn build_app(interactive_output: bool) -> Command {
     let mut app = Command::new(crate_name!())
         .version(VERSION.as_str())
         .color(color_when)
+        .styles(clap_cargo::style::CLAP_STYLING)
         .hide_possible_values(true)
         .args_conflicts_with_subcommands(true)
         .allow_external_subcommands(true)


### PR DESCRIPTION
I used [clap-cargo](https://github.com/crate-ci/clap-cargo) as it's easy to use and provides sensible default styles.
User can disable colors via `NO_COLOR=1` environment variable

| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="969" height="4416" alt="bat-before" src="https://github.com/user-attachments/assets/334423f5-bbad-4e2c-b649-bd8a81afc46f" /> | <img width="969" height="4416" alt="bat-after" src="https://github.com/user-attachments/assets/05ba3c3c-97a0-4885-a788-c1e26ae0de51" /> | <img width="969" height="4416" alt="bat-no-color" src="https://github.com/user-attachments/assets/2a5fee72-9a0d-48ff-92ad-247ab47820c6" /> |
