### PR TITLE
Add regression test for hidden file ignored suffix mapping

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3305,6 +3305,28 @@ fn all_global_git_config_locations_syntax_mapping_work() {
 }
 
 #[test]
+fn ignored_suffixes_work_for_hidden_file_name_mappings() {
+    let fake_home = Path::new(EXAMPLES_DIR).join("git").canonicalize().unwrap();
+    let expected = "\u{1b}[38;5;231m[\u{1b}[0m\u{1b}[38;5;149muser\u{1b}[0m\u{1b}[38;5;231m]\u{1b}[0m
+\u{1b}[38;5;231m    \u{1b}[0m\u{1b}[38;5;231memail\u{1b}[0m\u{1b}[38;5;231m \u{1b}[0m\u{1b}[38;5;203m=\u{1b}[0m\u{1b}[38;5;231m \u{1b}[0m\u{1b}[38;5;186mfoo@bar.net\u{1b}[0m
+\u{1b}[38;5;231m    \u{1b}[0m\u{1b}[38;5;231mname\u{1b}[0m\u{1b}[38;5;231m \u{1b}[0m\u{1b}[38;5;203m=\u{1b}[0m\u{1b}[38;5;231m \u{1b}[0m\u{1b}[38;5;186mfoobar\u{1b}[0m
+";
+
+    bat()
+        .env("HOME", fake_home.as_os_str())
+        .arg("-f")
+        .arg("--theme")
+        .arg("Monokai Extended")
+        .arg("-p")
+        .arg("--ignored-suffix=.suffix")
+        .arg("git/.gitconfig.suffix")
+        .assert()
+        .success()
+        .stdout(expected)
+        .stderr("");
+}
+
+#[test]
 fn map_syntax_and_ignored_suffix_work_together() {
     bat()
         .arg("-f")


### PR DESCRIPTION

**Repo:** sharkdp/bat (⭐ 50000)
**Type:** test
**Files changed:** 1
**Lines:** +22/-0

## What
Adds a focused integration test in `tests/integration_tests.rs` to verify that `--ignored-suffix` still preserves syntax detection for hidden Git config files, using `git/.gitconfig.suffix` as a regression case.

## Why
`bat` has separate syntax-detection logic for hidden file names such as `.gitconfig`, and existing tests already covered plain hidden files and ordinary ignored-suffix mappings independently. This patch closes the gap where those two behaviors interact, helping guard against regressions in hidden-file syntax resolution when users suffix backup or environment-specific config files.

## Testing
Reviewed the existing hidden-file and ignored-suffix test coverage, then added a targeted integration test alongside the related cases. Attempted to run `cargo test ignored_suffixes_work_for_hidden_file_name_mappings --test integration_tests`, but the environment could not resolve `index.crates.io`, so Cargo failed before dependencies could be fetched.

## Risk
Low / test-only change in one file with no production code impact.
