### PR TITLE
fix: disable less status column when paging (fixes #2497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Disable less's status column when paging so `$LESS=-J` does not overlap bat decorations, see #2497 (@leno23)
+- Fix `bat cache --build` failing when a `cache` directory exists in the working directory, see #1726, closes #3743 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Disable less's status column when paging so `$LESS=-J` does not overlap bat decorations, see #2497 (@leno23)
+- Disable less's status column when paging so `$LESS=-J` does not overlap bat decorations, see #2497, closes #3744 (@leno23)
 - Fix `bat cache --build` failing when a `cache` directory exists in the working directory, see #1726, closes #3743 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 
 ## Bugfixes
 - Disable less's status column when paging so `$LESS=-J` does not overlap bat decorations, see #2497, closes #3744 (@leno23)
-- Fix `bat cache --build` failing when a `cache` directory exists in the working directory, see #1726, closes #3743 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/src/output.rs
+++ b/src/output.rs
@@ -178,6 +178,13 @@ impl OutputType {
             } else {
                 p.args(args);
             }
+
+            // Disable less's status column; it conflicts with bat's line decorations when
+            // set via $LESS (e.g. `LESS=-J`). Command-line `+J` overrides `$LESS`, see #2497.
+            if retrieve_less_version(&pager.bin) != Some(LessVersion::BusyBox) {
+                p.arg("+J");
+            }
+
             p.env("LESSCHARSET", "UTF-8");
 
             #[cfg(feature = "lessopen")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1120,6 +1120,32 @@ fn do_not_exit_directory() {
 
 #[test]
 #[serial]
+#[cfg(unix)]
+fn less_status_column_disabled_when_less_env_has_j() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let less_mock = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("mocked-pagers")
+        .join("less");
+    let mut perms = std::fs::metadata(&less_mock).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&less_mock, perms).unwrap();
+
+    mocked_pagers::with_mocked_less_in_path(|| {
+        bat()
+            .env("LESS", "-J")
+            .env("PAGER", "less")
+            .arg("--paging=always")
+            .arg("test.txt")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("hello world").normalize());
+    });
+}
+
+#[test]
+#[serial]
 fn pager_basic() {
     mocked_pagers::with_mocked_versions_of_more_and_most_in_path(|| {
         bat()
@@ -1823,6 +1849,38 @@ fn cache_build() {
     assert!(tmp_syntaxes_path.exists());
     assert!(tmp_acknowledgements_path.exists());
     assert!(tmp_metadata_path.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn cache_build_twice_when_cache_directory_exists_in_cwd() {
+    let tmp_dir = tempdir().expect("can create temporary directory");
+    let root = tmp_dir.path();
+    let config_home = root.join("config");
+    let cache_dir = root.join("cache");
+    std::fs::create_dir_all(config_home.join("bat/themes")).unwrap();
+    std::fs::create_dir_all(config_home.join("bat/syntaxes")).unwrap();
+
+    bat_with_config()
+        .current_dir(root)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("BAT_CACHE_PATH", &cache_dir)
+        .arg("cache")
+        .arg("--build")
+        .arg("--blank")
+        .assert()
+        .success();
+    assert!(cache_dir.join("themes.bin").exists());
+    // `cache` is now a directory in cwd — must not disable the `cache` subcommand (#1726)
+    bat_with_config()
+        .current_dir(root)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("BAT_CACHE_PATH", &cache_dir)
+        .arg("cache")
+        .arg("--build")
+        .arg("--blank")
+        .assert()
+        .success();
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1851,38 +1851,6 @@ fn cache_build() {
     assert!(tmp_metadata_path.exists());
 }
 
-#[cfg(unix)]
-#[test]
-fn cache_build_twice_when_cache_directory_exists_in_cwd() {
-    let tmp_dir = tempdir().expect("can create temporary directory");
-    let root = tmp_dir.path();
-    let config_home = root.join("config");
-    let cache_dir = root.join("cache");
-    std::fs::create_dir_all(config_home.join("bat/themes")).unwrap();
-    std::fs::create_dir_all(config_home.join("bat/syntaxes")).unwrap();
-
-    bat_with_config()
-        .current_dir(root)
-        .env("XDG_CONFIG_HOME", &config_home)
-        .env("BAT_CACHE_PATH", &cache_dir)
-        .arg("cache")
-        .arg("--build")
-        .arg("--blank")
-        .assert()
-        .success();
-    assert!(cache_dir.join("themes.bin").exists());
-    // `cache` is now a directory in cwd — must not disable the `cache` subcommand (#1726)
-    bat_with_config()
-        .current_dir(root)
-        .env("XDG_CONFIG_HOME", &config_home)
-        .env("BAT_CACHE_PATH", &cache_dir)
-        .arg("cache")
-        .arg("--build")
-        .arg("--blank")
-        .assert()
-        .success();
-}
-
 #[test]
 fn utf16() {
     // The output will be converted to UTF-8 with the leading UTF-16

--- a/tests/mocked-pagers/less
+++ b/tests/mocked-pagers/less
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Mock `less` for integration tests. Verifies bat passes `+J` to override $LESS=-J (#2497).
+for arg in "$@"; do
+    if [[ "$arg" == "+J" ]]; then
+        has_plus_j=1
+        break
+    fi
+done
+if [[ -z "${has_plus_j:-}" ]]; then
+    echo "mock less: expected +J in arguments: $*" >&2
+    exit 1
+fi
+if [[ "${1:-}" == "--version" ]]; then
+    echo "less 608 (PCRE2 regular expressions)"
+    exit 0
+fi
+cat

--- a/tests/utils/mocked_pagers.rs
+++ b/tests/utils/mocked_pagers.rs
@@ -52,6 +52,13 @@ fn restore_path(original_path: String) {
     env::set_var("PATH", original_path);
 }
 
+/// Allows tests that need a mocked `less` in PATH (see `tests/mocked-pagers/less`).
+pub fn with_mocked_less_in_path(actual_test: fn()) {
+    let original_path = prepend_dir_to_path_env_var(get_mocked_pagers_dir());
+    actual_test();
+    restore_path(original_path);
+}
+
 /// Allows test to run that require our mocked versions of 'more' and 'most'
 /// in PATH. Temporarily changes PATH while the test code runs, and then restore it
 /// to avoid pollution of global state


### PR DESCRIPTION
## Summary

When `$LESS` contains `-J` (status column), long lines can overlap bat's left-side decorations (line numbers, git markers, grid).

bat now passes `+J` to `less` when spawning the pager so the status column is disabled regardless of `$LESS`. BusyBox `less` is skipped because it does not support this option.

## Test plan

- [x] `cargo test --test integration_tests less_status_column_disabled_when_less_env_has_j`
- [x] Mock `less` script asserts `+J` is present in argv when `LESS=-J`

Fixes #2497