### PR TITLE
ci: add riscv64 to release build matrix

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -172,6 +172,7 @@ jobs:
           - { target: aarch64-apple-darwin        , os: macos-latest  ,                                              }
           - { target: x86_64-pc-windows-msvc      , os: windows-2025  ,                                              }
           - { target: aarch64-pc-windows-msvc     , os: windows-11-arm,                                              }
+          - { target: riscv64gc-unknown-linux-gnu  , os: ubuntu-24.04-riscv, dpkg_arch: riscv64                         }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest , dpkg_arch: amd64,            use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest , dpkg_arch: musl-linux-amd64, use-cross: true }
     env:


### PR DESCRIPTION
Adds `riscv64gc-unknown-linux-gnu` to the release build matrix using native RISE riscv64 runners (`ubuntu-24.04-riscv`). Builds natively with cargo (no cross needed), same approach as the `windows-11-arm` entry.

Native riscv64 GitHub Actions runners are provided by the [RISE Project](https://riseproject.dev/), free for open source. To enable: install the [RISE runners GitHub App](https://github.com/apps/rise-risc-v-runners). Without the app, the job stays queued with no runner available.

Build validated on native riscv64 hardware and on RISE runner: https://github.com/gounthar/bat/actions/runs/23355357501

Closes #3463