### PR TITLE
chore: Change URL of Zig submodule from GitHub to Codeberg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -196,7 +196,7 @@
 	url = https://github.com/leanprover/vscode-lean4.git
 [submodule "assets/syntaxes/02_Extra/Zig"]
 	path = assets/syntaxes/02_Extra/Zig
-	url = https://github.com/ziglang/sublime-zig-language.git
+	url = https://codeberg.org/ziglang/sublime-zig-language.git
 [submodule "assets/syntaxes/02_Extra/gnuplot"]
 	path = assets/syntaxes/02_Extra/gnuplot
 	url = https://github.com/hesstobi/sublime_gnuplot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Syntaxes
 
+- Change the URL of Zig submodule from GitHub to Codeberg, see #3519 (@sorairolake)
+
 ## Themes
 
 ## `bat` as a library


### PR DESCRIPTION
The Zig project migrated from GitHub to Codeberg.[^1]

<https://github.com/ziglang/sublime-zig-language> also migrated to <https://codeberg.org/ziglang/sublime-zig-language>. The former repository has been archived, so we should change the URL to the latter repository.

[^1]: <https://ziglang.org/news/migrating-from-github-to-codeberg/>