### PR TITLE
fix(zsh): fix word-splitting on language names with spaces in tab completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixed test compatibility with future Cargo build directory changes, see #3550 (@nmacl)
 - Fixed bug caused by using `--plain` and `--terminal-width=N` flags simultaneously, see #3529 (@H4k1l)
 - Fixed syntax tests path, see #3610 (@foxfromworld)
+- Fix zsh tab completion word-splitting language names containing spaces (e.g. `HTML (Jinja2)`, `Apache Conf`), see #3693 (@YoshKoz)
 
 ## Other
 - Use git version of cross. See #3533 (@OctopusET)

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -90,7 +90,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         languages)
             local IFS=$'\n'
             local -a languages
-            languages=( $({{PROJECT_EXECUTABLE}} --list-languages | awk -F':|,' '{ for (i = 1; i <= NF; ++i) printf("%s:%s\n", $i, $1) }') )
+            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --list-languages | awk -F':|,' '{ for (i = 1; i <= NF; ++i) printf("%s:%s\n", $i, $1) }')"} )
 
             _describe 'language' languages && ret=0
         ;;


### PR DESCRIPTION
## Problem

Fixes #2897

When pressing Tab after `bat -l` (or `bat --language=`), language names containing spaces—such as `HTML (Jinja2)`, `Apache Conf`, `ARM Assembly`—are split into separate tokens by the shell's word-splitting on `$()` command substitution. This produces garbage completion entries like `(Jinja2)`, `Conf`, `Assembly`, etc.

Root cause: line 93 of `bat.zsh.in` uses `$()` which word-splits on `$IFS` (includes spaces) even when `local IFS=$'\n'` is set, because IFS only affects word-splitting of _unquoted variable expansions_, not command substitutions assigned directly to an array.

## Fix

Replace `$()` with `${(f)"$(...)"}` — the zsh flag `(f)` splits the result on newlines only. This is the exact pattern already used for theme completions on line 100:

```zsh
# Before (line 93):
languages=( $(bat --list-languages | awk ...) )

# After:
languages=( ${(f)"$(bat --list-languages | awk ...)"} )
```

One-character-class change, consistent with the existing theme completion pattern.

## Test

```zsh
bat -l <Tab>
# Should now complete "HTML (Jinja2)", "Apache Conf", etc. as single entries
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)