### PR TITLE
Avoid reading full binary files during detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Avoid reading an entire binary file while detecting whether it should be printed, closes #2262, see #3763 (@puneetdixit200)
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -13,6 +13,7 @@ use crate::output::{OutputHandle, OutputType};
 #[cfg(feature = "paging")]
 use crate::paging::PagingMode;
 use crate::printer::{InteractivePrinter, Printer, SimplePrinter};
+use crate::BinaryBehavior;
 use std::collections::VecDeque;
 use std::io::{self, BufRead, Write};
 use std::mem;
@@ -223,7 +224,7 @@ impl Controller<'_> {
             printer.print_header(writer, input, add_header_padding)?;
         }
 
-        if !input.reader.first_line.is_empty() {
+        if !input.reader.first_line.is_empty() && self.should_print_content(input) {
             let line_ranges = match self.config.visible_lines {
                 VisibleLines::Ranges(ref line_ranges) => line_ranges.clone(),
                 #[cfg(feature = "git")]
@@ -247,6 +248,16 @@ impl Controller<'_> {
         printer.print_footer(writer, input)?;
 
         Ok(())
+    }
+
+    fn should_print_content(&self, input: &OpenedInput) -> bool {
+        self.config.loop_through
+            || self.config.show_nonprintable
+            || matches!(self.config.binary, BinaryBehavior::AsText)
+            || !input
+                .reader
+                .content_type
+                .is_some_and(|content_type| content_type.is_binary())
     }
 
     fn print_file_ranges(
@@ -338,5 +349,105 @@ impl Controller<'_> {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assets::HighlightingAssets;
+    use crate::input::{InputDescription, InputMetadata, OpenedInputKind};
+
+    struct RecordingPrinter {
+        lines: usize,
+    }
+
+    impl Printer for RecordingPrinter {
+        fn print_header(
+            &mut self,
+            _handle: &mut OutputHandle,
+            _input: &OpenedInput,
+            _add_header_padding: bool,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        fn print_footer(&mut self, _handle: &mut OutputHandle, _input: &OpenedInput) -> Result<()> {
+            Ok(())
+        }
+
+        fn print_snip(&mut self, _handle: &mut OutputHandle) -> Result<()> {
+            Ok(())
+        }
+
+        fn print_line(
+            &mut self,
+            _out_of_range: bool,
+            _handle: &mut OutputHandle,
+            _line_number: usize,
+            _line_buffer: &[u8],
+            _max_buffered_line_number: MaxBufferedLineNumber,
+        ) -> Result<()> {
+            self.lines += 1;
+            Ok(())
+        }
+    }
+
+    fn binary_input() -> OpenedInput<'static> {
+        OpenedInput {
+            kind: OpenedInputKind::CustomReader,
+            metadata: InputMetadata::default(),
+            reader: InputReader::new(&b"binary\0prefix"[..]),
+            description: InputDescription::new("binary.bin"),
+        }
+    }
+
+    #[test]
+    fn interactive_binary_input_does_not_print_content() {
+        let config = Config::default();
+        let assets = HighlightingAssets::from_binary();
+        let controller = Controller::new(&config, &assets);
+        let mut printer = RecordingPrinter { lines: 0 };
+        let mut output = String::new();
+        let mut input = binary_input();
+
+        controller
+            .print_file(
+                &mut printer,
+                &mut OutputHandle::FmtWrite(&mut output),
+                &mut input,
+                false,
+                #[cfg(feature = "git")]
+                &None,
+            )
+            .unwrap();
+
+        assert_eq!(0, printer.lines);
+    }
+
+    #[test]
+    fn loop_through_binary_input_still_prints_content() {
+        let config = Config {
+            loop_through: true,
+            ..Default::default()
+        };
+        let assets = HighlightingAssets::from_binary();
+        let controller = Controller::new(&config, &assets);
+        let mut printer = RecordingPrinter { lines: 0 };
+        let mut output = String::new();
+        let mut input = binary_input();
+
+        controller
+            .print_file(
+                &mut printer,
+                &mut OutputHandle::FmtWrite(&mut output),
+                &mut input,
+                false,
+                #[cfg(feature = "git")]
+                &None,
+            )
+            .unwrap();
+
+        assert_eq!(1, printer.lines);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,6 +9,8 @@ use content_inspector::{self, ContentType};
 
 use crate::error::*;
 
+const BINARY_DETECTION_PREFIX_LEN: usize = 8 * 1024;
+
 /// A description of an Input source.
 /// This tells bat how to refer to the input.
 #[derive(Clone)]
@@ -263,8 +265,7 @@ impl<'a> InputReader<'a> {
     }
 
     pub(crate) fn try_new<R: BufRead + 'a>(mut reader: R) -> io::Result<InputReader<'a>> {
-        let mut first_line = vec![];
-        reader.read_until(b'\n', &mut first_line)?;
+        let mut first_line = read_initial_line(&mut reader)?;
 
         let content_type = inspect_content_type(&first_line);
 
@@ -317,6 +318,50 @@ impl<'a> InputReader<'a> {
             self.inner.consume(len);
         }
         Ok(true)
+    }
+}
+
+fn read_initial_line<R: BufRead>(reader: &mut R) -> io::Result<Vec<u8>> {
+    let mut first_line = Vec::new();
+
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(first_line);
+        }
+
+        if let Some(pos) = available.iter().position(|&b| b == b'\n') {
+            first_line.extend_from_slice(&available[..=pos]);
+            reader.consume(pos + 1);
+            return Ok(first_line);
+        }
+
+        let remaining = BINARY_DETECTION_PREFIX_LEN.saturating_sub(first_line.len());
+        if remaining == 0 {
+            if inspect_content_type(&first_line)
+                .is_some_and(|content_type| content_type.is_binary())
+            {
+                return Ok(first_line);
+            }
+
+            reader.read_until(b'\n', &mut first_line)?;
+            return Ok(first_line);
+        }
+
+        let len = available.len().min(remaining);
+        first_line.extend_from_slice(&available[..len]);
+        reader.consume(len);
+
+        if first_line.len() == BINARY_DETECTION_PREFIX_LEN {
+            if inspect_content_type(&first_line)
+                .is_some_and(|content_type| content_type.is_binary())
+            {
+                return Ok(first_line);
+            }
+
+            reader.read_until(b'\n', &mut first_line)?;
+            return Ok(first_line);
+        }
     }
 }
 
@@ -400,6 +445,33 @@ fn zip_magic_headers_are_treated_as_binary() {
         let reader = InputReader::new(&content[..]);
         assert_eq!(Some(ContentType::BINARY), reader.content_type);
     }
+}
+
+#[test]
+fn binary_input_without_newline_stops_after_prefix() {
+    let mut content = b"archive.ovf\0".to_vec();
+    content.resize(BINARY_DETECTION_PREFIX_LEN * 4, 0);
+
+    let mut reader = InputReader::new(&content[..]);
+    assert_eq!(Some(ContentType::BINARY), reader.content_type);
+    assert_eq!(BINARY_DETECTION_PREFIX_LEN, reader.first_line.len());
+
+    let mut buffer = Vec::new();
+    assert!(reader.read_line(&mut buffer).unwrap());
+    assert_eq!(BINARY_DETECTION_PREFIX_LEN, buffer.len());
+
+    buffer.clear();
+    assert!(reader.read_line(&mut buffer).unwrap());
+    assert_eq!(content.len() - BINARY_DETECTION_PREFIX_LEN, buffer.len());
+}
+
+#[test]
+fn non_binary_input_without_newline_keeps_full_first_line() {
+    let content = vec![b'a'; BINARY_DETECTION_PREFIX_LEN * 2];
+
+    let reader = InputReader::new(&content[..]);
+    assert_eq!(Some(ContentType::UTF_8), reader.content_type);
+    assert_eq!(content, reader.first_line);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- cap initial binary detection reads at an 8 KiB prefix for newline-free binary files
- keep text and UTF-16 first-line handling unchanged by continuing to read full text lines
- skip default interactive binary line printing while preserving loop-through, show-all, and --binary=as-text paths

Fixes #2262

## Tests
- env CARGO_TARGET_DIR=/tmp/bat-target cargo test --lib input::
- env CARGO_TARGET_DIR=/tmp/bat-target cargo test --lib controller::tests::
- env CARGO_TARGET_DIR=/tmp/bat-target cargo test binary --test integration_tests
- env CARGO_TARGET_DIR=/tmp/bat-target cargo test
- env CARGO_TARGET_DIR=/tmp/bat-target cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- git diff --check