### PR TITLE
fix: disable paging for --list-themes output

### DIFF
--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -287,7 +287,7 @@ impl App {
             .and_then(Iterator::max)
             .unwrap_or_default();
 
-        let paging_mode = match self.matches.get_one::<String>("paging").map(|s| s.as_str()) {
+        let mut paging_mode = match self.matches.get_one::<String>("paging").map(|s| s.as_str()) {
             Some("always") => {
                 // Disable paging if the second -p (or -pp) is specified after --paging=always
                 if extra_plain && plain_last_index > paging_last_index {
@@ -321,6 +321,10 @@ impl App {
             }
             _ => unreachable!("other values for --paging are not allowed"),
         };
+
+        if self.matches.get_flag("list-themes") {
+            paging_mode = PagingMode::Never;
+        }
 
         let mut syntax_mapping = SyntaxMapping::new();
         // start building glob matchers for builtin mappings immediately

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -613,6 +613,21 @@ fn list_themes_to_piped_output() {
 }
 
 #[test]
+#[serial]
+fn list_themes_disables_forced_paging() {
+    mocked_pagers::with_mocked_versions_of_more_and_most_in_path(|| {
+        bat()
+            .env("BAT_PAGER", mocked_pagers::from("echo pager-output"))
+            .arg("--paging=always")
+            .arg("--list-themes")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("DarkNeon").normalize())
+            .stdout(predicate::str::contains("pager-output").not());
+    });
+}
+
+#[test]
 fn list_languages() {
     bat()
         .arg("--list-languages")


### PR DESCRIPTION
## Summary
- force PagingMode::Never when --list-themes is active so theme listing is never paged
- add an integration test that verifies --list-themes --paging=always does not invoke the configured pager

Fixes #1618.

## Validation
- git diff --check
- attempted cargo test --test integration_tests list_themes_disables_forced_paging *(not runnable here: cargo toolchain is unavailable in this environment)*