### PR TITLE
Replace unmaintained serde_yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Replace the unmaintained `serde_yaml` crate with the maintained `serde_yaml_ng` fork, see #3727 (@curious-rabbit)
+- Cap bincode asset deserialisation at 256 MiB so a corrupt or malicious cache file cannot trigger an unbounded allocation, see #3727 (@curious-rabbit)
+- Cap per-line reads at 64 MiB so a file with no newline does not grow the line buffer without bound, see #3727 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)
 - Sanitize control characters in filenames before displaying them in the file header, error messages, and the terminal title, preventing ANSI escape injection via crafted filenames. Closes #3054, see #3691 (@curious-rabbit)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_with",
- "serde_yaml",
+ "serde_yaml_ng",
  "serial_test",
  "shell-words",
  "syn",
@@ -1436,10 +1436,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ unicode-width = "0.2.2"
 globset = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
-serde_yaml = "0.9.28"
+serde_yaml_ng = "0.10.0"
 semver = "1.0"
 path_abs = { version = "0.5", default-features = false }
 clircle = { version = "0.6.1", default-features = false }

--- a/examples/yaml.rs
+++ b/examples/yaml.rs
@@ -24,7 +24,7 @@ fn main() {
     };
 
     let mut bytes = Vec::with_capacity(128);
-    serde_yaml::to_writer(&mut bytes, &person).unwrap();
+    serde_yaml_ng::to_writer(&mut bytes, &person).unwrap();
     PrettyPrinter::new()
         .language("yaml")
         .line_numbers(true)

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -389,6 +389,9 @@ pub fn get_acknowledgements() -> String {
     )
 }
 
