### PR TITLE
Add --no-header flag and improve theme errors

### DIFF
--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -613,6 +613,11 @@ impl App {
             )),
         };
 
+        if matches.get_flag("no-header") {
+            styled_components.0.remove(&StyleComponent::HeaderFilename);
+            styled_components.0.remove(&StyleComponent::HeaderFilesize);
+        }
+
         // If `grid` is set, remove `rule` as it is a subset of `grid`, and print a warning.
         if styled_components.grid() && styled_components.0.remove(&StyleComponent::Rule) {
             bat_warning!("Style 'rule' is a subset of style 'grid', 'rule' will not be visible.");

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -516,6 +516,13 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("no-header")
+                .long("no-header")
+                .action(ArgAction::SetTrue)
+                .help("Disable the file header.")
+                .hide_short_help(true)
+        )
+        .arg(
             Arg::new("line-range")
                 .long("line-range")
                 .short('r')

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -276,6 +276,15 @@ fn get_new_terminal_title(inputs: &Vec<Input>) -> String {
 
 fn run_controller(inputs: Vec<Input>, config: &Config, cache_dir: &Path) -> Result<bool> {
     let assets = assets_from_cache_or_binary(config.use_custom_assets, cache_dir)?;
+    if config.theme != "ansi-light" && config.theme != "ansi-dark" {
+        let theme_known = assets.themes().any(|theme| theme == config.theme);
+        if !theme_known {
+            return Err(Error::Msg(format!(
+                "Unknown theme '{theme}'. Use '--list-themes' to list available themes.",
+                theme = config.theme,
+            )));
+        }
+    }
     let controller = Controller::new(config, &assets);
     if config.paging_mode != PagingMode::Never && config.set_terminal_title {
         set_terminal_title_to(get_new_terminal_title(&inputs));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3654,3 +3654,35 @@ fn plain_with_sized_terminal_width() {
         .stdout("hello \nworld\n")
         .stderr("");
 }
+
+
+#[test]
+fn no_header_flag_keeps_content() {
+    bat()
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=default")
+        .arg("--no-header")
+        .arg("single-line.txt")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Single Line")
+                .and(predicate::str::contains("File:").not()),
+        )
+        .stderr("");
+}
+
+#[test]
+fn unknown_theme_errors() {
+    bat()
+        .arg("--theme=ThemeDoesNotExist")
+        .arg("test.txt")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Unknown theme 'ThemeDoesNotExist'"))
+        .stderr(predicate::str::contains("--list-themes"));
+}


### PR DESCRIPTION
## Summary
- add a --no-header flag to suppress file headers
- emit a clear error when an unknown theme is requested
- add integration coverage for both behaviors

## Test plan
- not run (Rust toolchain not installed on server)