### PR TITLE
docs(README): list available --style components in Output style section

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,30 @@ and line numbers but no grid and no file header. Set the `BAT_STYLE` environment
 variable to make these changes permanent or use `bat`'s
 [configuration file](#configuration-file).
 
+By default, `bat` enables `changes`, `grid`, `header-filename`, `numbers`, and `snip`.
+
+The available pre-defined styles are:
+
+| Style | Description |
+|-------|-------------|
+| `default` | Enables the recommended style components listed above. |
+| `full` | Enables all available components. |
+| `auto` | Same as `default`, unless the output is piped. |
+| `plain` | Disables all available components. |
+
+The available individual components are:
+
+| Component | Description |
+|-----------|-------------|
+| `changes` | Show Git modification markers. |
+| `header` | Alias for `header-filename`. |
+| `header-filename` | Show filenames before the content. |
+| `header-filesize` | Show file sizes before the content. |
+| `grid` | Vertical/horizontal lines to separate the side bar and header from the content. |
+| `rule` | Horizontal lines to delimit files. |
+| `numbers` | Show line numbers in the side bar. |
+| `snip` | Draw separation lines between distinct line ranges. |
+
 >[!tip]
 > If you specify a default style in `bat`'s config file, you can change which components
 > are displayed during a single run of `bat` using the `--style` command-line argument.


### PR DESCRIPTION
## Summary

The "Output style" section explains how to use `--style` but does not enumerate what the values are, so users either need to know them or read the man page / source. This PR adds two tables to that section listing the four pre-defined styles and the eight individual components, with the descriptions copied verbatim from `bat --help`.

## Why this matters

Issue #3228 (and dup #3488) report the same gap: every other code-shape thing in the README around `--style=numbers,changes` is named, but the components themselves are not introduced anywhere on the page. The man page has them and `bat --help` has them, but neither is discoverable from a quick scroll through the README. The reporter explicitly says "either you know them or you dig through the source code." Adding the lists inline keeps the explanation next to the example that uses them.

## Changes

`README.md` "Output style" section:

- One sentence calling out the default-enabled set (`changes, grid, header-filename, numbers, snip`) so the existing "by default" mention in `bat --help` has a home in the README.
- A 4-row "pre-defined styles" table (`default`, `full`, `auto`, `plain`) with the same one-line descriptions `bat --help` prints.
- An 8-row "individual components" table (`changes`, `header`, `header-filename`, `header-filesize`, `grid`, `rule`, `numbers`, `snip`) with the same descriptions.

The existing tip block about `+`/`-` modifier prefixes is unchanged.

## Testing

Every value and description was verified against `bat --help` output on bat 0.26.1 locally. The README markdown was eyeballed for table rendering. No code paths were touched.

Closes #3228
