### PR TITLE
fix: sanitize subprocess call in generate_snapshots.py

### DIFF
--- a/tests/snapshots/generate_snapshots.py
+++ b/tests/snapshots/generate_snapshots.py
@@ -4,6 +4,7 @@ import itertools
 import subprocess
 import pathlib
 import shutil
+from typing import Iterable
 
 
 def generate_snapshots():
@@ -19,14 +20,14 @@ def generate_snapshots():
 
 
 def generate_style_snapshot(style):
-    generate_snapshot(style.replace(",", "_"), "--style={}".format(style))
+    generate_snapshot(style.replace(",", "_"), ["--style={}".format(style)])
 
 
-def generate_snapshot(name, arguments):
+def generate_snapshot(name: str, arguments: Iterable[str]):
     output_file = "output/{name}.snapshot.txt".format(name=name)
     command = [
         "cargo", "run", "--", "--paging=never", "--color=never",
-        "--decorations=always", arguments, "sample.rs"
+        "--decorations=always", *arguments, "sample.rs"
     ]
     print("generating snapshot for {}".format(name))
     with open(output_file, "w") as f:

--- a/tests/snapshots/generate_snapshots.py
+++ b/tests/snapshots/generate_snapshots.py
@@ -23,18 +23,19 @@ def generate_style_snapshot(style):
 
 
 def generate_snapshot(name, arguments):
-    command = "cargo run -- --paging=never --color=never --decorations=always "
-    command += "{args} sample.rs > output/{name}.snapshot.txt".format(
-        name=name,
-        args=arguments
-    )
+    output_file = "output/{name}.snapshot.txt".format(name=name)
+    command = [
+        "cargo", "run", "--", "--paging=never", "--color=never",
+        "--decorations=always", arguments, "sample.rs"
+    ]
     print("generating snapshot for {}".format(name))
-    subprocess.call(command, shell=True)
+    with open(output_file, "w") as f:
+        subprocess.call(command, stdout=f)
 
 
 def build_bat():
     print("building bat")
-    subprocess.call("cargo build", cwd="../..", shell=True)
+    subprocess.call(["cargo", "build"], cwd="../..")
 
 
 def prepare_output_dir():
@@ -49,7 +50,7 @@ def modify_sample_file():
 
 def undo_sample_file_modification():
     print("undoing sample.rs modifications")
-    subprocess.call("git checkout -- sample.rs", shell=True)
+    subprocess.call(["git", "checkout", "--", "sample.rs"])
 
 
 build_bat()


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `tests/snapshots/generate_snapshots.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tests/snapshots/generate_snapshots.py:32` |

**Description**: The Python test script uses subprocess.call() with shell=True, which executes commands through the system shell and interprets shell metacharacters. At line 32, a 'command' variable is passed directly to the shell without sanitization. If this variable contains or is influenced by external data (environment variables, configuration files, command-line arguments), attackers can inject arbitrary shell commands using operators like semicolons, pipes, or command substitution.

## Changes
- `tests/snapshots/generate_snapshots.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
