### PR TITLE
fix: only offer language names in zsh tab completion for `-l`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Fixed bug caused by using `--plain` and `--terminal-width=N` flags simultaneously, see #3529 (@H4k1l)
 - Fixed syntax tests path, see #3610 (@foxfromworld)
 - Fix zsh tab completion word-splitting language names containing spaces (e.g. `HTML (Jinja2)`, `Apache Conf`), see #3693 (@YoshKoz)
+- Fix zsh tab completion offering invalid `-l` arguments (file globs, paths, hidden filenames) sourced from the second column of `--list-languages`. Closes #3735, see #PR_NUMBER (@truffle-dev)
 
 ## Other
 - Use git version of cross. See #3533 (@OctopusET)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Fixed bug caused by using `--plain` and `--terminal-width=N` flags simultaneously, see #3529 (@H4k1l)
 - Fixed syntax tests path, see #3610 (@foxfromworld)
 - Fix zsh tab completion word-splitting language names containing spaces (e.g. `HTML (Jinja2)`, `Apache Conf`), see #3693 (@YoshKoz)
-- Fix zsh tab completion offering invalid `-l` arguments (file globs, paths, hidden filenames) sourced from the second column of `--list-languages`. Closes #3735, see #PR_NUMBER (@truffle-dev)
+- Fix zsh tab completion offering invalid `-l` arguments (file globs, paths, hidden filenames) sourced from the second column of `--list-languages`. Closes #3735, see #3737 (@truffle-dev)
 
 ## Other
 - Use git version of cross. See #3533 (@OctopusET)

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -90,12 +90,12 @@ _{{PROJECT_EXECUTABLE}}_main() {
         languages)
             local IFS=$'\n'
             local -a languages
-            # Only offer language names as completion values. The second column
-            # of `--list-languages` mixes plain extensions with globs (`*.rs`),
-            # absolute paths (`/etc/profile`), and full filenames
-            # (`Containerfile`); none of those parse as `-l` arguments. See
+            # `--list-languages` emits one `name:matchers` line per language,
+            # which `_describe` parses as `value:description`. Only the
+            # language name is offered as the completion value; the matchers
+            # show up as the menu description. See
             # https://github.com/sharkdp/bat/issues/3735.
-            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-languages | awk -F: '{ printf("%s:%s\n", $1, $2) }')"} )
+            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-languages)"} )
 
             _describe 'language' languages && ret=0
         ;;

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -90,7 +90,12 @@ _{{PROJECT_EXECUTABLE}}_main() {
         languages)
             local IFS=$'\n'
             local -a languages
-            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-languages | awk -F':|,' '{ for (i = 1; i <= NF; ++i) printf("%s:%s\n", $i, $1) }')"} )
+            # Only offer language names as completion values. The second column
+            # of `--list-languages` mixes plain extensions with globs (`*.rs`),
+            # absolute paths (`/etc/profile`), and full filenames
+            # (`Containerfile`); none of those parse as `-l` arguments. See
+            # https://github.com/sharkdp/bat/issues/3735.
+            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-languages | awk -F: '{ printf("%s:%s\n", $1, $2) }')"} )
 
             _describe 'language' languages && ret=0
         ;;


### PR DESCRIPTION
Closes #3735.

`bat --list-languages` prints `<name>:<file-matchers>`, where the matcher
column is a comma-separated mix of plain extensions (`rs`), globs
(`*.rs`), absolute paths (`/etc/profile`), and full filenames
(`Containerfile`). The zsh completion's awk script split each line on
`:` or `,` and emitted every field as a completion value, so tab
completion offered candidates that `-l` cannot parse:

```
$ bat -l '*.bash_login' /dev/null
[bat error]: unknown syntax: '*.bash_login'
```

Switch to splitting on `:` only, emit the language name as the
completion value, and use the matcher list as its description. This
matches the bash completion's behavior, which already keeps only the
first column (`assets/completions/bat.bash.in:80-89`).

After the change, the completion menu shows just language names with
their extensions as descriptive context:

```
ASP                            -- (asa)
ActionScript                   -- (as)
Ada                            -- (adb,ads)
...
```

Verified locally with `cargo build` and `cargo test --test integration_tests -- --test-threads=1` (232 passed). Unit tests (`cargo test --lib`) also pass (124).

The fish completion has a similar but partially-mitigated bug; out of scope here.