### PR TITLE
docs: align translated READMEs with English MANPAGER section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
+- Align translated README MANPAGER docs with current English version, see #3731 (@ChrisJr404). Closes #3730
 
 ## Features
 

--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -163,12 +163,10 @@ bat main.cpp | xclip
 `man` の色付けページャーとして使用できます:
 
 ```bash
-export MANPAGER="sh -c 'col -bx | bat -l man -p'"
+export MANPAGER="bat -plman"
 man 2 select
 ```
-
-フォーマットの問題が発生した場合は
-`MANROFFOPT="-c"` を設定する必要もあります。
+(一部の古い Debian または Ubuntu のリリースでは、実行ファイル名は `bat` ではなく `batcat` です)
 
 これを新しいコマンドにバンドルしたい場合は [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md) も使用できます。
 

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -189,12 +189,10 @@ bat main.cpp | xclip
 있습니다.
 
 ```bash
-export MANPAGER="sh -c 'col -bx | bat -l man -p'"
+export MANPAGER="bat -plman"
 man 2 select
 ```
-(Debian이나 Ubuntu를 사용한다면 `bat`을 `batcat`으로 치환하세요.)
-
-포팻 문제가 발생한다면, `MANROFFOPT="-c"`을 써야 할 수 있습니다.
+(일부 오래된 Debian 또는 Ubuntu 배포판에서는 실행 파일 이름이 `bat`이 아닌 `batcat`입니다.)
 
 이 기능을 포함한 새로운 명령어를 선호한다면,
 [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md)을 쓸
@@ -202,9 +200,6 @@ man 2 select
 
 참고로 [Manpage 문법](../assets/syntaxes/Manpage.sublime-syntax)은 본 저장소에서
 개발 중에 있으며, 아직 더 손봐야 합니다.
-
-또한, 이는 Mandoc의 `man` 구현에서
-[작동하지 않습니다](https://github.com/sharkdp/bat/issues/1145).
 
 #### `prettier` / `shfmt` / `rustfmt`
 

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -167,18 +167,14 @@ bat main.cpp | xclip
 `MANPAGER`:
 
 ```bash
-export MANPAGER="sh -c 'col -bx | bat -l man -p'"
+export MANPAGER="bat -plman"
 man 2 select
 ```
-(замените `bat` на `batcat`, если у вас Debian или Ubuntu)
-
-Возможно вам понадобится также установить `MANROFFOPT="-c"`, если у вас есть проблемы с форматированием.
+(в некоторых старых выпусках Debian или Ubuntu исполняемый файл называется `batcat` вместо `bat`)
 
 Если вы хотите сделать этой одной командой, вы можете использовать [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md).
 
 Обратите внимание, что [синтаксис manpage](assets/syntaxes/02_Extra/Manpage.sublime-syntax) разрабатывается в этом репозитории и все еще находится в разработке.
-
-Также заметьте, что это [не заработает](https://github.com/sharkdp/bat/issues/1145) с реализацией `man` через Mandocs.
 
 #### `prettier` / `shfmt` / `rustfmt`
 

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -173,18 +173,13 @@ bat main.cpp | xclip
 `bat` 可以通过设置 `MANPAGER` 环境变量，用作 `man` 的彩色分页器：
 
 ```bash
-export MANPAGER="sh -c 'awk '\''{ gsub(/\x1B\[[0-9;]*m/, \"\", \$0); gsub(/.\x08/, \"\", \$0); print }'\'' | bat -p -lman'"
+export MANPAGER="bat -plman"
 man 2 select
 ```
 
-（如果你使用 Debian 或 Ubuntu，请将 `batcat` 替换为 `bat`）
+（在某些较旧的 Debian 或 Ubuntu 发行版中，可执行文件名为 `batcat` 而非 `bat`）
 
 如果你希望将其打包为一个新的命令，也可以使用 [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md)。
-
-> [!WARNING]
-> 在使用 Mandoc 的 `man` 实现时，这[无法](https://github.com/sharkdp/bat/issues/1145)直接工作。
->
-> 请使用 `batman`，或将此 Shell 脚本包装为 [Shebang 可执行文件](https://en.wikipedia.org/wiki/Shebang_(Unix))，并将 `MANPAGER` 指向该文件。
 
 注意，[Manpage 语法](assets/syntaxes/02_Extra/Manpage.sublime-syntax)是在此仓库中开发的，仍需一些改进。
 


### PR DESCRIPTION
Closes #3730.

The translated READMEs (zh/ru/ko/ja) drifted out of sync with the English README's `man` section after #3517 simplified the MANPAGER example to `bat -plman` (the runtime now strips overstriking via `strip_overstrike`, so the `col -bx`/`awk` and `MANROFFOPT="-c"` workarounds are no longer needed).

The Chinese README was also showing the bat/batcat substitution direction reversed ("replace `batcat` with `bat`" instead of the other way around), and the Japanese README was missing the batcat note entirely.

### Changes per file

| File | MANPAGER pipe | batcat note | Mandoc warning | MANROFFOPT note |
| --- | --- | --- | --- | --- |
| `doc/README-zh.md` | `awk ... \| bat -p -lman` -> `bat -plman` | reversed -> fixed | dropped | n/a |
| `doc/README-ru.md` | `col -bx \| bat -l man -p` -> `bat -plman` | reworded to match English | dropped | dropped |
| `doc/README-ko.md` | `col -bx \| bat -l man -p` -> `bat -plman` | reworded to match English | dropped | dropped |
| `doc/README-ja.md` | `col -bx \| bat -l man -p` -> `bat -plman` | added (was missing) | n/a | dropped |

The English `README.md` is unchanged and is treated as the source of truth, since #3517 explicitly simplified its `man` section after adding `strip_overstrike` to the runtime.

### Why drop the warnings/notes

- `MANROFFOPT="-c"` and `col -bx` were workarounds for backspace overstriking; with #3517's `strip_overstrike` they're redundant.
- The Mandoc `> [!WARNING]` block was removed from `README.md` in #3517 for the same reason; the translated copies were just stragglers.

Each language's prose is preserved verbatim aside from the lines listed above; this is purely a technical-accuracy and consistency cleanup.

### Note on #3684

There's an open PR (#3684) that proposes re-introducing `col -bx` + `MANROFFOPT="-c"` to the English README. If that lands, the same change can be mirrored across the translations in a one-line follow-up; in the meantime this PR keeps the four translations honest with what's currently in `README.md`.