### PR TITLE
[bat] Fix ctrl-c exiting less when BAT_PAGER is set

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -151,7 +151,11 @@ impl OutputType {
 
                 // Ensures that 'less' quits together with 'bat'
                 // The BusyBox version of less does not support -K
-                if less_version != Some(LessVersion::BusyBox) {
+                // Only add -K if the pager came from the generic PAGER env var,
+                // not if it came from BAT_PAGER, --pager, or config
+                if less_version != Some(LessVersion::BusyBox)
+                    && pager.source == PagerSource::EnvVarPager
+                {
                     p.arg("-K"); // Short version of '--quit-on-intr'
                 }
 


### PR DESCRIPTION
When a user explicitly sets BAT_PAGER environment variable, they expect their pager configuration to be respected. The -K (--quit-on-intr) flag was being added to less even when BAT_PAGER was set, causing ctrl-c to exit less immediately instead of allowing the user to scroll.

This fix ensures -K is only added when the pager comes from the generic PAGER environment variable (which defaults to 'less' on most systems), not when the user explicitly configures BAT_PAGER, --pager, or config.

Fixes #3444