### PR TITLE
fix: disable --wrap=character/word when output is piped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Disable --wrap=character/word when output is piped, see #3765 (@leno23)
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -407,12 +407,25 @@ impl App {
                 if self.matches.get_flag("chop-long-lines") {
                     WrappingMode::NoWrapping(true)
                 } else {
+                    let wrap_to_terminal = self.interactive_output || maybe_term_width.is_some();
                     match self.matches.get_one::<String>("wrap").map(|s| s.as_str()) {
-                        Some("character") => WrappingMode::Character,
-                        Some("word") => WrappingMode::Word,
+                        Some("character") => {
+                            if wrap_to_terminal {
+                                WrappingMode::Character
+                            } else {
+                                WrappingMode::NoWrapping(false)
+                            }
+                        }
+                        Some("word") => {
+                            if wrap_to_terminal {
+                                WrappingMode::Word
+                            } else {
+                                WrappingMode::NoWrapping(false)
+                            }
+                        }
                         Some("never") => WrappingMode::NoWrapping(true),
                         Some("auto") | None => {
-                            if self.interactive_output || maybe_term_width.is_some() {
+                            if wrap_to_terminal {
                                 if style_components.plain() && maybe_term_width.is_none() {
                                     WrappingMode::NoWrapping(false)
                                 } else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1099,6 +1099,28 @@ fn terminal_width_arg_overrides_env() {
 }
 
 #[test]
+fn wrap_character_disabled_when_output_piped() {
+    let tmp_dir = tempdir().expect("can create temporary directory");
+    let tmp_path = tmp_dir.path().join("long.txt");
+    std::fs::write(
+        &tmp_path,
+        "0123456789abcdef0123456789abcdef0123456789abcdef\n",
+    )
+    .expect("can write temporary file");
+
+    bat()
+        .arg(&tmp_path)
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--style=plain")
+        .arg("--wrap=character")
+        .assert()
+        .success()
+        .stdout("0123456789abcdef0123456789abcdef0123456789abcdef\n")
+        .stderr("");
+}
+
+#[test]
 fn fail_non_existing() {
     bat().arg("non-existing-file").assert().failure();
 }


### PR DESCRIPTION
## Summary

- When `--wrap=character` or `--wrap=word` is configured, bat now only wraps if stdout is a TTY or a terminal width was set explicitly (`--terminal-width` / `BAT_WIDTH`)
- Matches the existing `--wrap=auto` behavior and avoids unexpected wrapping when `--no-paging` output is piped to another program

Fixes #3660

## Test plan

- [x] `cargo test --test integration_tests wrap_character_disabled_when_output_piped`
- [x] `cargo test --test integration_tests terminal_width`