### PR TITLE
Support BAT_WIDTH for terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)
 - Added support for `hidden_file_extensions` from `.sublime-syntax` files, see #3613 (@Matei02355)
 - Add word wrapping mode via `--wrap=word`, see #3597 (@veeceey)
-- Support configuring `--terminal-width` via `BAT_WIDTH`, see #0000 (@officialasishkumar)
+- Support configuring `--terminal-width` via `BAT_WIDTH`, see #3679 (@officialasishkumar)
 - Implement `--unbuffered` mode for streaming input, allowing partial lines to display immediately (e.g. `tail -f | bat -u`). Closes #3555, see #3583 (@mainnebula)
 - Added an initial `flake.nix` for a ready made development environment; see #3578 (@vorburger)
 - Add `--quiet-empty` (`-E`) flag to suppress output when input is empty. Closes #1936, see #3563 (@NORMAL-EX)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)
 - Added support for `hidden_file_extensions` from `.sublime-syntax` files, see #3613 (@Matei02355)
 - Add word wrapping mode via `--wrap=word`, see #3597 (@veeceey)
+- Support configuring `--terminal-width` via `BAT_WIDTH`, see #0000 (@officialasishkumar)
 - Implement `--unbuffered` mode for streaming input, allowing partial lines to display immediately (e.g. `tail -f | bat -u`). Closes #3555, see #3583 (@mainnebula)
 - Added an initial `flake.nix` for a ready made development environment; see #3578 (@vorburger)
 - Add `--quiet-empty` (`-E`) flag to suppress output when input is empty. Closes #1936, see #3563 (@NORMAL-EX)

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -77,7 +77,8 @@ Options:
       --terminal-width <width>
           Explicitly set the width of the terminal instead of determining it automatically. If
           prefixed with '+' or '-', the value will be treated as an offset to the actual terminal
-          width. See also: '--wrap'.
+          width. This can also be configured via the BAT_WIDTH environment variable (e.g. export
+          BAT_WIDTH="100"). See also: '--wrap'.
 
   -n, --number
           Only show line numbers, no other decorations. This is an alias for '--style=numbers'

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -240,6 +240,7 @@ pub fn build_app(interactive_output: bool) -> Command {
         .arg(
             Arg::new("terminal-width")
                 .long("terminal-width")
+                .overrides_with("terminal-width")
                 .value_name("width")
                 .hide_short_help(true)
                 .allow_hyphen_values(true)
@@ -255,10 +256,13 @@ pub fn build_app(interactive_output: bool) -> Command {
                             })
                             .map_err(|e| e.to_string())
                     })
-                .help(
+                .help("Explicitly set the width of the terminal instead of determining it automatically.")
+                .long_help(
                     "Explicitly set the width of the terminal instead of determining it \
                      automatically. If prefixed with '+' or '-', the value will be treated \
-                     as an offset to the actual terminal width. See also: '--wrap'.",
+                     as an offset to the actual terminal width. This can also be configured \
+                     via the BAT_WIDTH environment variable (e.g. export BAT_WIDTH=\"100\"). \
+                     See also: '--wrap'.",
                 ),
         )
         .arg(

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -153,6 +153,7 @@ fn get_args_from_str(content: &str) -> Result<Vec<OsString>, shell_words::ParseE
 pub fn get_args_from_env_vars() -> Vec<OsString> {
     [
         ("--tabs", "BAT_TABS"),
+        ("--terminal-width", "BAT_WIDTH"),
         ("--theme", bat::theme::env::BAT_THEME),
         ("--theme-dark", bat::theme::env::BAT_THEME_DARK),
         ("--theme-light", bat::theme::env::BAT_THEME_LIGHT),

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -328,6 +328,7 @@ fn invoke_bugreport(app: &App, cache_dir: &Path) {
             "BAT_STYLE",
             "BAT_TABS",
             "BAT_THEME",
+            "BAT_WIDTH",
             bat::theme::env::BAT_THEME_DARK,
             bat::theme::env::BAT_THEME_LIGHT,
             "COLORTERM",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1048,6 +1048,57 @@ fn tabs_4_arg_overrides_env_noconfig() {
 }
 
 #[test]
+fn terminal_width_env_var_is_respected() {
+    let tmp_dir = tempdir().expect("can create temporary directory");
+    let tmp_path = tmp_dir.path().join("long.txt");
+    std::fs::write(
+        &tmp_path,
+        "0123456789abcdef0123456789abcdef0123456789abcdef\n",
+    )
+    .expect("can write temporary file");
+
+    bat()
+        .env("BAT_WIDTH", "20")
+        .arg(&tmp_path)
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--style=numbers")
+        .arg("--decorations=always")
+        .arg("--wrap=character")
+        .assert()
+        .success()
+        .stdout("   1 0123456789abcde\n     f0123456789abcd\n     ef0123456789abc\n     def\n")
+        .stderr("");
+}
+
+#[test]
+fn terminal_width_arg_overrides_env() {
+    let tmp_dir = tempdir().expect("can create temporary directory");
+    let tmp_path = tmp_dir.path().join("long.txt");
+    std::fs::write(
+        &tmp_path,
+        "0123456789abcdef0123456789abcdef0123456789abcdef\n",
+    )
+    .expect("can write temporary file");
+
+    bat()
+        .env("BAT_WIDTH", "20")
+        .arg(&tmp_path)
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--style=numbers")
+        .arg("--decorations=always")
+        .arg("--wrap=character")
+        .arg("--terminal-width=10")
+        .assert()
+        .success()
+        .stdout(
+            "   1 01234\n     56789\n     abcde\n     f0123\n     45678\n     9abcd\n     ef012\n     34567\n     89abc\n     def\n",
+        )
+        .stderr("");
+}
+
+#[test]
 fn fail_non_existing() {
     bat().arg("non-existing-file").assert().failure();
 }
@@ -1474,6 +1525,7 @@ fn diagnostic_sanity_check() {
         .assert()
         .success()
         .stdout(predicate::str::contains("BAT_PAGER="))
+        .stdout(predicate::str::contains("BAT_WIDTH="))
         .stderr("");
 }
 


### PR DESCRIPTION
## Summary
- add `BAT_WIDTH` as an environment-backed alias for `--terminal-width`
- surface `BAT_WIDTH` in `--diagnostic` output and the terminal-width help text
- add integration coverage for env-driven width selection and normal CLI override precedence

## Testing
- `cargo test --lib`
- `cargo test --test integration_tests`

Closes #3679