### PR TITLE
Fix typos in changelog and controller variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,7 +276,7 @@
 
 - Various bash completion improvements, see #2310 (@scop)
 - Disable completion of `cache` subcommand, see #2399 (@cyqsimon)
-- Signifigantly improve startup performance on macOS, see #2442 (@BlackHoleFox)
+- Significantly improve startup performance on macOS, see #2442 (@BlackHoleFox)
 - Bump MSRV to 1.62, see #2496 (@Enselic)
 
 ## Syntaxes

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -90,7 +90,7 @@ impl Controller<'_> {
 
         let attached_to_pager = match (&output_handle, &output_type_opt) {
             (Some(_), _) => true,
-            (None, Some(ot)) => ot.is_pager(),
+            (None, Some(output_type)) => output_type.is_pager(),
             (None, None) => false,
         };
 
@@ -103,7 +103,7 @@ impl Controller<'_> {
         let mut writer = match (output_handle, &mut output_type_opt) {
             (Some(OutputHandle::FmtWrite(w)), _) => OutputHandle::FmtWrite(w),
             (Some(OutputHandle::IoWrite(w)), _) => OutputHandle::IoWrite(w),
-            (None, Some(ot)) => ot.handle()?,
+            (None, Some(output_type)) => output_type.handle()?,
             (None, None) => unreachable!("No output handle and no output type available"),
         };
         let mut no_errors: bool = true;


### PR DESCRIPTION
- correct “Significantly” spelling in CHANGELOG macOS performance note
- rename temporary output_type binding in controller for clarity

Tests: not run (typo-only changes)

Timestamp: 2025-12-06T12:55:15Z
Repository: bat
Branch: master
Signing: GPG (989AF9F0)
Performance: 2 files, +3/-3 lines