### PR TITLE
Fix macOS capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A special *thank you* goes to our biggest <a href="doc/sponsors.md">sponsors</a>
   <br>
   <strong>Warp, the intelligent terminal</strong>
   <br>
-  <sub>Available on MacOS, Linux, Windows</sub>
+  <sub>Available on macOS, Linux, Windows</sub>
 </a>
 </p>
 


### PR DESCRIPTION
Small documentation-only capitalization cleanup. No code changes.