### PR TITLE
fix: avoid unknown theme warning when showing help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+<<<<<<< HEAD
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
+=======
+- Avoid unknown theme warnings when showing `--help` with a custom `BAT_THEME`, see #3754 (@leno23)
+>>>>>>> c89872d4 (test: expect no theme warning on --help with custom BAT_THEME)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -139,7 +139,7 @@ impl App {
         use_pager: bool,
         use_color: bool,
         pager: Option<&str>,
-        theme_options: ThemeOptions,
+        _theme_options: ThemeOptions,
         use_custom_assets: bool,
     ) -> Result<()> {
         use crate::assets::assets_from_cache_or_binary;
@@ -149,7 +149,6 @@ impl App {
             controller::Controller,
             input::Input,
             style::{StyleComponent, StyleComponents},
-            theme::theme,
             PagingMode,
         };
 
@@ -174,7 +173,9 @@ impl App {
             colored_output: use_color,
             true_color: use_color,
             language: if use_color { Some("help") } else { None },
-            theme: theme(theme_options).to_string(),
+            // Help is rendered with plain styling; use the built-in theme to avoid
+            // warnings when BAT_THEME names a user theme that is not loaded yet.
+            theme: "ansi".to_string(),
             ..Default::default()
         };
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1565,8 +1565,7 @@ fn help_uses_valid_config() {
     std::fs::write(&tmp_config_path, "--theme=NonExistentThemeName123")
         .expect("can write config file");
 
-    // --help should read the config file and try to use the theme
-    // (we'll see a warning about unknown theme. This is the easiest way to prove the theme is read from config.)
+    // --help uses plain styling and should not warn about themes from config.
     bat_with_config()
         .env("BAT_CONFIG_PATH", tmp_config_path.to_str().unwrap())
         .arg("--help")
@@ -1575,7 +1574,7 @@ fn help_uses_valid_config() {
         .stdout(predicate::str::contains(
             "A cat(1) clone with syntax highlighting",
         ))
-        .stderr(predicate::str::contains("Unknown theme"));
+        .stderr(predicate::str::contains("Unknown theme").not());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `bat --help` / `bat -h` now uses the built-in `ansi` theme for rendering help text
- Avoids spurious `Unknown theme` warnings when `BAT_THEME` is set to a custom theme name

Fixes #3559

## Test plan
- [ ] `BAT_THEME=MyCustomTheme bat --help` (no warning)
- [ ] `bat --help` still renders correctly with color when appropriate