### PR TITLE
Add Dockerfile and GitHub Actions workflow for Docker image build (closes #3633)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "Building bat version: $VERSION"
+
+          docker build \
+            --build-arg BAT_VERSION=$VERSION \
+            -t ghcr.io/sharkdp/bat:$VERSION .
+
+      - name: Push Docker image
+        run: |
+          VERSION=${{ github.ref_name }}
+          docker push ghcr.io/sharkdp/bat:$VERSION
+
+      - name: Push latest tag
+        if: github.event_name == 'release'
+        run: |
+          VERSION=${{ github.ref_name }}
+          docker tag ghcr.io/sharkdp/bat:$VERSION ghcr.io/sharkdp/bat:latest
+          docker push ghcr.io/sharkdp/bat:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
-- [CI/CD] Added Dockerfile and GitHub Actions workflow to build and publish Docker images to GHCR, see #3633 (@foxfromworld)
+- Added Dockerfile and GitHub Actions workflow to build and publish Docker images to GHCR (@foxfromworld). Closes #3633
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
-- Added Dockerfile and GitHub Actions workflow to build and publish Docker images to GHCR (@foxfromworld). Closes #3633
+- Added Dockerfile and GitHub Actions workflow to build and publish Docker images to GHCR, see #3764 (@foxfromworld)
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
+- [CI/CD] Added Dockerfile and GitHub Actions workflow to build and publish Docker images to GHCR, see #3633 (@foxfromworld)
 
 ## Features
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1.88-slim
+
+ARG BAT_VERSION
+ENV BAT_VERSION=${BAT_VERSION}
+
+RUN apt-get update && apt-get install -y wget tar cargo build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/sharkdp/bat/archive/refs/tags/${BAT_VERSION}.tar.gz && \
+    tar -xzf ${BAT_VERSION}.tar.gz && \
+    cd bat-${BAT_VERSION#v} && \
+    cargo build --release && \
+    mv target/release/bat /usr/local/bin/ && \
+
+    cd .. && rm -rf bat-${BAT_VERSION#v} ${BAT_VERSION}.tar.gz
+
+ENTRYPOINT ["bat"]


### PR DESCRIPTION
This PR introduces Docker support for bat:

- Added a `Dockerfile` to build bat from source.
- Added a GitHub Actions workflow (`docker.yml`) that triggers on release and automatically builds and publishes Docker images to GHCR.
- Images are tagged with the release version (e.g. `ghcr.io/sharkdp/bat:v0.26.10`) and also pushed as `latest`.

This allows users to run bat directly via Docker without compiling Rust locally:

```
docker pull ghcr.io/sharkdp/bat:vX.Y.Z
docker run --rm ghcr.io/sharkdp/bat:vX.Y.Z --version
```

Closes #3633