### PR TITLE
Include `.ssh/` subdirectories in SSH Config syntax mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Map several Google Cloud CLI config files to their appropriate syntax #3635 (@victor-gp)
 - Map all ignore dotfiles to Git Ignore syntax #3636 (@victor-gp)
 - Improved Kotlin syntax, see #3699 (@guille)
+- Include subdirectories in SSH Config syntax mapping, see #3758 (@injust)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/common/50-ssh.toml
+++ b/src/syntax_mapping/builtins/common/50-ssh.toml
@@ -1,2 +1,2 @@
 [mappings]
-"SSH Config" = ["**/.ssh/config"]
+"SSH Config" = ["**/.ssh/**/config"]


### PR DESCRIPTION
This supports the use case of organizing an SSH config with subdirectories inside `~/.ssh/`, and using [`Include`](https://man.openbsd.org/ssh_config#Include) from the main config file. This is [less common than I expected](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29.ssh%5C%2F.*%5C%2Fconfig%24%2F&type=code), but I think it's still worth adding.