### PR TITLE
Add Ghostty syntax mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Map several Google Cloud CLI config files to their appropriate syntax #3635 (@victor-gp)
 - Map all ignore dotfiles to Git Ignore syntax #3636 (@victor-gp)
 - Improved Kotlin syntax, see #3699 (@guille)
+- Add Ghostty syntax mapping, see #3759 (@injust)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/unix-family/50-ghostty.toml
+++ b/src/syntax_mapping/builtins/unix-family/50-ghostty.toml
@@ -1,0 +1,2 @@
+[mappings]
+"INI" = ["**/ghostty/**/*.ghostty", "**/ghostty/themes/*"]


### PR DESCRIPTION
Add syntax mapping for Ghostty's config file and themes directory.

Ghostty 1.2.3 renamed its [config file](https://ghostty.org/docs/config#file-location) to `config.ghostty`, but also supports [splitting the config into multiple files](https://ghostty.org/docs/config#splitting-into-multiple-files).