### PR TITLE
docs: fix contributing guide grammar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for considering to contribute to `bat`!
+Thank you for considering contributing to `bat`!
 
 
 


### PR DESCRIPTION
## Summary
- fix the opening sentence grammar in the contributing guide

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- CONTRIBUTING: https://github.com/sharkdp/bat/blob/master/CONTRIBUTING.md
- PR template: N/A

## Validation
- Not run (docs-only change)
