### PR TITLE
fix sanitation for --strip-ansi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies in `--strip-ansi=always`. Previously these passed through as text, see #3725 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)
 - Sanitize control characters in filenames before displaying them in the file header, error messages, and the terminal title, preventing ANSI escape injection via crafted filenames. Closes #3054, see #3691 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## Bugfixes
 - Strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies in `--strip-ansi=always`. Previously these passed through as text, see #3725 (@curious-rabbit)
+- `--strip-ansi=always`: also consume the trailing byte of single-byte ESC sequences (RIS, DECSC/DECRC, keypad, VT52). Previously the byte after ESC leaked as text, see #3725 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)
 - Sanitize control characters in filenames before displaying them in the file header, error messages, and the terminal title, preventing ANSI escape injection via crafted filenames. Closes #3054, see #3691 (@curious-rabbit)

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -281,6 +281,16 @@ fn test_strip_ansi_8bit_c1() {
 }
 
 #[test]
+fn test_strip_ansi_single_char_esc() {
+    // Single-byte ESC sequences (RIS, DECSC/DECRC, keypad, VT52). The byte
+    // after ESC is part of the sequence; both must be stripped.
+    assert_eq!(strip_ansi("a\x1bcb"), "ab");
+    assert_eq!(strip_ansi("a\x1b7b\x1b8c"), "abc");
+    assert_eq!(strip_ansi("a\x1b=b\x1b>c"), "abc");
+    assert_eq!(strip_ansi("a\x1bZb"), "ab");
+}
+
+#[test]
 fn test_strip_overstrike() {
     // Bold: X\x08X (same char repeated)
     assert_eq!(strip_overstrike("H\x08Hello", 1), "Hello");

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -271,6 +271,16 @@ fn test_strip_ansi() {
 }
 
 #[test]
+fn test_strip_ansi_8bit_c1() {
+    // 8-bit CSI introducer (U+009B) followed by SGR.
+    assert_eq!(strip_ansi("a\u{9B}31mRED\u{9B}0mb"), "aREDb");
+    // 7-bit DCS body must also be consumed.
+    assert_eq!(strip_ansi("a\x1bP1;0|payload\x1b\\b"), "ab");
+    // 8-bit DCS body via U+0090 + U+009C terminator.
+    assert_eq!(strip_ansi("a\u{90}body\u{9C}b"), "ab");
+}
+
+#[test]
 fn test_strip_overstrike() {
     // Bold: X\x08X (same char repeated)
     assert_eq!(strip_overstrike("H\x08Hello", 1), "Hello");

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -386,12 +386,23 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
     }
 
     fn next_text(&mut self) -> Option<EscapeSequenceOffsets> {
-        self.chars_take_while(|c| c != '\x1B')
+        self.chars_take_while(|c| !is_sequence_introducer(c))
             .map(|(start, end)| EscapeSequenceOffsets::Text { start, end })
     }
 
     fn next_sequence(&mut self) -> Option<EscapeSequenceOffsets> {
         let (start_sequence, c) = self.chars.next().expect("to not be finished");
+
+        // Handle 8-bit C1 introducers as their 7-bit `ESC <x>` equivalents.
+        match c {
+            '\u{9B}' => return self.next_csi_body(start_sequence),
+            '\u{9D}' => return self.next_osc_body(start_sequence),
+            '\u{90}' | '\u{98}' | '\u{9E}' | '\u{9F}' => {
+                return self.next_string_terminated_body(start_sequence)
+            }
+            _ => {}
+        }
+
         match self.chars.peek() {
             None => Some(EscapeSequenceOffsets::Unknown {
                 start: start_sequence,
@@ -400,6 +411,11 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
 
             Some((_, ']')) => self.next_osc(start_sequence),
             Some((_, '[')) => self.next_csi(start_sequence),
+            // 7-bit DCS/SOS/PM/APC: `ESC P/X/^/_` introduces a string body.
+            Some((_, 'P' | 'X' | '^' | '_')) => {
+                self.chars.next();
+                self.next_string_terminated_body(start_sequence)
+            }
             Some((i, c)) => match c {
                 '\x20'..='\x2F' => self.next_nf(start_sequence),
                 c => Some(EscapeSequenceOffsets::Unknown {
@@ -413,12 +429,27 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
     fn next_osc(&mut self, start_sequence: usize) -> Option<EscapeSequenceOffsets> {
         let (osc_open_index, osc_open_char) = self.chars.next().expect("to not be finished");
         debug_assert_eq!(osc_open_char, ']');
+        let start_command = osc_open_index + osc_open_char.len_utf8();
+        Some(self.read_osc_body(start_sequence, start_command))
+    }
 
+    /// OSC body parser entered after the 8-bit introducer U+009D was consumed.
+    fn next_osc_body(&mut self, start_sequence: usize) -> Option<EscapeSequenceOffsets> {
+        let start_command = start_sequence + '\u{9D}'.len_utf8();
+        Some(self.read_osc_body(start_sequence, start_command))
+    }
+
+    fn read_osc_body(
+        &mut self,
+        start_sequence: usize,
+        start_command: usize,
+    ) -> EscapeSequenceOffsets {
         let mut start_terminator: usize;
         let mut end_sequence: usize;
 
         loop {
-            match self.chars_take_while(|c| !matches!(c, '\x07' | '\x1B')) {
+            // ST is BEL, ESC `\\`, or U+009C.
+            match self.chars_take_while(|c| !matches!(c, '\x07' | '\x1B' | '\u{9C}')) {
                 None => {
                     start_terminator = self.text.len();
                     end_sequence = start_terminator;
@@ -434,6 +465,11 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
             match self.chars.next() {
                 Some((ti, '\x07')) => {
                     end_sequence = ti + '\x07'.len_utf8();
+                    break;
+                }
+
+                Some((ti, '\u{9C}')) => {
+                    end_sequence = ti + '\u{9C}'.len_utf8();
                     break;
                 }
 
@@ -466,10 +502,61 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
             }
         }
 
-        Some(EscapeSequenceOffsets::OSC {
+        EscapeSequenceOffsets::OSC {
             start_sequence,
-            start_command: osc_open_index + osc_open_char.len_utf8(),
+            start_command,
             start_terminator,
+            end: end_sequence,
+        }
+    }
+
+    /// DCS/SOS/PM/APC body parser. Emitted as `Unknown` so the body is stripped.
+    fn next_string_terminated_body(
+        &mut self,
+        start_sequence: usize,
+    ) -> Option<EscapeSequenceOffsets> {
+        let mut end_sequence: usize;
+
+        loop {
+            match self.chars_take_while(|c| !matches!(c, '\x07' | '\x1B' | '\u{9C}')) {
+                None => {
+                    end_sequence = self.text.len();
+                    break;
+                }
+                Some((_, end)) => {
+                    end_sequence = end;
+                }
+            }
+
+            match self.chars.next() {
+                Some((ti, '\x07')) => {
+                    end_sequence = ti + '\x07'.len_utf8();
+                    break;
+                }
+                Some((ti, '\u{9C}')) => {
+                    end_sequence = ti + '\u{9C}'.len_utf8();
+                    break;
+                }
+                Some((ti, '\x1B')) => match self.chars.next() {
+                    Some((i, '\\')) => {
+                        end_sequence = i + '\\'.len_utf8();
+                        break;
+                    }
+                    None => {
+                        end_sequence = ti + '\x1B'.len_utf8();
+                        break;
+                    }
+                    _ => {}
+                },
+                None => break,
+                Some((_, tc)) => {
+                    panic!("this should not be reached: char {tc:?}")
+                }
+            }
+        }
+
+        Some(EscapeSequenceOffsets::Unknown {
+            start: start_sequence,
             end: end_sequence,
         })
     }
@@ -477,9 +564,20 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
     fn next_csi(&mut self, start_sequence: usize) -> Option<EscapeSequenceOffsets> {
         let (csi_open_index, csi_open_char) = self.chars.next().expect("to not be finished");
         debug_assert_eq!(csi_open_char, '[');
+        Some(self.read_csi_body(start_sequence, csi_open_index + csi_open_char.len_utf8()))
+    }
 
-        let start_parameters: usize = csi_open_index + csi_open_char.len_utf8();
+    /// CSI body parser entered after the 8-bit introducer U+009B was consumed.
+    fn next_csi_body(&mut self, start_sequence: usize) -> Option<EscapeSequenceOffsets> {
+        let start_parameters = start_sequence + '\u{9B}'.len_utf8();
+        Some(self.read_csi_body(start_sequence, start_parameters))
+    }
 
+    fn read_csi_body(
+        &mut self,
+        start_sequence: usize,
+        start_parameters: usize,
+    ) -> EscapeSequenceOffsets {
         // Keep iterating while within the range of `0x30-0x3F`.
         let mut start_intermediates: usize = start_parameters;
         if let Some((_, end)) = self.chars_take_while(|c| matches!(c, '\x30'..='\x3F')) {
@@ -498,13 +596,13 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
             Some((i, c)) => i + c.len_utf8(),
         };
 
-        Some(EscapeSequenceOffsets::CSI {
+        EscapeSequenceOffsets::CSI {
             start_sequence,
             start_parameters,
             start_intermediates,
             start_final_byte,
             end: end_of_sequence,
-        })
+        }
     }
 
     fn next_nf(&mut self, start_sequence: usize) -> Option<EscapeSequenceOffsets> {
@@ -543,11 +641,20 @@ impl Iterator for EscapeSequenceOffsetsIterator<'_> {
     type Item = EscapeSequenceOffsets;
     fn next(&mut self) -> Option<Self::Item> {
         match self.chars.peek() {
-            Some((_, '\x1B')) => self.next_sequence(),
+            Some((_, c)) if is_sequence_introducer(*c) => self.next_sequence(),
             Some((_, _)) => self.next_text(),
             None => None,
         }
     }
+}
+
+/// True for ESC and the 8-bit C1 sequence introducers (DCS/SOS/CSI/OSC/PM/APC).
+#[inline]
+fn is_sequence_introducer(c: char) -> bool {
+    matches!(
+        c,
+        '\x1B' | '\u{90}' | '\u{98}' | '\u{9B}' | '\u{9D}' | '\u{9E}' | '\u{9F}'
+    )
 }
 
 /// An iterator over ANSI/VT escape sequences within a string.
@@ -715,6 +822,79 @@ mod tests {
                 end: 4,
             })
         );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_8bit_csi() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\u{9B}31m");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::CSI {
+                start_sequence: 0,
+                start_parameters: 2,
+                start_intermediates: 4,
+                start_final_byte: 4,
+                end: 5,
+            })
+        );
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_8bit_osc_with_8bit_st() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\u{9D}0;title\u{9C}");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::OSC {
+                start_sequence: 0,
+                start_command: 2,
+                start_terminator: 9,
+                end: 11,
+            })
+        );
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_parses_7bit_dcs_consumes_body() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\x1BP1;0;|payload\x1B\\rest");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::Unknown { start: 0, end: 16 })
+        );
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::Text { start: 16, end: 20 })
+        );
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_8bit_dcs_consumes_body() {
+        let mut iter = EscapeSequenceOffsetsIterator::new("\u{90}body\u{9C}rest");
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::Unknown { start: 0, end: 8 })
+        );
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::Text { start: 8, end: 12 })
+        );
+    }
+
+    #[test]
+    fn test_escape_sequence_offsets_iterator_truncated_dcs_consumes_to_eof() {
+        // Unterminated DCS must still be consumed, not emitted as `Text`.
+        let input = "\x1BPno-terminator";
+        let mut iter = EscapeSequenceOffsetsIterator::new(input);
+        assert_eq!(
+            iter.next(),
+            Some(EscapeSequenceOffsets::Unknown {
+                start: 0,
+                end: input.len(),
+            })
+        );
+        assert_eq!(iter.next(), None);
     }
 
     #[test]

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -651,9 +651,13 @@ impl Iterator for EscapeSequenceOffsetsIterator<'_> {
 /// True for ESC and the 8-bit C1 sequence introducers (DCS/SOS/CSI/OSC/PM/APC).
 #[inline]
 fn is_sequence_introducer(c: char) -> bool {
+    // Fast path: most bytes are ASCII non-ESC.
+    if (c as u32) < 0x80 {
+        return c == '\x1B';
+    }
     matches!(
         c,
-        '\x1B' | '\u{90}' | '\u{98}' | '\u{9B}' | '\u{9D}' | '\u{9E}' | '\u{9F}'
+        '\u{90}' | '\u{98}' | '\u{9B}' | '\u{9D}' | '\u{9E}' | '\u{9F}'
     )
 }
 

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -416,12 +416,19 @@ impl<'a> EscapeSequenceOffsetsIterator<'a> {
                 self.chars.next();
                 self.next_string_terminated_body(start_sequence)
             }
