### PR TITLE
fix(pager): avoid combining less -K with -F (fixes #3458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Avoid passing `-K` to `less` together with `-F` in default paging mode, fixing abnormal pager exit at EOF. Closes #3458, see #3774 (@leno23)
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/src/output.rs
+++ b/src/output.rs
@@ -151,7 +151,13 @@ impl OutputType {
 
                 // Ensures that 'less' quits together with 'bat'
                 // The BusyBox version of less does not support -K
-                if less_version != Some(LessVersion::BusyBox) {
+                //
+                // Do not combine -K (--quit-on-intr) with -F (--quit-if-one-screen): this
+                // caused less to exit abnormally when scrolling past EOF in some versions,
+                // leaking terminal escape sequences to the shell (see #3458).
+                if less_version != Some(LessVersion::BusyBox)
+                    && single_screen_action != SingleScreenAction::Quit
+                {
                     p.arg("-K"); // Short version of '--quit-on-intr'
                 }
 


### PR DESCRIPTION
## Summary

Since v0.26, bat passes `-K` (`--quit-on-intr`) to `less` by default. In the usual interactive paging mode (`--paging=auto`), this is combined with `-F` (`--quit-if-one-screen`).

On some `less` versions, this combination causes the pager to exit abnormally when scrolling past EOF, leaving the terminal in application keypad mode and leaking escape sequences such as `^[OB` to the shell. This matches the regression reported between bat 0.25 and 0.26.

Only pass `-K` when `-F` is not in use (for example with `--paging=always`).

Fixes #3458

## Test plan

- [x] `cargo test --lib`
- [x] `cargo clippy -- -D warnings`
- [ ] Manual: open a file with default paging, scroll to EOF, press Down repeatedly — pager should stay open and shell should not print `^[OB`

Made with [Cursor](https://cursor.com)