### PR TITLE
[Python] Support uv as script runner in shebang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Improve native man pages and command help syntax highlighting by stripping overstriking, see #3517 (@akirk)
 - Add `--fallback-syntax`/`--fallback-language` to apply syntax highlighting only when auto-detection fails, see #1341 (@Xavrir)
 - Map `BUILD` case sensitively to Python (Starlark) for Bazel, see #3576 (@vorburger)
+- Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
 - Treat ZIP archives as binary content based on their magic header, see #3686 (@officialasishkumar)

--- a/assets/patches/Python.sublime-syntax.patch
+++ b/assets/patches/Python.sublime-syntax.patch
@@ -2,6 +2,15 @@ diff --git syntaxes/01_Packages/Python/Python.sublime-syntax syntaxes/01_Package
 index 2acd86d8..86257f7b 100644
 --- syntaxes/01_Packages/Python/Python.sublime-syntax
 +++ syntaxes/01_Packages/Python/Python.sublime-syntax
+@@ -25,7 +31,7 @@ file_extensions:
+   - wscript
+   - bazel
+   - bzl
+-first_line_match: ^#!\s*/.*\bpython(\d(\.\d)?)?\b
++first_line_match: ^#!\s*/.*\b(python(\d(\.\d)?)?|uv)\b
+ scope: source.python
+
+ variables:
 @@ -988,10 +988,6 @@ contexts:
          - match: \}
            scope: punctuation.section.mapping-or-set.end.python


### PR DESCRIPTION
This is a backport from upstream: https://github.com/sublimehq/Packages/blob/0fb98d39560bc4806ccf18da3c16e4a39ab805c0/Python/Python.sublime-syntax#L4131