### PR TITLE
docs: fix README instructions on how to use bat with man

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,11 @@ bat main.cpp | xclip
 #### `man`
 
 `bat` can be used as a colorizing pager for `man`, by setting the
-`MANPAGER` environment variable:
+`MANPAGER` and `MANROFFOPT` environment variables:
 
 ```bash
-export MANPAGER="bat -plman"
+export MANPAGER="sh -c 'col -bx | bat -plman'"
+export MANROFFOPT="-c"
 man 2 select
 ```
 (on some older Debian or Ubuntu releases, the executable is named `batcat` instead of `bat`)


### PR DESCRIPTION
Update the documentation for using `bat` as a colorizing pager for `man`. The current setup sometimes causes man to break the highlighting and print raw escape characters into bat.

<img width="429" height="458" alt="print of the error" src="https://github.com/user-attachments/assets/6ed17d71-48ba-42b5-9bc5-7bcd1dc76f67"/>
