### PR TITLE
ci: Use git version of cross for better target support

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -195,9 +195,7 @@ jobs:
 
     - name: Install cross
       if: matrix.job.use-cross
-      uses: taiki-e/install-action@v2
-      with:
-        tool: cross
+      run: cargo install cross --git https://github.com/cross-rs/cross --rev 588b3c99db52b5a9c5906fab96cfadcf1bde7863
 
     - name: Overwrite build command env variable
       if: matrix.job.use-cross

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed test compatibility with future Cargo build directory changes, see #3550 (@nmacl)
 
 ## Other
+- Use git version of cross. See #3533 (@OctopusET)
 
 - Bump MSRV to 1.88, update `time` crate to 0.3.47 to fix RUSTSEC-2026-0009, see #3581 (@NORMAL-EX)
 


### PR DESCRIPTION
riscv64gc-unknown-linux-musl isn't released yet, and maintainer aims for more things for new release. So I don't think new release will be released soon.

https://github.com/cross-rs/cross/pull/1664
https://github.com/cross-rs/cross/issues/1718

Also, I think it's not easy to change version of taiki-e/install-action@v2 upstream.