### PR TITLE
feat: map Caddyfile to nginx syntax highlighting (fixes #3644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Features
 
-- Map `Caddyfile` to nginx syntax highlighting as an approximation of the Caddyfile format, see #3644 (@leno23)
+- Map `Caddyfile` to nginx syntax highlighting as an approximation of the Caddyfile format. Closes #3644, see #3775 (@leno23)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)
 - Added support for `hidden_file_extensions` from `.sublime-syntax` files, see #3613 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Features
 
+- Map `Caddyfile` to nginx syntax highlighting as an approximation of the Caddyfile format, see #3644 (@leno23)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)
 - Added support for `hidden_file_extensions` from `.sublime-syntax` files, see #3613 (@Matei02355)

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -293,6 +293,20 @@ mod tests {
     }
 
     #[test]
+    fn builtin_mappings_caddyfile_maps_to_nginx() {
+        let map = SyntaxMapping::new();
+
+        assert_eq!(
+            map.get_syntax_for("/etc/caddy/Caddyfile"),
+            Some(MappingTarget::MapTo("nginx"))
+        );
+        assert_eq!(
+            map.get_syntax_for("Caddyfile"),
+            Some(MappingTarget::MapTo("nginx"))
+        );
+    }
+
+    #[test]
     fn builtin_mappings_build_is_case_sensitive() {
         let map = SyntaxMapping::new();
 

--- a/src/syntax_mapping/builtins/common/50-caddy.toml
+++ b/src/syntax_mapping/builtins/common/50-caddy.toml
@@ -1,0 +1,5 @@
+[mappings]
+"nginx" = [
+    "Caddyfile",
+    "**/Caddyfile",
+]


### PR DESCRIPTION
## Summary

Fixes #3644 (partially).

Caddyfile uses a nginx-like configuration format. Until a dedicated Caddyfile syntax meets bat's inclusion criteria, map `Caddyfile` paths to the existing nginx highlighter. This matches what many users already configure manually via `--map-syntax`.

## Changes

- Add builtin syntax mapping for `Caddyfile` and `**/Caddyfile` → nginx
- Add unit test

## Test plan

- [x] `cargo test -p bat --lib builtin_mappings_caddyfile`
- [x] `cargo test -p bat --lib syntax_mapping`

Made with [Cursor](https://cursor.com)