### PR TITLE
fix: omit less -S when quit-if-one-screen and --wrap=never (fixes #3738)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Do not pass `-S` to `less` when quit-if-one-screen is active and `--wrap=never` is set, so `$LESS=--quit-if-one-screen` works as expected, see #3738 (@leno23)
+- Do not pass `-S` to `less` when quit-if-one-screen is active and `--wrap=never` is set, so `$LESS=--quit-if-one-screen` works as expected, see #3738, closes #3745 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Do not pass `-S` to `less` when quit-if-one-screen is active and `--wrap=never` is set, so `$LESS=--quit-if-one-screen` works as expected, see #3738 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/src/output.rs
+++ b/src/output.rs
@@ -143,7 +143,11 @@ impl OutputType {
                     p.arg("-F"); // Short version of --quit-if-one-screen for compatibility
                 }
 
-                if wrapping_mode == WrappingMode::NoWrapping(true) {
+                // `-S` (chop long lines) breaks `-F` (quit-if-one-screen) when lines are wider than
+                // the terminal but the file fits vertically — see #3738.
+                if wrapping_mode == WrappingMode::NoWrapping(true)
+                    && single_screen_action != SingleScreenAction::Quit
+                {
                     p.arg("-S"); // Short version of --chop-long-lines for compatibility
                 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1120,6 +1120,33 @@ fn do_not_exit_directory() {
 
 #[test]
 #[serial]
+#[cfg(unix)]
+fn wrap_never_does_not_pass_chop_long_lines_with_quit_if_one_screen() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let less_mock = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("mocked-pagers")
+        .join("less-no-chop-with-quit");
+    let mut perms = std::fs::metadata(&less_mock).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&less_mock, perms).unwrap();
+
+    mocked_pagers::with_mocked_less_no_chop_with_quit_in_path(|| {
+        bat()
+            .env("LESS", "--quit-if-one-screen")
+            .env("PAGER", "less")
+            .arg("--wrap=never")
+            .arg("--paging=always")
+            .arg("test.txt")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("hello world").normalize());
+    });
+}
+
+#[test]
+#[serial]
 fn pager_basic() {
     mocked_pagers::with_mocked_versions_of_more_and_most_in_path(|| {
         bat()

--- a/tests/mocked-pagers/less-no-chop-with-quit
+++ b/tests/mocked-pagers/less-no-chop-with-quit
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Mock `less` for #3738: bat must not pass `-S` together with `-F` (--quit-if-one-screen).
+has_f=false
+has_s=false
+for arg in "$@"; do
+    case "$arg" in
+        -F | --quit-if-one-screen) has_f=true ;;
+        -S | --chop-long-lines) has_s=true ;;
+    esac
+done
+if [[ "$has_f" == true && "$has_s" == true ]]; then
+    echo "mock less: -F and -S must not be used together: $*" >&2
+    exit 1
+fi
+if [[ "${1:-}" == "--version" ]]; then
+    echo "less 608 (PCRE2 regular expressions)"
+    exit 0
+fi
+cat

--- a/tests/utils/mocked_pagers.rs
+++ b/tests/utils/mocked_pagers.rs
@@ -52,17 +52,12 @@ fn restore_path(original_path: String) {
     env::set_var("PATH", original_path);
 }
 
-
 /// Uses `tests/mocked-pagers/less-no-chop-with-quit` as `less` on PATH.
 pub fn with_mocked_less_no_chop_with_quit_in_path(actual_test: fn()) {
     let dir = get_mocked_pagers_dir();
     let original_path = prepend_dir_to_path_env_var(dir.clone());
     let less_mock = dir.join("less-no-chop-with-quit");
-    let less_name = if cfg!(windows) {
-        "less.bat"
-    } else {
-        "less"
-    };
+    let less_name = if cfg!(windows) { "less.bat" } else { "less" };
     let less_link = dir.join(less_name);
     let _ = std::fs::remove_file(&less_link);
     #[cfg(unix)]

--- a/tests/utils/mocked_pagers.rs
+++ b/tests/utils/mocked_pagers.rs
@@ -52,6 +52,28 @@ fn restore_path(original_path: String) {
     env::set_var("PATH", original_path);
 }
 
+
+/// Uses `tests/mocked-pagers/less-no-chop-with-quit` as `less` on PATH.
+pub fn with_mocked_less_no_chop_with_quit_in_path(actual_test: fn()) {
+    let dir = get_mocked_pagers_dir();
+    let original_path = prepend_dir_to_path_env_var(dir.clone());
+    let less_mock = dir.join("less-no-chop-with-quit");
+    let less_name = if cfg!(windows) {
+        "less.bat"
+    } else {
+        "less"
+    };
+    let less_link = dir.join(less_name);
+    let _ = std::fs::remove_file(&less_link);
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&less_mock, &less_link).expect("symlink mock less");
+    #[cfg(windows)]
+    std::fs::copy(&less_mock, &less_link).expect("copy mock less");
+    actual_test();
+    let _ = std::fs::remove_file(&less_link);
+    restore_path(original_path);
+}
+
 /// Allows test to run that require our mocked versions of 'more' and 'most'
 /// in PATH. Temporarily changes PATH while the test code runs, and then restore it
 /// to avoid pollution of global state


### PR DESCRIPTION
## Summary

`bat --wrap=never` passes `-S` (chop long lines) to `less`. Combined with quit-if-one-screen (`-F`, including via `$LESS=--quit-if-one-screen`), wide lines make `less` think the file does not fit on one screen, so it no longer quits immediately (#3738).

Skip `-S` when bat enables quit-if-one-screen.

## Test plan

- [x] `cargo test --test integration_tests wrap_never_does_not_pass_chop_long_lines_with_quit_if_one_screen`
- [x] Mock `less` asserts `-F` and `-S` are not passed together for `LESS=--quit-if-one-screen` + `--wrap=never`

Fixes #3738