### PR TITLE
Support custom assets (themes) when displaying help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Bugfixes
 
 - `--help` now correctly honors `--pager=builtin`. See #3516 (@keith-hall)
+- `--help` now correctly honors custom themes. See #3524 (@keith-hall)
 
 ## Other
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -112,6 +112,7 @@ impl App {
 
             let pager = matches.get_one::<String>("pager").map(|s| s.as_str());
             let theme_options = Self::theme_options_from_matches(&matches);
+            let use_custom_assets = !matches.get_flag("no-custom-assets");
 
             Self::display_help(
                 interactive_output,
@@ -120,6 +121,7 @@ impl App {
                 use_color,
                 pager,
                 theme_options,
+                use_custom_assets,
             )?;
             std::process::exit(0);
         }
@@ -138,6 +140,7 @@ impl App {
         use_color: bool,
         pager: Option<&str>,
         theme_options: ThemeOptions,
+        use_custom_assets: bool,
     ) -> Result<()> {
         use crate::assets::assets_from_cache_or_binary;
         use crate::directories::PROJECT_DIRS;
@@ -176,7 +179,7 @@ impl App {
         };
 
         let cache_dir = PROJECT_DIRS.cache_dir();
-        let assets = assets_from_cache_or_binary(false, cache_dir)?;
+        let assets = assets_from_cache_or_binary(use_custom_assets, cache_dir)?;
         Controller::new(&help_config, &assets)
             .run(inputs, None)
             .ok();


### PR DESCRIPTION
Fixes #3522 

In case something is broken with custom assets, they can still be ignored with --no-custom-assets, so it feels safe to add support for custom themes when displaying help.