### PR TITLE
build(deps): replace unmaintained bincode with postcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Fixed bug caused by using `--plain` and `--terminal-width=N` flags simultaneously, see #3529 (@H4k1l)
 
+## Dependencies
+
+- Replace unmaintained `bincode` dependency with maintained `postcard` serialization library to address RUSTSEC-2025-0141, see #3582
+
 ## Features
 
 - Implement `--unbuffered` mode for streaming input, allowing partial lines to display immediately (e.g. `tail -f | bat -u`). Closes #3555, see #3583 (@mainnebula)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ regex-fancy = ["syntect/regex-fancy"] # Use the rust-only "fancy-regex" engine
 [dependencies]
 nu-ansi-term = "0.50.3"
 ansi_colours = "^1.2"
-bincode = "1.0"
+postcard = { version = "1.0", features = ["alloc"] }
 console = "0.16.2"
 flate2 = "1.1"
 once_cell = "1.20"

--- a/src/assets/build_assets.rs
+++ b/src/assets/build_assets.rs
@@ -142,17 +142,19 @@ pub(crate) fn asset_to_contents<T: serde::Serialize>(
     description: &str,
     compressed: bool,
 ) -> Result<Vec<u8>> {
-    let mut contents = vec![];
+    let serialized = postcard::to_allocvec(asset)
+        .map_err(|_| format!("Could not serialize {description}"))?;
+    
     if compressed {
-        bincode::serialize_into(
-            flate2::write::ZlibEncoder::new(&mut contents, flate2::Compression::best()),
-            asset,
-        )
+        let mut contents = vec![];
+        use std::io::Write;
+        flate2::write::ZlibEncoder::new(&mut contents, flate2::Compression::best())
+            .write_all(&serialized)
+            .map_err(|_| format!("Could not compress {description}"))?;
+        Ok(contents)
     } else {
-        bincode::serialize_into(&mut contents, asset)
+        Ok(serialized)
     }
-    .map_err(|_| format!("Could not serialize {description}"))?;
-    Ok(contents)
 }
 
 fn asset_to_cache<T: serde::Serialize>(

--- a/src/assets/serialized_syntax_set.rs
+++ b/src/assets/serialized_syntax_set.rs
@@ -4,7 +4,7 @@ use syntect::parsing::SyntaxSet;
 
 use super::*;
 
-/// A SyntaxSet in serialized form, i.e. bincoded and flate2 compressed.
+/// A SyntaxSet in serialized form, i.e. serialized with postcard and optionally flate2 compressed.
 /// We keep it in this format since we want to load it lazily.
 #[derive(Debug)]
 pub enum SerializedSyntaxSet {


### PR DESCRIPTION
Fixes #3582

## Description
Replace the unmaintained bincode 1.3.3 dependency with postcard, an actively maintained binary serialization library, to address RUSTSEC-2025-0141.

## Changes
- Replace `bincode` with `postcard` in Cargo.toml dependencies
- Update serialization code in `build_assets.rs` to use `postcard::to_allocvec`
- Update deserialization code in `assets.rs` to use `postcard::from_bytes`
- Handle decompression with explicit buffer management
- Update documentation comment in `serialized_syntax_set.rs`
- Add changelog entry under Dependencies section

## Rationale
Bincode 1.3.3 is unmaintained due to a harassment incident, and attempts to upgrade to newer versions (2.x and 3.x) have failed due to binary format incompatibility with the embedded serialized assets.

Postcard is:
- Actively maintained
- Designed for embedded/resource-constrained uses
- Has excellent serde integration
- Widely used in production Rust projects

## Testing
- [ ] cargo build --release passes
- [ ] cargo test passes
- [ ] bat --version works
- [ ] Serialization/deserialization of assets works correctly