### PR TITLE
fix: allow cache subcommand when ./cache is a directory (fixes #1726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Fix `bat cache --build` failing when a `cache` directory exists in the working directory, see #1726 (@leno23)
+- Fix `bat cache --build` failing when a `cache` directory exists in the working directory, see #1726, closes #3743 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Fix `bat cache --build` failing when a `cache` directory exists in the working directory, see #1726 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -701,9 +701,10 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .help("Print version"),
         );
 
-    // Check if the current directory contains a file name cache. Otherwise,
-    // enable the 'bat cache' subcommand.
-    if Path::new("cache").exists() {
+    // Check if the current directory contains a file named `cache`. Otherwise,
+    // enable the `bat cache` subcommand. A directory named `cache` must not
+    // disable the subcommand (see #1726).
+    if Path::new("cache").is_file() {
         app
     } else {
         app.subcommand(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1825,6 +1825,38 @@ fn cache_build() {
     assert!(tmp_metadata_path.exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn cache_build_twice_when_cache_directory_exists_in_cwd() {
+    let tmp_dir = tempdir().expect("can create temporary directory");
+    let root = tmp_dir.path();
+    let config_home = root.join("config");
+    let cache_dir = root.join("cache");
+    std::fs::create_dir_all(config_home.join("bat/themes")).unwrap();
+    std::fs::create_dir_all(config_home.join("bat/syntaxes")).unwrap();
+
+    bat_with_config()
+        .current_dir(root)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("BAT_CACHE_PATH", &cache_dir)
+        .arg("cache")
+        .arg("--build")
+        .arg("--blank")
+        .assert()
+        .success();
+    assert!(cache_dir.join("themes.bin").exists());
+    // `cache` is now a directory in cwd — must not disable the `cache` subcommand (#1726)
+    bat_with_config()
+        .current_dir(root)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("BAT_CACHE_PATH", &cache_dir)
+        .arg("cache")
+        .arg("--build")
+        .arg("--blank")
+        .assert()
+        .success();
+}
+
 #[test]
 fn utf16() {
     // The output will be converted to UTF-8 with the leading UTF-16


### PR DESCRIPTION
## Summary

`bat cache --build` failed on the second run when `BAT_CACHE_PATH` pointed to a `./cache` directory in the current working directory:

```
error: Found argument '--build' which wasn't expected
```

The `cache` subcommand was disabled whenever `Path::new("cache").exists()`, including when `cache` is a **directory** created by the previous build.

## Fix

Only disable the `cache` subcommand when `cache` is a **file** in the working directory (`is_file()`), matching the original intent in the comment.

## Tests

- Added `cache_build_twice_when_cache_directory_exists_in_cwd` integration test

Fixes #1726.