### PR TITLE
fix(completions): force --no-paging on bat invocations in completion scripts (#3760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -14,12 +14,12 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
     $ArrayPrint      = @('unicode', 'caret')
 
     function Get-MyThemes(){
-        $themes = {{PROJECT_EXECUTABLE}} --list-themes | ForEach-Object {$_  -replace "^(.*)$", '''$1'''} | select-object
+        $themes = {{PROJECT_EXECUTABLE}} --no-paging --list-themes | ForEach-Object {$_  -replace "^(.*)$", '''$1'''} | select-object
         return $themes
     }
 
     function Get-MyLanguages(){
-        $themes = {{PROJECT_EXECUTABLE}} --list-languages | ForEach-Object{[pscustomobject]@{MyParameter=$_.Substring(0,$_.IndexOf(":")).Trim();MyDescription=$_.Substring($_.IndexOf(":")+1)}} | select-object
+        $themes = {{PROJECT_EXECUTABLE}} --no-paging --list-languages | ForEach-Object{[pscustomobject]@{MyParameter=$_.Substring(0,$_.IndexOf(":")).Trim();MyDescription=$_.Substring($_.IndexOf(":")+1)}} | select-object
         return $themes
     }
 

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -80,7 +80,7 @@ _bat() {
 	-l | --language)
 		local IFS=$'\n'
 		COMPREPLY=($(compgen -W "$(
-			"$1" --list-languages | while IFS=: read -r lang _; do
+			"$1" --no-paging --list-languages | while IFS=: read -r lang _; do
 				printf "%s\n" "$lang"
 			done
 		)" -- "$cur"))
@@ -150,14 +150,14 @@ _bat() {
 		;;
 	--theme)
 		local IFS=$'\n'
-		COMPREPLY=($(compgen -W "auto${IFS}auto:always${IFS}auto:system${IFS}dark${IFS}light${IFS}$("$1" --list-themes)" -- "$cur"))
+		COMPREPLY=($(compgen -W "auto${IFS}auto:always${IFS}auto:system${IFS}dark${IFS}light${IFS}$("$1" --no-paging --list-themes)" -- "$cur"))
 		__bat_escape_completions
 		return 0
 		;;
 	--theme-dark | \
 	--theme-light)
 		local IFS=$'\n'
-		COMPREPLY=($(compgen -W "$("$1" --list-themes)" -- "$cur"))
+		COMPREPLY=($(compgen -W "$("$1" --no-paging --list-themes)" -- "$cur"))
 		__bat_escape_completions
 		return 0
 		;;

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -15,11 +15,11 @@ function __bat_complete_files -a token
 end
 
 function __bat_complete_one_language -a comp
-    command $bat --list-languages | string split -f1 : | string match -e "$comp"
+    command $bat --no-paging --list-languages | string split -f1 : | string match -e "$comp"
 end
 
 function __bat_complete_list_languages
-    for spec in (command $bat --list-languages)
+    for spec in (command $bat --no-paging --list-languages)
         set -l name (string split -f1 : $spec)
         for ext in (string split -f2 : $spec | string split ,)
             test -n "$ext"; or continue
@@ -234,11 +234,11 @@ complete -c $bat -l tabs -x -a "$tabs_opts" -d "Set tab width" -n __bat_no_excl_
 
 complete -c $bat -l terminal-width -x -d "Set terminal <width>, +<offset>, or -<offset>" -n __bat_no_excl_args
 
-complete -c $bat -l theme -x -a "$special_themes(command $bat --list-themes | command cat)" -d "Set the syntax highlighting theme" -n __bat_no_excl_args
+complete -c $bat -l theme -x -a "$special_themes(command $bat --no-paging --list-themes | command cat)" -d "Set the syntax highlighting theme" -n __bat_no_excl_args
 
-complete -c $bat -l theme-dark -x -a "(command $bat --list-themes | command cat)" -d "Set the syntax highlighting theme for dark backgrounds" -n __bat_no_excl_args
+complete -c $bat -l theme-dark -x -a "(command $bat --no-paging --list-themes | command cat)" -d "Set the syntax highlighting theme for dark backgrounds" -n __bat_no_excl_args
 
-complete -c $bat -l theme-light -x -a "(command $bat --list-themes | command cat)" -d "Set the syntax highlighting theme for light backgrounds" -n __bat_no_excl_args
+complete -c $bat -l theme-light -x -a "(command $bat --no-paging --list-themes | command cat)" -d "Set the syntax highlighting theme for light backgrounds" -n __bat_no_excl_args
 
 complete -c $bat -s u -l unbuffered -d "Enable unbuffered input reading for streaming use cases" -n __bat_no_excl_args
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -95,20 +95,20 @@ _{{PROJECT_EXECUTABLE}}_main() {
             # language name is offered as the completion value; the matchers
             # show up as the menu description. See
             # https://github.com/sharkdp/bat/issues/3735.
-            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-languages)"} )
+            languages=( ${(f)"$({{PROJECT_EXECUTABLE}} --no-paging --color=never --decorations=never --list-languages)"} )
 
             _describe 'language' languages && ret=0
         ;;
 
         themes)
             local -a themes expl
-            themes=(${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-themes)"} )
+            themes=(${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --no-paging --color=never --decorations=never --list-themes)"} )
 
             _wanted themes expl 'theme' compadd -a themes && ret=0
         ;;
         theme_preferences)
             local -a themes expl
-            themes=(auto dark light auto:always auto:system ${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --color=never --decorations=never --list-themes)"} )
+            themes=(auto dark light auto:always auto:system ${(f)"$(_call_program themes {{PROJECT_EXECUTABLE}} --no-paging --color=never --decorations=never --list-themes)"} )
 
             _wanted themes expl 'theme' compadd -a themes && ret=0
         ;;


### PR DESCRIPTION
Closes #3760.

## Repro from the issue

```bash
export LESSOPEN='|-bat -f -pp %s'
unset BAT_PAGER
unset PAGER
# Open Zsh, type `bat -l Per` then Ctrl-D to fire completion.
# Before: completion expands to `bat -l $'\033'\[38\;2\;248\;248\;242mPerl`
# After:  completion expands to `bat -l Perl`
```

## What changed

Every shell completion script (bash, zsh, fish, PowerShell) shells out to bat to enumerate languages/themes for tab completion candidates. When the user has wired bat into `LESSOPEN`, bat's normal pager auto-detection can engage at completion time and reflect ANSI escape sequences back into the candidate list.

These `--list-languages` / `--list-themes` calls are always meant to be machine-readable, so they should never page. Pass `--no-paging` (the public alias for `--paging=never`, already documented in `bat --help`) on each invocation:

- `assets/completions/bat.zsh.in` -- 3 invocations
- `assets/completions/bat.bash.in` -- 3 invocations
- `assets/completions/bat.fish.in` -- 5 invocations
- `assets/completions/_bat.ps1.in` -- 2 invocations

Touches the four completion files plus a CHANGELOG entry. No production code changes.