### PR TITLE
Fix --list-themes ignoring BAT_OPTS paging options (closes #1618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## Bugfixes
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
+- Fix `--list-themes` ignoring `BAT_OPTS` paging options (e.g., `--paging=always`), see #1618
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)
 - Sanitize control characters in filenames before displaying them in the file header, error messages, and the terminal title, preventing ANSI escape injection via crafted filenames. Closes #3054, see #3691 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ## Bugfixes
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
-- Fix `--list-themes` ignoring `BAT_OPTS` paging options (e.g., `--paging=always`), see #1618
+- Fix `--list-themes` ignoring `BAT_OPTS` paging options (e.g., `--paging=always`), see #1618, closes #3739 (@mkslzk)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)
 - Sanitize control characters in filenames before displaying them in the file header, error messages, and the terminal title, preventing ANSI escape injection via crafted filenames. Closes #3054, see #3691 (@curious-rabbit)

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -247,6 +247,10 @@ pub fn list_themes(
         ))?;
     }
 
+    // Ignore paging options for --list-themes to fix issue #1618
+    let mut config = config.clone();
+    config.paging_mode = PagingMode::Never;
+
     let mut output_type =
         OutputType::from_mode(config.paging_mode, config.wrapping_mode, config.pager)?;
     let mut writer = output_type.handle()?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -613,6 +613,21 @@ fn list_themes_to_piped_output() {
 }
 
 #[test]
+fn list_themes_ignores_paging_from_bat_opts() {
+    // Regression test for issue #1618
+    // --list-themes should never page, even when BAT_OPTS specifies --paging=always
+    bat()
+        .env("BAT_OPTS", "--paging=always --pager=less")
+        .arg("--list-themes")
+        .assert()
+        .success()
+        // All themes should be in the output, not just the first one
+        .stdout(predicate::str::contains("DarkNeon"))
+        .stdout(predicate::str::contains("1337"))
+        .stdout(predicate::str::contains("Dracula"));
+}
+
+#[test]
 fn list_languages() {
     bat()
         .arg("--list-languages")


### PR DESCRIPTION
## Summary

When `BAT_OPTS` contains `--paging=always`, the `--list-themes` command passes all themes through the pager one line at a time, making the output effectively unusable.

## Fix

Ignore paging options for `--list-themes`, consistent with how `--help` is handled. The config is cloned and `paging_mode` is set to `Never` before creating the OutputType.

**Changes:**
- `src/bin/bat/main.rs`: Clone config and set `paging_mode = PagingMode::Never` before OutputType creation
- `tests/integration_tests.rs`: Added regression test `list_themes_ignores_paging_from_bat_opts()`
- `CHANGELOG.md`: Added entry under Bugfixes

Closes #1618