### PR TITLE
fix: preserve ANSI escapes while stripping manpage overstrike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 ## Bugfixes
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
-- Preserve ANSI escape sequences that appear before overstrike backspaces in man pages, see #3724 (@sjh9714)
+- Preserve ANSI escape sequences that appear before overstrike backspaces in man pages, see #3762 (@sjh9714)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)
 - Sanitize control characters in filenames before displaying them in the file header, error messages, and the terminal title, preventing ANSI escape injection via crafted filenames. Closes #3054, see #3691 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ## Bugfixes
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
+- Preserve ANSI escape sequences that appear before overstrike backspaces in man pages, see #3724 (@sjh9714)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)
 - Sanitize control characters in filenames before displaying them in the file header, error messages, and the terminal title, preventing ANSI escape injection via crafted filenames. Closes #3054, see #3691 (@curious-rabbit)

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -189,14 +189,14 @@ pub fn sanitize_for_terminal(input: &str) -> String {
 pub fn strip_overstrike(line: &str, first_backspace: usize) -> String {
     let mut output = String::with_capacity(line.len());
     output.push_str(&line[..first_backspace]);
-    output.pop();
+    pop_visible_char(&mut output);
 
     let mut remaining = &line[first_backspace + 1..];
 
     loop {
         if let Some(pos) = remaining.find('\x08') {
             output.push_str(&remaining[..pos]);
-            output.pop();
+            pop_visible_char(&mut output);
             remaining = &remaining[pos + 1..];
         } else {
             output.push_str(remaining);
@@ -205,6 +205,26 @@ pub fn strip_overstrike(line: &str, first_backspace: usize) -> String {
     }
 
     output
+}
+
+fn pop_visible_char(output: &mut String) {
+    let mut char_to_remove = None;
+
+    for seq in EscapeSequenceOffsetsIterator::new(output) {
+        if let EscapeSequenceOffsets::Text { .. } = seq {
+            let start = seq.index_of_start();
+            let text = &output[start..seq.index_past_end()];
+
+            if let Some((relative_start, chr)) = text.char_indices().next_back() {
+                let char_start = start + relative_start;
+                char_to_remove = Some((char_start, char_start + chr.len_utf8()));
+            }
+        }
+    }
+
+    if let Some((start, end)) = char_to_remove {
+        output.replace_range(start..end, "");
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Default)]
@@ -289,6 +309,11 @@ fn test_strip_overstrike() {
 
     // Unicode with overstrike
     assert_eq!(strip_overstrike("ä\x08äöü", 2), "äöü");
+}
+
+#[test]
+fn test_strip_overstrike_preserves_ansi_before_backspace() {
+    assert_eq!(strip_overstrike("v\x1b[22m\x08v", 6), "\x1b[22mv");
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2811,6 +2811,21 @@ fn strip_overstrike_for_manpage_syntax() {
 }
 
 #[test]
+fn strip_overstrike_for_manpage_syntax_keeps_ansi_escapes_intact() {
+    // Some man page renderers can emit SGR resets between the first overstruck
+    // character and the backspace. The reset should be preserved, not truncated.
+    bat()
+        .arg("--force-colorization")
+        .arg("--language=man")
+        .write_stdin("NAME\n       v\x1b[22m\x08v normal\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[22v").not())
+        .stdout(predicate::str::contains("\x1b[22m"))
+        .stderr("");
+}
+
+#[test]
 fn no_strip_overstrike_for_other_syntax() {
     // Overstrike is NOT stripped for other syntaxes (e.g., Rust)
     bat()


### PR DESCRIPTION
## Summary

- Preserve ANSI escape sequences that appear between an overstruck character and the following backspace.
- Prevent manpage overstrike stripping from truncating SGR resets like `\x1b[22m` into broken sequences such as `\x1b[22v`.
- Add unit and integration regression coverage for the manpage path.

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" cargo test test_strip_overstrike_preserves_ansi_before_backspace`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --test integration_tests strip_overstrike_for_manpage_syntax_keeps_ansi_escapes_intact`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --locked strip_overstrike`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --locked`

Refs #3724
