### PR TITLE
docs: fix README sidebar wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ languages:
 ### Git integration
 
 `bat` communicates with `git` to show modifications with respect to the index
-(see left side bar):
+(see left sidebar):
 
 ![Git integration example](https://i.imgur.com/2lSW4RE.png)
 


### PR DESCRIPTION
## Summary
- Use “sidebar” as a single word in the README Git integration section.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/sharkdp/bat/blob/master/CONTRIBUTING.md

## Validation/testing
- Not run (docs change only)