### PR TITLE
docs: note fzf preview needs --theme=auto:system (fixes #3433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- Document using `--theme=auto:system` in the `fzf` preview example so light/dark themes work when output is piped. Closes #3433, see #3773 (@leno23)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ bat f - g  # output 'f', then stdin, then 'g'.
 
 You can use `bat` as a previewer for [`fzf`](https://github.com/junegunn/fzf). To do this,
 use `bat`'s `--color=always` option to force colorized output. Because `fzf` reads the preview
-via a pipe, also pass `--theme=auto:system` (or an explicit `--theme`) so light/dark themes
-match your system preference. You can also use the `--line-range` option to restrict the load
+via a pipe, also pass `--theme=auto:system` on macOS (or an explicit `--theme` on
+other platforms) so light/dark themes match your system preference. You can also use the
+`--line-range` option to restrict the load
 times for long files:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -101,11 +101,13 @@ bat f - g  # output 'f', then stdin, then 'g'.
 #### `fzf`
 
 You can use `bat` as a previewer for [`fzf`](https://github.com/junegunn/fzf). To do this,
-use `bat`'s `--color=always` option to force colorized output. You can also use `--line-range`
-option to restrict the load times for long files:
+use `bat`'s `--color=always` option to force colorized output. Because `fzf` reads the preview
+via a pipe, also pass `--theme=auto:system` (or an explicit `--theme`) so light/dark themes
+match your system preference. You can also use the `--line-range` option to restrict the load
+times for long files:
 
 ```bash
-fzf --preview "bat --color=always --style=numbers --line-range=:500 {}"
+fzf --preview "bat --color=always --theme=auto:system --style=numbers --line-range=:500 {}"
 ```
 
 For more information, see [`fzf`'s `README`](https://github.com/junegunn/fzf#preview-window).


### PR DESCRIPTION
## Summary

When `bat` is used as an `fzf` preview command, its output is redirected through a pipe. In that case, bat cannot detect the terminal background to pick a light/dark theme automatically, so previews may always appear in the dark theme.

Document the recommended `--theme=auto:system` flag in the fzf integration example.

Fixes #3433

## Test plan

- [x] Documentation-only change

Made with [Cursor](https://cursor.com)