### PR TITLE
fix: pass --color=never --decorations=never in zsh completions

### DIFF
--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -90,20 +90,20 @@ _{{PROJECT_EXECUTABLE}}_main() {
         languages)
             local IFS=$'\n'
             local -a languages
-            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --list-languages | awk -F':|,' '{ for (i = 1; i <= NF; ++i) printf("%s:%s\n", $i, $1) }')"} )
+            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-languages | awk -F':|,' '{ for (i = 1; i <= NF; ++i) printf("%s:%s\n", $i, $1) }')"} )
 
             _describe 'language' languages && ret=0
         ;;
 
         themes)
             local -a themes expl
-            themes=(${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --list-themes)"} )
+            themes=(${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-themes)"} )
 
             _wanted themes expl 'theme' compadd -a themes && ret=0
         ;;
         theme_preferences)
             local -a themes expl
-            themes=(auto dark light auto:always auto:system ${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --list-themes)"} )
+            themes=(auto dark light auto:always auto:system ${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-themes)"} )
 
             _wanted themes expl 'theme' compadd -a themes && ret=0
         ;;


### PR DESCRIPTION
Fixes #3733.

Zsh completion for `bat` shows ANSI escape codes and decoration characters
in the preview because `bat` is invoked without `--color=never` or
`--decorations=never`. The completions script calls `bat` for previews
but doesn't suppress formatting, so raw escape sequences leak into the
completion menu.

Add `--color=never --decorations=never` to the preview invocation in the
zsh completion script.