### PR TITLE
Fix pager spawn under QEMU user-mode emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix `--wrap=never` and `-S` flags being ignored when piping to pager, see #3592 (@IMaloney)
 - Fix crash with BusyBox `less` on Windows, see #3527 (@Anchal-T)
 - Fix `bat cache --help` failing with 'unexpected argument' error, see #3580 and #3560 (@NORMAL-EX)
+- Fix pager spawn detection under QEMU user-mode emulation. See #3531 (@OctopusET)
 - `--help` now correctly honors `--pager=builtin`. See #3516 (@keith-hall)
 - `--help` now correctly honors custom themes. See #3524 (@keith-hall)
 - Fixed test compatibility with future Cargo build directory changes, see #3550 (@nmacl)

--- a/src/output.rs
+++ b/src/output.rs
@@ -129,6 +129,10 @@ impl OutputType {
         let args = pager.args;
 
         if pager.kind == PagerKind::Less {
+            if retrieve_less_version(&pager.bin).is_none() {
+                return Ok(OutputType::stdout());
+            }
+
             // less needs to be called with the '-R' option in order to properly interpret the
             // ANSI color sequences printed by bat. If someone has set PAGER="less -F", we
             // therefore need to overwrite the arguments and add '-R'.
@@ -187,16 +191,19 @@ impl OutputType {
             p.args(args);
         };
 
-        Ok(p.stdin(Stdio::piped())
-            .spawn()
-            .map(OutputType::Pager)
-            .unwrap_or_else(|_| {
+        Ok(match p.stdin(Stdio::piped()).spawn() {
+            Ok(mut child) => match child.try_wait() {
+                Ok(Some(status)) if !status.success() => OutputType::stdout(),
+                _ => OutputType::Pager(child),
+            },
+            Err(_) => {
                 crate::bat_warning!(
                     "Pager '{}' not found, outputting to stdout instead",
                     &pager.bin
                 );
                 OutputType::stdout()
-            }))
+            }
+        })
     }
 
     pub(crate) fn stdout() -> Self {


### PR DESCRIPTION
QEMU user-mode emulation with glibc 2.34+ may return success from posix_spawn even when the child process fails to execute and exits immediately.

It's caused by QEMU's current implementation limitation.

Use try_wait() after spawn to detect this and fall back to stdout.

Related PR: https://github.com/BurntSushi/ripgrep/pull/3248
Failed CI without this PR: https://github.com/OctopusET/bat/actions/runs/18910014240/job/53977874904