### PR TITLE
Add syntax mappings for GCloud CLI config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Don't color strings inside CSV files, to make it easier to tell which column they belong to, see #3521 (@keith-hall)
 - Add syntax highlighting support for COBOL, see #3584 (@adukhan99)
 - Fixed manpage syntax so that ANSI escape codes don't get incorrectly highlighted and thus broken, see #3586 (@BlueElectivire)
+- Map several Google Cloud CLI config files to their appropriate syntax #3635 (@victor-gp)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/common/50-gcloud-cli-config.toml
+++ b/src/syntax_mapping/builtins/common/50-gcloud-cli-config.toml
@@ -1,0 +1,3 @@
+[mappings]
+"INI" = [".boto", "**/gcloud/configurations/config_*"]
+"Git Ignore" = [".gcloudignore"]


### PR DESCRIPTION
> `.boto` => INI

I was uninstalling `gcloud-cli` and the docs said to review the contents of `~/.boto` [^1].

`bat` doesn't recognize it but it's just an INI-like file to configure `gsutil` [^2].

I took the chance to add a few more mappings for other GCloud CLI config files without extension:

> `.gcloudignore` => Git Ignore

This one's self-explanatory, but it's documented in [^3].

:exclamation:  Makes me wonder if we could just do a blanket `Git Ignore = ".?*ignore"` for every kind of ignore file. For instance, `bat` doesn't catch `.dockerignore` either.

> `**/gcloud/configurations/config_*` => INI

These are configuration files for each different profile you have configured for the `gcloud-cli` [^4].

They're named like "config_default" or "config_<name>", without a file extension, but they are also INI syntax [^5][^6].

[^1]: https://docs.cloud.google.com/sdk/docs/uninstall-cloud-sdk
[^2]: https://docs.cloud.google.com/storage/docs/boto-gsutil
[^3]: https://docs.cloud.google.com/sdk/gcloud/reference/topic/gcloudignore
[^4]: https://docs.cloud.google.com/sdk/docs/configurations
[^5]: https://stackoverflow.com/questions/74290882/return-active-gcp-project-name-programatically-for-both-local-dev-and-deployed-c/7^4292151#74292151
[^6]: https://stackoverflow.com/questions/49212350/where-does-gcloud-store-its-defaults/49256835#49256835