### PR TITLE
Fix macOS capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A special *thank you* goes to our biggest <a href="doc/sponsors.md">sponsors</a>
   <br>
   <strong>Warp, the intelligent terminal</strong>
   <br>
-  <sub>Available on MacOS, Linux, Windows</sub>
+  <sub>Available on macOS, Linux, Windows</sub>
 </a>
 </p>
 


### PR DESCRIPTION
## Summary
- Fix macOS capitalization in the README sponsor copy.

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- Docs-only change with no behavior impact.
- Followed https://github.com/sharkdp/bat/blob/master/CONTRIBUTING.md
- bat CONTRIBUTING notes that changelog-entry check failures can be ignored for docs-only fixes.

## Validation
- Not run; docs-only change.