-            Some((i, c)) => match c {
+            Some(&(i, c)) => match c {
                 '\x20'..='\x2F' => self.next_nf(start_sequence),
-                c => Some(EscapeSequenceOffsets::Unknown {
-                    start: start_sequence,
-                    end: i + c.len_utf8(),
-                }),
+                c => {
+                    // Single-byte ESC sequence (RIS, DECSC/DECRC, keypad, VT52 etc.).
+                    let end = match self.chars.next() {
+                        Some((j, fc)) => j + fc.len_utf8(),
+                        None => i + c.len_utf8(),
+                    };
+                    Some(EscapeSequenceOffsets::Unknown {
+                        start: start_sequence,
+                        end,
+                    })
+                }
             },
         }
     }


### PR DESCRIPTION
`--strip-ansi=always` left two classes of ANSI escape sequence in the output:

- **8-bit C1 introducers** (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F). On terminals that interpret 8-bit C1 in UTF-8 (kitty, by default; older xterm and VTE configurations), these are the single-codepoint equivalents of `ESC P`, `ESC X`, `ESC [`, `ESC ]`, `ESC ^`, `ESC _` . They introduce DCS, SOS, CSI, OSC, PM, and APC sequences respectively. Bat's parser treated them as text.
- **DCS / SOS / PM / APC bodies**. Even when introduced by the 7-bit `ESC P/X/^/_`, the body up to the string terminator was emitted as text and survived `strip_ansi`.

This patch teaches `EscapeSequenceOffsetsIterator` to recognise the 8-bit introducers as their 7-bit equivalents, and to consume string-terminated bodies (via either form of introducer) as a single opaque `Unknown` segment. Both then drop out of `strip_ansi` along with the existing CSI/OSC handling.

A small unit test in `src/preprocessor.rs` covers the three new cases (8-bit CSI, 7-bit DCS body, 8-bit DCS body with 8-bit ST). 


Note:
--strip-ansi=always is bypassed entirely when bat selects SimplePrinter (i.e. when stdout is piped or --color=never is set), so bat --strip-ansi=always file | grep … **returns the raw escape sequences**. 
The existing strip_ansi_does_not_affect_simple_printer test seems to lock this in deliberately. is that still the intended scope, or shoudl this be fixed? strip-ansi=always implies it always filters but thats not true