### PR TITLE
Fix README Fedora section links

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ pacman -S bat
 
 ### On Fedora
 
-You can install [the `bat` package](https://koji.fedoraproject.org/koji/packageinfo?packageID=27506) from the official sources:
+You can install [the `bat` package](https://packages.fedoraproject.org/pkgs/rust-bat/bat/) from the official sources:
 
 ```bash
 dnf install bat

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ pacman -S bat
 
 ### On Fedora
 
-You can install [the `bat` package](https://koji.fedoraproject.org/koji/packageinfo?packageID=27506) from the official [Fedora Modular](https://docs.fedoraproject.org/en-US/modularity/using-modules/) repository.
+You can install [the `bat` package](https://koji.fedoraproject.org/koji/packageinfo?packageID=27506) from the official sources:
 
 ```bash
 dnf install bat


### PR DESCRIPTION
The modular repository has been retired as of Fedora 39 (https://fedoraproject.org/wiki/Changes/RetireModularity). `bat` is now present in `updates` (https://docs.fedoraproject.org/en-US/quick-docs/fedora-repositories/#the-updates-repository).

This PR removes the link to the (now dead/404 page for modularity) and makes it the same as the others. I didn't think it necessary to include the details of it being in `updates` as it isn't something that needs to be enabled by default.

It also updates the link to the Fedora package from the build system page to the proper package page (that still links back to the build system) and feels more unified with the links to other distro packages.