### PR TITLE
docs: warn about zsh -h global alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- Warn about `zsh` global `-h` alias side effects in README, see #3732 (@MrSebicu). Closes #3486
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 

--- a/README.md
+++ b/README.md
@@ -210,12 +210,13 @@ help() {
 
 Then you can do `$ help cp` or `$ help git commit`.
 
-When you are using `zsh`, you can also use global aliases to override `-h` and `--help` entirely:
+When you are using `zsh`, you can also use a global alias for `--help`:
 
 ```bash
-alias -g -- -h='-h 2>&1 | bat --language=help --style=plain'
 alias -g -- --help='--help 2>&1 | bat --language=help --style=plain'
 ```
+
+Avoid installing a `zsh` global alias for `-h` unless you are comfortable with its side effects. `zsh` expands global aliases anywhere on the command line, including sourced shell scripts and conditionals such as `[[ -h "$path" ]]`, so a global `-h` alias can break tools that use `-h` as the "is symlink" test.
 
 For `fish`, you can use abbreviations:
 


### PR DESCRIPTION
Fixes #3486.

## Summary
- stop recommending a zsh global alias for `-h` in the help-highlighting docs
- explain that zsh global aliases expand inside sourced scripts and conditionals such as `[[ -h "$path" ]]`
- keep the safer `--help` global alias and existing fish abbreviation examples

## Testing
- `git diff --check`