### PR TITLE
docs: clarify custom theme file format requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## Other
+- Clarify custom theme file format requirements, see #3751 (@leno23)
 
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/README.md
+++ b/README.md
@@ -591,12 +591,14 @@ syntax:
 
 ### Adding new themes
 
-This works very similar to how we add new syntax definitions.
+This works similarly to [adding new syntax definitions](#adding-new-syntaxes--language-definitions), but themes use a different file format than syntaxes.
+
 > [!NOTE]
-> Custom themes must be stored in [`.tmTheme` files](https://www.sublimetext.com/docs/color_schemes_tmtheme.html).
+> Custom themes must be stored in [`.tmTheme` files](https://www.sublimetext.com/docs/color_schemes_tmtheme.html) (XML).
+> Sublime Text `.sublime-syntax` files are for syntax highlighting only and cannot be used as themes.
 > Newer `.sublime-color-scheme` files are currently not supported.
 
-First, create a folder with the new syntax highlighting themes:
+First, create a folder with the new color themes:
 ```bash
 mkdir -p "$(bat --config-dir)/themes"
 cd "$(bat --config-dir)/themes"


### PR DESCRIPTION
## Summary
- Clarify that custom themes require `.tmTheme` files, not `.sublime-syntax` language definitions
- Cross-link to the syntax definitions section for comparison

Fixes #1948