### PR TITLE
fix: honor --decorations=auto when piping with --color=always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Fix `--decorations=auto` showing headers and grid when output is piped if `--color=always` is set, see #3710 (@leno23)
+- Disable less's status column when paging so `$LESS=-J` does not overlap bat decorations, see #2497, closes #3744 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Fix `--decorations=auto` showing headers and grid when output is piped if `--color=always` is set, see #3710, closes # (@leno23)
-- Disable less's status column when paging so `$LESS=-J` does not overlap bat decorations, see #2497, closes #3744 (@leno23)
+- Fix `--decorations=auto` showing headers and grid when output is piped if `--color=always` is set, see #3748 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Fix `--decorations=auto` showing headers and grid when output is piped if `--color=always` is set, see #3710 (@leno23)
+- Fix `--decorations=auto` showing headers and grid when output is piped if `--color=always` is set, see #3710, closes # (@leno23)
 - Disable less's status column when paging so `$LESS=-J` does not overlap bat decorations, see #2497, closes #3744 (@leno23)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -623,14 +623,24 @@ impl App {
                 StyleComponentList::to_components(lists, self.interactive_output, true)
             }
 
-            // Use the automatic default behavior: default style for terminals,
-            // plain output for non-interactive destinations.
-            None => StyleComponents(HashSet::from_iter(
-                StyleComponent::Auto
-                    .components(self.interactive_output)
-                    .iter()
-                    .cloned(),
-            )),
+            // Honor `--decorations=auto` (the default): plain style when output is not
+            // interactive. `--decorations=always` keeps the full default style even when piped.
+            None => {
+                let decorations = self
+                    .matches
+                    .get_one::<String>("decorations")
+                    .map(|s| s.as_str());
+                let default_style = match decorations {
+                    Some("auto") => StyleComponent::Auto,
+                    _ => StyleComponent::Default,
+                };
+                StyleComponents(HashSet::from_iter(
+                    default_style
+                        .components(self.interactive_output)
+                        .iter()
+                        .cloned(),
+                ))
+            }
         };
 
         // If `grid` is set, remove `rule` as it is a subset of `grid`, and print a warning.

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -623,9 +623,10 @@ impl App {
                 StyleComponentList::to_components(lists, self.interactive_output, true)
             }
 
-            // Use the default.
+            // Use the automatic default behavior: default style for terminals,
+            // plain output for non-interactive destinations.
             None => StyleComponents(HashSet::from_iter(
-                StyleComponent::Default
+                StyleComponent::Auto
                     .components(self.interactive_output)
                     .iter()
                     .cloned(),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -487,6 +487,17 @@ fn piped_output_with_auto_style() {
 }
 
 #[test]
+fn piped_output_with_color_always_and_auto_decorations_for_file() {
+    bat()
+        .arg("--color=always")
+        .arg("--decorations=auto")
+        .arg("test.txt")
+        .assert()
+        .success()
+        .stdout("\u{1b}[38;5;231mhello world\u{1b}[0m\n");
+}
+
+#[test]
 #[cfg(not(target_os = "windows"))]
 fn piped_output_with_default_style_flag() {
     bat()


### PR DESCRIPTION
## Summary

With `--color=always` and `--decorations=auto`, piping output (e.g. `bat --color=always file | cat`) incorrectly included headers, grid, and line numbers. The implicit default style used `StyleComponent::Default` even on non-interactive stdout.

Use `StyleComponent::Auto` for the default style path so decorations follow the documented auto behavior on pipes while colors still work via `InteractivePrinter`.

Fixes #3710

Related: similar approach in #3719 (this PR adds CHANGELOG + green CI).

## Test plan

- [x] `piped_output_with_color_always_and_auto_decorations_for_file`
- [x] `cargo test --test integration_tests piped_output_with_color_always`