### PR TITLE
fix: --wrap=never breaks less --quit-if-one-screen (#3738)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fix i686 `.deb` package using incorrect architecture name (`i686` instead of `i386`), preventing installation on Debian. Closes #3611, see #3650 (@Sim-hu)
 - Fix inconsistent `.deb` MUSL package names (aarch64-musl used `arm64` instead of `musl-linux-arm64`, and `musleabihf` target missed `bat-musl` prefix). Closes #3482, see #3642 (@mvanhorn)
 - Fix incorrect text width computation when using `--binary=as-text` with non-printable characters in caret notation, see #3640 and #3631 (@eyupcanakman)
+- Fix `--wrap=never` defeating `less --quit-if-one-screen`. Closes #3738, see #3746 (@mvanhorn)
 - Fix `BAT_CONFIG_DIR` pointing at system config directory causing duplicate flag errors. Closes #3589, see #3620 (@Xavrir)
 - Fix syntax highlighting for symlinked files when the symlink name has no extension but the target does. Closes #1001, see #3621 (@Xavrir)
 - Report error when pager is missing instead of silently falling back, see #3588 (@IMaloney)

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "paging")]
+use std::env;
 use std::fmt;
 use std::io;
 #[cfg(feature = "paging")]
@@ -60,6 +62,20 @@ impl std::fmt::Debug for BuiltinPager {
 enum SingleScreenAction {
     Quit,
     Nothing,
+}
+
+#[cfg(feature = "paging")]
+fn less_env_contains_quit_if_one_screen() -> bool {
+    env::var("LESS")
+        .ok()
+        .and_then(|less| shell_words::split(&less).ok())
+        .is_some_and(|args| {
+            args.iter().any(|arg| {
+                arg == "--quit-if-one-screen"
+                    || arg == "-F"
+                    || (arg.starts_with('-') && !arg.starts_with("--") && arg.contains('F'))
+            })
+        })
 }
 
 #[derive(Debug)]
@@ -143,7 +159,10 @@ impl OutputType {
                     p.arg("-F"); // Short version of --quit-if-one-screen for compatibility
                 }
 
-                if wrapping_mode == WrappingMode::NoWrapping(true) {
+                let quit_if_one_screen = single_screen_action == SingleScreenAction::Quit
+                    || less_env_contains_quit_if_one_screen();
+
+                if wrapping_mode == WrappingMode::NoWrapping(true) && !quit_if_one_screen {
                     p.arg("-S"); // Short version of --chop-long-lines for compatibility
                 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,8 @@
 use predicates::boolean::PredicateBooleanExt;
 use predicates::{prelude::predicate, str::PredicateStrExt};
 use serial_test::serial;
+#[cfg(unix)]
+use std::env;
 use std::path::Path;
 use std::str::from_utf8;
 use tempfile::tempdir;
@@ -705,6 +707,36 @@ fn setup_temp_file(content: &[u8]) -> io::Result<(PathBuf, tempfile::TempDir)> {
 }
 
 #[cfg(unix)]
+fn setup_mock_less() -> io::Result<(tempfile::TempDir, PathBuf, std::ffi::OsString)> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("Couldn't create tempdir");
+    let less = dir.path().join("less");
+    let captured_args = dir.path().join("less_args");
+    std::fs::write(
+        &less,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf 'less 668 (POSIX regular expressions)\n'
+  exit 0
+fi
+printf '%s\n' "$@" > "$BAT_TEST_LESS_ARGS"
+cat >/dev/null
+"#,
+    )?;
+    std::fs::set_permissions(&less, std::fs::Permissions::from_mode(0o755))?;
+
+    let path = env::join_paths(
+        std::iter::once(dir.path().to_path_buf()).chain(env::split_paths(
+            &env::var_os("PATH").expect("PATH should be set for tests"),
+        )),
+    )
+    .expect("PATH should be joinable");
+
+    Ok((dir, captured_args, path))
+}
+
+#[cfg(unix)]
 #[test]
 fn basic_io_cycle() -> io::Result<()> {
     let (filename, dir) = setup_temp_file(b"I am not empty")?;
@@ -1368,6 +1400,59 @@ fn pager_more() {
             .success()
             .stdout(predicate::eq("hello world\n").normalize());
     });
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn less_pager_wrap_never_omits_chop_long_lines_when_quitting_if_one_screen() {
+    let (_dir, captured_args, path) = setup_mock_less().unwrap();
+
+    bat()
+        .env("PATH", path)
+        .env("LESS", "--quit-if-one-screen")
+        .env("BAT_TEST_LESS_ARGS", &captured_args)
+        .arg("--paging=always")
+        .arg("--wrap=never")
+        .arg("--color=never")
+        .arg("--decorations=never")
+        .arg("--style=plain")
+        .arg("long-single-line.txt")
+        .assert()
+        .success()
+        .stdout("");
+
+    let args = std::fs::read_to_string(captured_args).unwrap();
+    assert!(
+        !args.lines().any(|arg| arg == "-S"),
+        "less -S prevents --quit-if-one-screen from quitting for long one-screen lines: {args:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn less_pager_wrap_never_keeps_chop_long_lines_without_quit_if_one_screen() {
+    let (_dir, captured_args, path) = setup_mock_less().unwrap();
+
+    bat()
+        .env("PATH", path)
+        .env("BAT_TEST_LESS_ARGS", &captured_args)
+        .arg("--paging=always")
+        .arg("--wrap=never")
+        .arg("--color=never")
+        .arg("--decorations=never")
+        .arg("--style=plain")
+        .arg("long-single-line.txt")
+        .assert()
+        .success()
+        .stdout("");
+
+    let args = std::fs::read_to_string(captured_args).unwrap();
+    assert!(
+        args.lines().any(|arg| arg == "-S"),
+        "--wrap=never should still pass -S to less when quit-if-one-screen is inactive: {args:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes `bat --wrap=never` defeating less's `--quit-if-one-screen` when content fits on one screen.

## Why this matters
`LESS=--quit-if-one-screen` is a popular less configuration. Today, this works for `less foo` directly but breaks under `bat --wrap=never foo`. Reproducer from #3738:

```
LESS=--quit-if-one-screen bat --wrap=never <wide-line-file-fits-vertically>
```

less doesn't auto-quit even though the file fits, forcing the user to press q.

Root cause: with `--wrap=never`, bat passes `-S` (chop long lines) to less. When less also receives `-F` (either from bat's own quit-if-one-screen path or from `$LESS`), the `-S`/`-F` combination keeps less from auto-quitting on one-screen content. The patch skips `-S` whenever `-F` is in play, so less can quit as expected.

Tradeoff to be aware of: when `$LESS` contains `-F`, long lines will now wrap in less instead of being chopped. If preserving `-S` matters more than auto-quit in that case, the approach can be reworked.

## Testing
New integration tests in `tests/integration_tests.rs` install a mock `less` that captures the arguments it receives, and assert the exact flags bat passes per wrapping mode: `--wrap=never` with and without quit-if-one-screen, plus regression coverage for `--wrap=auto` and `--wrap=character`.

Fixes #3738
