### PR TITLE
fix: treat OpenPGP/GPG encrypted files as binary (fixes #3554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Treat OpenPGP/GPG encrypted files as binary, see #3756 (@leno23)
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/src/input.rs
+++ b/src/input.rs
@@ -351,6 +351,11 @@ fn looks_like_openpgp_message(bytes: &[u8]) -> bool {
         return true;
     }
 
+    // Valid UTF-8 text (e.g. CJK) can have lead bytes with bit 7 set; do not treat as binary packets.
+    if std::str::from_utf8(bytes).is_ok() {
+        return false;
+    }
+
     let Some(&first) = bytes.first() else {
         return false;
     };
@@ -461,6 +466,14 @@ fn non_zip_pk_prefix_is_not_treated_as_binary() {
     assert_eq!(
         Some(ContentType::UTF_8),
         inspect_content_type(b"PK\x03\x03hello")
+    );
+}
+
+#[test]
+fn utf8_text_is_not_treated_as_openpgp() {
+    assert_eq!(
+        Some(ContentType::UTF_8),
+        inspect_content_type("ビタミンA\n".as_bytes())
     );
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -363,13 +363,12 @@ fn looks_like_openpgp_message(bytes: &[u8]) -> bool {
 
     // ANSI escape sequences (CSI/OSC) start with ESC (0x1b). Old-format OpenPGP headers
     // can also encode tag 6 + length-type 3 as 0x1b, so disambiguate via the introducer.
-    if first == 0x1b {
-        if bytes
+    if first == 0x1b
+        && bytes
             .get(1)
             .is_some_and(|&b| matches!(b, b'[' | b']' | b'P' | b'_'))
-        {
-            return false;
-        }
+    {
+        return false;
     }
 
     // Old-format packet headers use low tag bytes; avoid matching plain text (e.g. "PK…").
@@ -378,7 +377,14 @@ fn looks_like_openpgp_message(bytes: &[u8]) -> bool {
     }
 
     let tag = (first >> 2) & 0x0f;
-    (1..=18).contains(&tag)
+    if !(1..=18).contains(&tag) {
+        return false;
+    }
+
+    // Length/type octets following the header are rarely printable ASCII in real packets.
+    bytes
+        .get(1)
+        .is_some_and(|&second| !(0x20..=0x7e).contains(&second))
 }
 
 fn has_zip_signature(bytes: &[u8]) -> bool {
@@ -455,6 +461,18 @@ fn non_zip_pk_prefix_is_not_treated_as_binary() {
     assert_eq!(
         Some(ContentType::UTF_8),
         inspect_content_type(b"PK\x03\x03hello")
+    );
+}
+
+#[test]
+fn text_like_lines_are_not_treated_as_openpgp() {
+    assert_eq!(
+        Some(ContentType::UTF_8),
+        inspect_content_type(b"\t1\t2\t3\n")
+    );
+    assert_eq!(
+        Some(ContentType::UTF_8),
+        inspect_content_type(b"  // comment\n")
     );
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -326,11 +326,45 @@ fn inspect_content_type(first_line: &[u8]) -> Option<ContentType> {
     }
 
     let content_type = content_inspector::inspect(first_line);
-    if content_type == ContentType::UTF_8 && has_zip_signature(first_line) {
+    if content_type == ContentType::UTF_8
+        && (has_zip_signature(first_line) || looks_like_openpgp_message(first_line))
+    {
         Some(ContentType::BINARY)
     } else {
         Some(content_type)
     }
+}
+
+/// OpenPGP messages (e.g. GPG symmetric encryption) often contain no NUL bytes in the
+/// first line, so `content_inspector` may classify them as UTF-8 text.
+fn looks_like_openpgp_message(bytes: &[u8]) -> bool {
+    const ARMOR_PREFIXES: &[&[u8]] = &[
+        b"-----BEGIN PGP MESSAGE-----",
+        b"-----BEGIN PGP ",
+        b"-----BEGIN OPENPGP ",
+    ];
+
+    if ARMOR_PREFIXES.iter().any(|prefix| bytes.starts_with(prefix)) {
+        return true;
+    }
+
+    let Some(&first) = bytes.first() else {
+        return false;
+    };
+
+    // RFC 4880 §4.2: new packet format (bit 7 set) or old format (bit 7 clear).
+    if first & 0x80 != 0 {
+        let tag = first & 0x3f;
+        return (1..=39).contains(&tag);
+    }
+
+    // Old-format packet headers use low tag bytes; avoid matching plain text (e.g. "PK…").
+    if first > 0x40 {
+        return false;
+    }
+
+    let tag = (first >> 2) & 0x0f;
+    (1..=18).contains(&tag)
 }
 
 fn has_zip_signature(bytes: &[u8]) -> bool {
@@ -408,6 +442,32 @@ fn non_zip_pk_prefix_is_not_treated_as_binary() {
         Some(ContentType::UTF_8),
         inspect_content_type(b"PK\x03\x03hello")
     );
+}
+
+#[test]
+fn openpgp_armored_message_is_treated_as_binary() {
+    let content = b"-----BEGIN PGP MESSAGE-----\n";
+    let reader = InputReader::new(&content[..]);
+    assert_eq!(Some(ContentType::BINARY), reader.content_type);
+}
+
+#[test]
+fn openpgp_binary_packet_is_treated_as_binary() {
+    // Typical start of a symmetrically encrypted OpenPGP message (new packet format).
+    let content = [
+        0x8c, 0x0d, 0x03, 0x07, 0x03, 0x0c, 0x24, 0x23, 0x02, 0x01, 0xfe, 0x00, 0x85, 0x01,
+        0x0c, 0x80, b'\n',
+    ];
+    let reader = InputReader::new(&content[..]);
+    assert_eq!(Some(ContentType::BINARY), reader.content_type);
+}
+
+#[test]
+fn openpgp_old_packet_format_is_treated_as_binary() {
+    // Tag 9 (encrypted data), old packet format, 2-octet length type.
+    let content = [0x26, 0x00, 0x01, b'\n'];
+    let reader = InputReader::new(&content[..]);
+    assert_eq!(Some(ContentType::BINARY), reader.content_type);
 }
 
 #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -361,6 +361,17 @@ fn looks_like_openpgp_message(bytes: &[u8]) -> bool {
         return (1..=39).contains(&tag);
     }
 
+    // ANSI escape sequences (CSI/OSC) start with ESC (0x1b). Old-format OpenPGP headers
+    // can also encode tag 6 + length-type 3 as 0x1b, so disambiguate via the introducer.
+    if first == 0x1b {
+        if bytes
+            .get(1)
+            .is_some_and(|&b| matches!(b, b'[' | b']' | b'P' | b'_'))
+        {
+            return false;
+        }
+    }
+
     // Old-format packet headers use low tag bytes; avoid matching plain text (e.g. "PK…").
     if first > 0x40 {
         return false;
@@ -444,6 +455,18 @@ fn non_zip_pk_prefix_is_not_treated_as_binary() {
     assert_eq!(
         Some(ContentType::UTF_8),
         inspect_content_type(b"PK\x03\x03hello")
+    );
+}
+
+#[test]
+fn ansi_escape_sequences_are_not_treated_as_openpgp() {
+    assert_eq!(
+        Some(ContentType::UTF_8),
+        inspect_content_type(b"\x1b]8;;http://example.com/\x1b\\")
+    );
+    assert_eq!(
+        Some(ContentType::UTF_8),
+        inspect_content_type(b"\x1b[33mColor\n")
     );
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -344,7 +344,10 @@ fn looks_like_openpgp_message(bytes: &[u8]) -> bool {
         b"-----BEGIN OPENPGP ",
     ];
 
-    if ARMOR_PREFIXES.iter().any(|prefix| bytes.starts_with(prefix)) {
+    if ARMOR_PREFIXES
+        .iter()
+        .any(|prefix| bytes.starts_with(prefix))
+    {
         return true;
     }
 
@@ -455,8 +458,8 @@ fn openpgp_armored_message_is_treated_as_binary() {
 fn openpgp_binary_packet_is_treated_as_binary() {
     // Typical start of a symmetrically encrypted OpenPGP message (new packet format).
     let content = [
-        0x8c, 0x0d, 0x03, 0x07, 0x03, 0x0c, 0x24, 0x23, 0x02, 0x01, 0xfe, 0x00, 0x85, 0x01,
-        0x0c, 0x80, b'\n',
+        0x8c, 0x0d, 0x03, 0x07, 0x03, 0x0c, 0x24, 0x23, 0x02, 0x01, 0xfe, 0x00, 0x85, 0x01, 0x0c,
+        0x80, b'\n',
     ];
     let reader = InputReader::new(&content[..]);
     assert_eq!(Some(ContentType::BINARY), reader.content_type);


### PR DESCRIPTION
## Summary
- Extend `inspect_content_type` so armored (`-----BEGIN PGP …`) and binary OpenPGP packet headers are classified as `BINARY`, not UTF-8 text.
- `content_inspector` only checks for NUL bytes in the first 1024 bytes; GPG symmetric ciphertext often has none, which led to garbled terminal output.
- Old-format packet detection is limited to low header bytes to avoid false positives on text like `PK…` zip paths.

## Test plan
- [x] `cargo test -p bat input::`

Fixes #3554