### PR TITLE
fix(syntax): avoid treating Haskell operators as comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ## Syntaxes
 
+- Fix Haskell highlighting for operators that start with double dashes, see #3707 (@imwyvern)
 - Add shebang-based detection for Tcl (`tclsh`, `wish`) and Expect (`expect`) scripts, see #3647 (@mvanhorn)
 - Change the URL of Zig submodule from GitHub to Codeberg, see #3519 (@sorairolake)
 - Don't color strings inside CSV files, to make it easier to tell which column they belong to, see #3521 (@keith-hall)

--- a/assets/patches/Haskell.sublime-syntax.patch
+++ b/assets/patches/Haskell.sublime-syntax.patch
@@ -1,0 +1,13 @@
+diff --git syntaxes/01_Packages/Haskell/Haskell.sublime-syntax syntaxes/01_Packages/Haskell/Haskell.sublime-syntax
+index e45d6734..264e528a 100644
+--- syntaxes/01_Packages/Haskell/Haskell.sublime-syntax
++++ syntaxes/01_Packages/Haskell/Haskell.sublime-syntax
+@@ -199,7 +199,7 @@ contexts:
+           scope: punctuation.definition.comment.end.haskell
+           pop: true
+   comments:
+-    - match: '--'
++    - match: '--+(?=$|[^|!%$?~+:\-.=</>\\])'
+       scope: punctuation.definition.comment.haskell
+       push:
+         - meta_scope: comment.line.double-dash.haskell


### PR DESCRIPTION
The Haskell syntax treated any `--` sequence as a line comment starter, so legal operators such as `-->` in fixity declarations were highlighted as comments.

This adds a syntax patch matching double-dash comments only when the dash sequence is not followed by another Haskell operator character, while preserving normal comments like `-- text` and `--foo`.

Fixes #3694.

Verification:
- `patch --dry-run --strip=0 -d assets < assets/patches/Haskell.sublime-syntax.patch`
- regex smoke check for `-- comment`, `--foo`, `---`, `-->`, and `--->`
- `assets/create.sh` could not be run in this environment because `bat` is not installed on PATH.
