### PR TITLE
docs: use double quotes in fzf examples for Windows compatibility

### DIFF
--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -104,7 +104,7 @@ bat f - g  # output 'f', then stdin, then 'g'.
 その場合、`bat` の `--color=always` オプションを用いてカラー出力を強制しなければなりません。
 また、`--line-range` オプションを用いることで巨大なファイルの読み込み時間を制限できます:
 ```bash
-fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}'
+fzf --preview "bat --color=always --style=numbers --line-range=:500 {}"
 ```
 
 詳しくは [`fzf` の `README`](https://github.com/junegunn/fzf#preview-window) を参照してください。

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -110,7 +110,7 @@ bat f - g  # output 'f', then stdin, then 'g'.
 합니다.
 또한 `--line-range` 옵션으로 긴 파일의 로드 시간을 제한할 수 있습니다:
 ```bash
-fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}'
+fzf --preview "bat --color=always --style=numbers --line-range=:500 {}"
 ```
 더 많은 정보는
 [`fzf`의 `README`](https://github.com/junegunn/fzf#preview-window)를 참고하세요.

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -99,7 +99,7 @@ bat f - g  # 输出 f，接着是标准输入流，最后 g
 你可以使用`bat`作为`fzf`的预览器。这需要在`bat`后添加`--color=always`选项，以及`--line-range` 选项来限制大文件的加载次数。
 
 ```bash
-fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}'
+fzf --preview "bat --color=always --style=numbers --line-range=:500 {}"
 ```
 
 更多信息请参阅[`fzf`的说明](https://github.com/junegunn/fzf#preview-window)。


### PR DESCRIPTION
The fzf preview example in the translated README files uses single quotes,
which don't work on Windows (PowerShell/cmd). The main README.md was already
updated to use double quotes, but the Japanese, Korean, and Chinese translations
still had single quotes.

This aligns the translated docs with the main README.

Fixes #2095
