### PR TITLE
windows: statically link the CRT to remove vcruntime dependency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+# On Windows MSVC, statically link the C runtime so that the resulting EXE does
+# not depend on the vcruntime DLL.
+#
+# See: https://github.com/sharkdp/bat/issues/3634
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Bump MSRV to 1.88, update `time` crate to 0.3.47 to fix RUSTSEC-2026-0009, see #3581 (@NORMAL-EX)
 - Allow home and end keys to be used with builtin pager, see #3651 (@keith-hall)
 - Builtin syntax mapping: cleanup matcher glob parsing logic #3652 (@cyqsimon)
+- Statically link the CRT for MSVC builds via Cargo config to avoid runtime DLL dependencies. Closes #3634, see #3692 (@barry3406)
 
 ## Syntaxes
 


### PR DESCRIPTION
Adds a `.cargo/config.toml` that sets `target-feature=+crt-static` for the `i686-pc-windows-msvc`, `x86_64-pc-windows-msvc`, and `aarch64-pc-windows-msvc` targets so the resulting `bat.exe` no longer depends on the vcruntime DLL.

Mirrors the fix applied to fd in sharkdp/fd#1891 (for sharkdp/fd#1874). All three MSVC targets that appear in bat's release matrix (see `.github/workflows/CICD.yml`) are covered.

Closes #3634

### Changelog entry

Added under `## Other` in the `unreleased` section of `CHANGELOG.md`.