### PR TITLE
Fix --list-themes with --paging=always from BAT_OPTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add `--fallback-syntax`/`--fallback-language` to apply syntax highlighting only when auto-detection fails, see #1341 (@Xavrir)
 
 ## Bugfixes
+- Fix `--list-themes` being broken when `--paging=always` is set via `BAT_OPTS`, see #1618 (@Xavrir)
 - Report error when pager is missing instead of silently falling back, see #3588 (@IMaloney)
 - Fix `--wrap=never` and `-S` flags being ignored when piping to pager, see #3592 (@IMaloney)
 - Fix crash with BusyBox `less` on Windows, see #3527 (@Anchal-T)

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -248,8 +248,11 @@ pub fn list_themes(
         ))?;
     }
 
-    let mut output_type =
-        OutputType::from_mode(config.paging_mode, config.wrapping_mode, config.pager)?;
+    let paging_mode = match config.paging_mode {
+        PagingMode::Always => PagingMode::QuitIfOneScreen,
+        other => other,
+    };
+    let mut output_type = OutputType::from_mode(paging_mode, config.wrapping_mode, config.pager)?;
     let mut writer = output_type.handle()?;
     writer.write_fmt(format_args!("{buf}"))?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -613,6 +613,26 @@ fn list_themes_to_piped_output() {
 }
 
 #[test]
+fn list_themes_ignores_paging_always() {
+    bat()
+        .arg("--paging=always")
+        .arg("--list-themes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DarkNeon").normalize());
+}
+
+#[test]
+fn list_themes_ignores_paging_always_from_env() {
+    bat()
+        .env("BAT_OPTS", "--paging=always")
+        .arg("--list-themes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DarkNeon").normalize());
+}
+
+#[test]
 fn list_languages() {
     bat()
         .arg("--list-languages")


### PR DESCRIPTION
## Summary

Fix `--list-themes` being broken when `--paging=always` is set via `BAT_OPTS` or command line.

## Problem

When `BAT_OPTS="--paging=always"` is set, running `bat --list-themes` forces the pager unconditionally, which can make the output unusable (the pager traps the output).

## Fix

Downgrade `PagingMode::Always` to `PagingMode::QuitIfOneScreen` in `list_themes()` before creating the output type. This:
- Keeps paging when theme list is longer than the terminal (which it usually is)
- Prevents forced paging from `--paging=always`
- Matches how `--list-languages` handles paging (forces `QuitIfOneScreen`)
- Preserves `PagingMode::Never` when explicitly set

## Tests

Two integration tests added:
- `list_themes_ignores_paging_always` — explicit `--paging=always` flag
- `list_themes_ignores_paging_always_from_env` — via `BAT_OPTS` environment variable

All 379 tests pass (224 integration + 155 unit/doc).

Closes #1618