### PR TITLE
Fix integration tests on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 /target/
 **/*.rs.bk
 
+# Editors
+.idea/
+.vscode/
+
 # Generated files
 /assets/completions/_bat.ps1
 /assets/completions/bat.bash

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1357,27 +1357,33 @@ fn disable_pager_if_pp_flag_comes_after_paging() {
 }
 
 #[test]
+#[serial]
 fn enable_pager_if_disable_paging_flag_comes_before_paging() {
-    bat()
-        .env("PAGER", "echo pager-output")
-        .arg("-P")
-        .arg("--paging=always")
-        .arg("test.txt")
-        .assert()
-        .success()
-        .stdout(predicate::eq("pager-output\n").normalize());
+    mocked_pagers::with_mocked_versions_of_more_and_most_in_path(|| {
+        bat()
+            .env("PAGER", mocked_pagers::from("echo pager-output"))
+            .arg("-P")
+            .arg("--paging=always")
+            .arg("test.txt")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("pager-output\n").normalize());
+    });
 }
 
 #[test]
+#[serial]
 fn enable_pager_if_pp_flag_comes_before_paging() {
-    bat()
-        .env("PAGER", "echo pager-output")
-        .arg("-pp")
-        .arg("--paging=always")
-        .arg("test.txt")
-        .assert()
-        .success()
-        .stdout(predicate::eq("pager-output\n").normalize());
+    mocked_pagers::with_mocked_versions_of_more_and_most_in_path(|| {
+        bat()
+            .env("PAGER", mocked_pagers::from("echo pager-output"))
+            .arg("-pp")
+            .arg("--paging=always")
+            .arg("test.txt")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("pager-output\n").normalize());
+    });
 }
 
 #[test]
@@ -1394,15 +1400,18 @@ fn paging_does_not_override_simple_plain() {
 }
 
 #[test]
+#[serial]
 fn simple_plain_does_not_override_paging() {
-    bat()
-        .env("PAGER", "echo pager-output")
-        .arg("--paging=always")
-        .arg("--plain")
-        .arg("test.txt")
-        .assert()
-        .success()
-        .stdout(predicate::eq("pager-output\n"));
+    mocked_pagers::with_mocked_versions_of_more_and_most_in_path(|| {
+        bat()
+            .env("PAGER", mocked_pagers::from("echo pager-output"))
+            .arg("--paging=always")
+            .arg("--plain")
+            .arg("test.txt")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("pager-output\n").normalize());
+    });
 }
 
 #[test]


### PR DESCRIPTION
This fixes a few integration tests which were failing on Windows.

I used the same pattern as in other tests where the pager is expected to be enabled.

This seems related to #2602.

I'm not adding an entry to the changelog since it doesn't have any effect to the user.
