### PR TITLE
fix: ignore BAT_OPTS paging mode for --list-themes

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -205,6 +205,7 @@ pub fn list_themes(
     style.insert(StyleComponent::Plain);
     config.language = Some("Rust");
     config.style_components = StyleComponents(style);
+    config.paging_mode = PagingMode::QuitIfOneScreen;
 
     let default_theme_name = default_theme(color_scheme(detect_color_scheme).unwrap_or_default());
     let mut buf = String::new();


### PR DESCRIPTION
Nevermind, this isn't a big enough issue to warrant fixing. 