+/// Cap on bytes consumed by a single bincode asset deserialization.
+const ASSET_DESERIALIZE_LIMIT: u64 = 256 * 1024 * 1024;
+
 pub(crate) fn from_binary<T: serde::de::DeserializeOwned>(v: &[u8], compressed: bool) -> T {
     asset_from_contents(v, "n/a", compressed)
         .expect("data integrated in binary is never faulty, but make sure `compressed` is in sync!")
@@ -399,10 +402,17 @@ fn asset_from_contents<T: serde::de::DeserializeOwned>(
     description: &str,
     compressed: bool,
 ) -> Result<T> {
+    use bincode::Options;
+    // Default options + size limit, so a hostile length prefix can't OOM.
+    let opts = bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+        .with_limit(ASSET_DESERIALIZE_LIMIT);
+
     if compressed {
-        bincode::deserialize_from(flate2::read::ZlibDecoder::new(contents))
+        opts.deserialize_from(flate2::read::ZlibDecoder::new(contents))
     } else {
-        bincode::deserialize_from(contents)
+        opts.deserialize_from(contents)
     }
     .map_err(|_| format!("Could not parse {description}").into())
 }

--- a/src/assets/assets_metadata.rs
+++ b/src/assets/assets_metadata.rs
@@ -27,14 +27,14 @@ impl AssetsMetadata {
     #[cfg(feature = "build-assets")]
     pub(crate) fn save_to_folder(&self, path: &Path) -> Result<()> {
         let file = File::create(path.join(FILENAME))?;
-        serde_yaml::to_writer(file, self)?;
+        serde_yaml_ng::to_writer(file, self)?;
 
         Ok(())
     }
 
     fn try_load_from_folder(path: &Path) -> Result<Self> {
         let file = File::open(path.join(FILENAME))?;
-        Ok(serde_yaml::from_reader(file)?)
+        Ok(serde_yaml_ng::from_reader(file)?)
     }
 
     /// Load metadata about the stored cache file from the given folder.

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[error(transparent)]
     GlobParsingError(#[from] ::globset::Error),
     #[error(transparent)]
-    SerdeYamlError(#[from] ::serde_yaml::Error),
+    SerdeYamlError(#[from] ::serde_yaml_ng::Error),
     #[error("unable to detect syntax for {0}")]
     UndetectedSyntax(String),
     #[error("unknown syntax: '{0}'")]

--- a/src/input.rs
+++ b/src/input.rs
@@ -264,14 +264,17 @@ impl<'a> InputReader<'a> {
 
     pub(crate) fn try_new<R: BufRead + 'a>(mut reader: R) -> io::Result<InputReader<'a>> {
         let mut first_line = vec![];
-        reader.read_until(b'\n', &mut first_line)?;
+        let mut truncated = false;
+        read_until_capped(&mut reader, b'\n', &mut first_line, &mut truncated)?;
 
         let content_type = inspect_content_type(&first_line);
 
-        if content_type == Some(ContentType::UTF_16LE) {
-            read_utf16_line(&mut reader, &mut first_line, 0x00, 0x0A)?;
-        } else if content_type == Some(ContentType::UTF_16BE) {
-            read_utf16_line(&mut reader, &mut first_line, 0x0A, 0x00)?;
+        if !truncated {
+            if content_type == Some(ContentType::UTF_16LE) {
+                read_utf16_line(&mut reader, &mut first_line, 0x00, 0x0A)?;
+            } else if content_type == Some(ContentType::UTF_16BE) {
+                read_utf16_line(&mut reader, &mut first_line, 0x0A, 0x00)?;
+            }
         }
 
         Ok(InputReader {
@@ -299,8 +302,8 @@ impl<'a> InputReader<'a> {
             return self.read_line_unbuffered(buf);
         }
 
-        let res = self.inner.read_until(b'\n', buf).map(|size| size > 0)?;
-        Ok(res)
+        let mut truncated = false;
+        read_until_capped(&mut self.inner, b'\n', buf, &mut truncated)
     }
 
     fn read_line_unbuffered(&mut self, buf: &mut Vec<u8>) -> io::Result<bool> {
@@ -317,6 +320,53 @@ impl<'a> InputReader<'a> {
             self.inner.consume(len);
         }
         Ok(true)
+    }
+}
+
+/// Cap on bytes for a single line; protects against files with no `\n`.
+pub(crate) const MAX_LINE_BYTES: usize = 64 * 1024 * 1024;
+
+/// `BufRead::read_until` capped at `MAX_LINE_BYTES`; on cap, drains to next `delim`.
+fn read_until_capped<R: BufRead + ?Sized>(
+    reader: &mut R,
+    delim: u8,
+    buf: &mut Vec<u8>,
+    truncated: &mut bool,
+) -> io::Result<bool> {
+    let initial = buf.len();
+    loop {
+        let remaining = MAX_LINE_BYTES.saturating_sub(buf.len());
+        if remaining == 0 {
+            *truncated = true;
+            let mut sink = vec![];
+            loop {
+                let chunk = reader.fill_buf()?;
+                if chunk.is_empty() {
+                    break;
+                }
+                if let Some(pos) = chunk.iter().position(|&b| b == delim) {
+                    reader.consume(pos + 1);
+                    break;
+                }
+                let len = chunk.len();
+                sink.clear();
+                sink.extend_from_slice(chunk);
+                reader.consume(len);
+            }
+            return Ok(true);
+        }
+        let chunk = reader.fill_buf()?;
+        if chunk.is_empty() {
+            return Ok(buf.len() != initial);
+        }
+        let take = chunk.len().min(remaining);
+        if let Some(pos) = chunk[..take].iter().position(|&b| b == delim) {
+            buf.extend_from_slice(&chunk[..=pos]);
+            reader.consume(pos + 1);
+            return Ok(true);
+        }
+        buf.extend_from_slice(&chunk[..take]);
+        reader.consume(take);
     }
 }
 
@@ -346,13 +396,20 @@ fn read_utf16_line<R: BufRead>(
     preceded_by_char: u8,
 ) -> io::Result<bool> {
     loop {
+        if buf.len() >= MAX_LINE_BYTES {
+            break;
+        }
         let mut temp = Vec::new();
-        let n = reader.read_until(read_until_char, &mut temp)?;
-        if n == 0 {
+        let mut truncated = false;
+        let n = read_until_capped(reader, read_until_char, &mut temp, &mut truncated)?;
+        if !n {
             // EOF reached
             break;
         }
         buf.extend_from_slice(&temp);
+        if truncated {
+            break;
+        }
         if buf.len() >= 2
             && buf[buf.len() - 2] == preceded_by_char
             && buf[buf.len() - 1] == read_until_char
@@ -591,4 +648,53 @@ fn utf16le_issue3367() {
     assert!(res.is_ok());
     assert!(!res.unwrap());
     assert!(buffer.is_empty());
+}
+
+#[test]
+fn read_line_caps_unbounded_line() {
+    use std::io::Cursor;
+
+    let content = vec![b'A'; MAX_LINE_BYTES + 1024];
+    let mut reader = InputReader::new(Cursor::new(content));
+
+    let mut buffer = vec![];
+    let res = reader.read_line(&mut buffer);
+    assert!(res.is_ok());
+    assert!(res.unwrap());
+    assert_eq!(buffer.len(), MAX_LINE_BYTES);
+
+    buffer.clear();
+    let res = reader.read_line(&mut buffer);
+    assert!(res.is_ok());
+    assert!(!res.unwrap());
+    assert!(buffer.is_empty());
+}
+
+#[test]
+fn read_line_cap_then_resumes_on_next_line() {
+    use std::io::Cursor;
+
+    let mut content = vec![b'A'; MAX_LINE_BYTES + 1024];
+    content.push(b'\n');
+    content.extend_from_slice(b"second line\n");
+    let mut reader = InputReader::new(Cursor::new(content));
+
+    let mut buffer = vec![];
+    reader.read_line(&mut buffer).unwrap();
+    assert_eq!(buffer.len(), MAX_LINE_BYTES);
+
+    buffer.clear();
+    let res = reader.read_line(&mut buffer);
+    assert!(res.is_ok());
+    assert!(res.unwrap());
+    assert_eq!(b"second line\n", &buffer[..]);
+}
+
+#[test]
+fn first_line_caps_unbounded_input() {
+    use std::io::Cursor;
+
+    let content = vec![b'A'; MAX_LINE_BYTES + 4096];
+    let reader = InputReader::new(Cursor::new(content));
+    assert!(reader.first_line.len() <= MAX_LINE_BYTES);
 }

--- a/tests/github-actions.rs
+++ b/tests/github-actions.rs
@@ -1,7 +1,7 @@
 #[test]
 fn all_jobs_not_missing_any_jobs() {
-    let yaml: serde_yaml::Value =
-        serde_yaml::from_reader(std::fs::File::open(".github/workflows/CICD.yml").unwrap())
+    let yaml: serde_yaml_ng::Value =
+        serde_yaml_ng::from_reader(std::fs::File::open(".github/workflows/CICD.yml").unwrap())
             .unwrap();
     let jobs = yaml.get("jobs").unwrap();
 


### PR DESCRIPTION
* Replace unmaintained serde_yaml with serde_yaml_ng.
* Cap bincode asset deserialization at 256 MiB so a hostile length prefix in the cache cannot trigger an unbounded allocation.
* Cap per-line reads in InputReader at 64 MiB so a file with no newline cannot grow the line buffer without bound.