### PR TITLE
Fix panic in BuiltinPager Drop when pager thread fails (#3449)

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -225,8 +225,8 @@ impl Drop for OutputType {
                 let _ = command.wait();
             }
             OutputType::BuiltinPager(ref mut pager) => {
-                if pager.handle.is_some() {
-                    let _ = pager.handle.take().unwrap().join().unwrap();
+                if let Some(handle) = pager.handle.take() {
+                    let _ = handle.join();
                 }
             }
             OutputType::Stdout(_) => (),


### PR DESCRIPTION
## Summary

Fix a double-panic (abort) in the `Drop` implementation for `OutputType::BuiltinPager` when the pager thread has panicked.

## Problem

The current code in the `Drop` impl:
```rust
let _ = pager.handle.take().unwrap().join().unwrap();
```

The second `.unwrap()` panics if `join()` returns `Err` (which happens when the pager thread panicked). Since this is in `Drop`, panicking here causes a double-panic and process abort.

## Fix

```rust
if let Some(handle) = pager.handle.take() {
    let _ = handle.join();
}
```

- Use `if let` instead of `.is_some()` + `.unwrap()` (more idiomatic)
- Discard the `join()` result with `let _ =`, matching the pattern used for `OutputType::Pager`

## Testing

`cargo check` passes. The fix is a one-line logic change in a `Drop` impl.

Fixes #3449