### PR TITLE
docs: explain how to remove fish help abbreviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ abbr -a --position anywhere -- --help '--help | bat -plhelp'
 abbr -a --position anywhere -- -h '-h | bat -plhelp'
 ```
 
+To remove these abbreviations later, run:
+
+```fish
+abbr --erase -- --help
+abbr --erase -- -h
+```
+
 This way, you can keep on using `cp --help`, but get colorized help pages.
 
 Be aware that in some cases, `-h` may not be a shorthand of `--help` (for example with `ls`). In cases where you need to use `-h` 


### PR DESCRIPTION
## Summary
- document how fish users can remove accidental help abbreviations created for `bat --help` / `bat -h`
- add copy-paste erase commands for both long and short forms
- keep the change scoped to the shell-aliases section in `README.md`

## Testing
- `git diff --check upstream/master...HEAD`
- Rust toolchain is not available in this environment, so runtime tests were not runnable for this docs-only update.

## Related
Fixes #3536
