### PR TITLE
feat: deprecate --style=auto in favor of --decorations=auto (fixes #3752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Other
 
-- Deprecate `--style=auto` in favor of `--decorations=auto`, see #3752 (@leno23)
+- Deprecate `--style=auto` in favor of `--decorations=auto`, see #3770 (@leno23)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- Deprecate `--style=auto` in favor of `--decorations=auto`, see #3752 (@leno23)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -620,6 +620,12 @@ impl App {
                     .map(|v| StyleComponentList::from_str(v))
                     .collect::<Result<Vec<StyleComponentList>>>()?;
 
+                if lists.iter().any(|list| list.contains_auto()) {
+                    bat_warning!(
+                        "The style component 'auto' is deprecated; use '--decorations=auto' (the default) to control when decorations are shown."
+                    );
+                }
+
                 StyleComponentList::to_components(lists, self.interactive_output, true)
             }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -177,6 +177,13 @@ impl StyleComponentList {
         self.0.iter().any(|(a, _)| *a == ComponentAction::Override)
     }
 
+    /// Returns `true` if the list explicitly includes the deprecated `auto` style component.
+    pub fn contains_auto(&self) -> bool {
+        self.0
+            .iter()
+            .any(|(_, component)| *component == StyleComponent::Auto)
+    }
+
     /// Combines multiple [StyleComponentList]s into a single [StyleComponents] set.
     ///
     /// ## Precedence

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -483,7 +483,10 @@ fn piped_output_with_auto_style() {
         .write_stdin("hello\nworld\n")
         .assert()
         .success()
-        .stdout("hello\nworld\n"); // Should be plain when piped
+        .stdout("hello\nworld\n") // Should be plain when piped
+        .stderr(predicate::str::contains(
+            "The style component 'auto' is deprecated",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Warn when users pass the deprecated `auto` **style** component (`--style=auto` or `BAT_STYLE=auto`). Decoration visibility should be controlled via `--decorations=auto` (the default), not `--style`.

## Changes

- `src/style.rs` — `StyleComponentList::contains_auto()`
- `src/bin/bat/app.rs` — emit `bat_warning!` when `auto` appears in `--style`
- `tests/integration_tests.rs` — assert warning in `piped_output_with_auto_style`
- `CHANGELOG.md` — unreleased entry

## Behavior

No functional change yet; only a deprecation warning. Existing `piped_output_with_auto_style` behavior is preserved.

Fixes #3752

## Test plan

- [x] `cargo test --test integration_tests piped_output_with_auto_style`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

Made with [Cursor](https://cursor.com)