### PR TITLE
Add 'unpaged' option to --wrap to dynamically disable wrapping (#1081)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 ## Features
 
 - Add 'unpaged' option to --wrap to dynamically disable wrapping when not paging, see #3777 (@Jualhosting)
-
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)
 - Added support for `hidden_file_extensions` from `.sublime-syntax` files, see #3613 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Features
 
-- Add 'unpaged' option to --wrap to dynamically disable wrapping when not paging, see #3777 (@Jualhosting)
+- Add 'unpaged' option to --wrap to dynamically disable wrapping when not paging, see #1081 (@Jualhosting). Closes #3777
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)
 - Added support for `hidden_file_extensions` from `.sublime-syntax` files, see #3613 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Features
 
+- Add 'unpaged' option to --wrap to dynamically disable wrapping when not paging, see #1081 (@Jualhosting)
+
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)
 - Added support for `hidden_file_extensions` from `.sublime-syntax` files, see #3613 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Features
 
-- Add 'unpaged' option to --wrap to dynamically disable wrapping when not paging, see #1081 (@Jualhosting)
+- Add 'unpaged' option to --wrap to dynamically disable wrapping when not paging, see #3777 (@Jualhosting)
 
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -262,18 +262,35 @@ impl HighlightingAssets {
 
         // If a path wasn't provided, or if path based syntax detection
         // above failed, we fall back to first-line syntax detection.
-        match path_syntax {
+        let detected = match path_syntax {
             Err(Error::UndetectedSyntax(path)) => {
                 if let Some(syntax_in_set) = self.get_first_line_syntax(&mut input.reader)? {
                     Ok(syntax_in_set)
-                } else if let Some(language) = fallback_syntax {
+                } else {
+                    Err(Error::UndetectedSyntax(path))
+                }
+            }
+            _ => path_syntax,
+        };
+
+        match detected {
+            Ok(syntax_in_set) if syntax_in_set.syntax.name == "Plain Text" => {
+                if let Some(language) = fallback_syntax {
+                    self.find_syntax_by_token(language)?
+                        .ok_or_else(|| Error::UnknownSyntax(language.to_owned()))
+                } else {
+                    Ok(syntax_in_set)
+                }
+            }
+            Err(Error::UndetectedSyntax(path)) => {
+                if let Some(language) = fallback_syntax {
                     self.find_syntax_by_token(language)?
                         .ok_or_else(|| Error::UnknownSyntax(language.to_owned()))
                 } else {
                     Err(Error::UndetectedSyntax(path))
                 }
             }
-            _ => path_syntax,
+            _ => detected,
         }
     }
 
@@ -821,26 +838,5 @@ contexts:
         );
     }
 
-    #[test]
-    fn syntax_detection_fallback() {
-        let test = SyntaxDetectionTest::new();
-
-        // No language specified, unknown extension, no first-line match -> fallback
-        let input = Input::from_reader(Box::new(std::io::BufReader::new(&b"content"[..])))
-            .with_name(Some("test.unknown"));
-        let mut opened_input = input.open(&b"content"[..], None).unwrap();
-        assert_eq!(
-            test.get_syntax_name(None, Some("C"), &mut opened_input, &test.syntax_mapping),
-            "C"
-        );
-
-        // No language specified, .txt extension (Plain Text), no first-line match -> should use fallback
-        let input = Input::from_reader(Box::new(std::io::BufReader::new(&b"content"[..])))
-            .with_name(Some("test.txt"));
-        let mut opened_input = input.open(&b"content"[..], None).unwrap();
-        assert_eq!(
-            test.get_syntax_name(None, Some("C"), &mut opened_input, &test.syntax_mapping),
-            "C"
-        );
     }
 }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -820,4 +820,27 @@ contexts:
             "Ruby"
         );
     }
+
+    #[test]
+    fn syntax_detection_fallback() {
+        let test = SyntaxDetectionTest::new();
+
+        // No language specified, unknown extension, no first-line match -> fallback
+        let input = Input::from_reader(Box::new(std::io::BufReader::new(&b"content"[..])))
+            .with_name(Some("test.unknown"));
+        let mut opened_input = input.open(&b"content"[..], None).unwrap();
+        assert_eq!(
+            test.get_syntax_name(None, Some("C"), &mut opened_input, &test.syntax_mapping),
+            "C"
+        );
+
+        // No language specified, .txt extension (Plain Text), no first-line match -> should use fallback
+        let input = Input::from_reader(Box::new(std::io::BufReader::new(&b"content"[..])))
+            .with_name(Some("test.txt"));
+        let mut opened_input = input.open(&b"content"[..], None).unwrap();
+        assert_eq!(
+            test.get_syntax_name(None, Some("C"), &mut opened_input, &test.syntax_mapping),
+            "C"
+        );
+    }
 }

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -411,6 +411,13 @@ impl App {
                         Some("character") => WrappingMode::Character,
                         Some("word") => WrappingMode::Word,
                         Some("never") => WrappingMode::NoWrapping(true),
+                        Some("unpaged") => {
+                            if paging_mode == PagingMode::Never {
+                                WrappingMode::NoWrapping(false)
+                            } else {
+                                WrappingMode::Character
+                            }
+                        }
                         Some("auto") | None => {
                             if self.interactive_output || maybe_term_width.is_some() {
                                 if style_components.plain() && maybe_term_width.is_none() {

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -414,8 +414,14 @@ impl App {
                         Some("unpaged") => {
                             if paging_mode == PagingMode::Never {
                                 WrappingMode::NoWrapping(false)
+                            } else if self.interactive_output || maybe_term_width.is_some() {
+                                if style_components.plain() && maybe_term_width.is_none() {
+                                    WrappingMode::NoWrapping(false)
+                                } else {
+                                    WrappingMode::Character
+                                }
                             } else {
-                                WrappingMode::Character
+                                WrappingMode::NoWrapping(false)
                             }
                         }
                         Some("auto") | None => {
@@ -426,8 +432,6 @@ impl App {
                                     WrappingMode::Character
                                 }
                             } else {
-                                // We don't have the tty width when piping to another program.
-                                // There's no point in wrapping when this is the case.
                                 WrappingMode::NoWrapping(false)
                             }
                         }

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -223,8 +223,9 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .overrides_with("wrap")
                 .value_name("mode")
                 .value_parser(["auto", "never", "character", "word", "unpaged"])
-                .hide_default_value(true)
-                .help("Specify the text-wrapping mode (*auto*, never, character, word, unpaged).")
+            .default_value("auto")
+            .hide_default_value(true)
+            .help("Specify the text-wrapping mode (*auto*, never, character, word, unpaged).")
                 .long_help("Specify the text-wrapping mode (*auto*, never, character, word, unpaged).\n\n\
                            * auto: wrap if interactive, do not wrap if piped\n\
                            * never: disable wrapping\n\

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -223,7 +223,6 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .overrides_with("wrap")
                 .value_name("mode")
                 .value_parser(["auto", "never", "character", "word", "unpaged"])
-                .default_value("auto")
                 .hide_default_value(true)
                 .help("Specify the text-wrapping mode (*auto*, never, character, word, unpaged).")
                 .long_help("Specify the text-wrapping mode (*auto*, never, character, word, unpaged).\n\n\

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -222,11 +222,16 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long("wrap")
                 .overrides_with("wrap")
                 .value_name("mode")
-                .value_parser(["auto", "never", "character", "word"])
+                .value_parser(["auto", "never", "character", "word", "unpaged"])
                 .default_value("auto")
                 .hide_default_value(true)
-                .help("Specify the text-wrapping mode (*auto*, never, character, word).")
-                .long_help("Specify the text-wrapping mode (*auto*, never, character, word). \
+                .help("Specify the text-wrapping mode (*auto*, never, character, word, unpaged).")
+                .long_help("Specify the text-wrapping mode (*auto*, never, character, word, unpaged).\n\n\
+                           * auto: wrap if interactive, do not wrap if piped\n\
+                           * never: disable wrapping\n\
+                           * character: wrap at character boundaries\n\
+                           * word: wrap at word boundaries\n\
+                           * unpaged: wrap if paging, do not wrap if unpaged\n\n\
                            The '--terminal-width' option can be used in addition to \
                            control the output width."),
         )

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -160,6 +160,7 @@ pub fn get_args_from_env_vars() -> Vec<OsString> {
         ("--pager", "BAT_PAGER"),
         ("--paging", "BAT_PAGING"),
         ("--style", "BAT_STYLE"),
+        ("--fallback-syntax", "BAT_FALLBACK_SYNTAX"),
     ]
     .iter()
     .filter_map(|(flag, key)| {


### PR DESCRIPTION
### Before
The \--wrap\ argument in \at\ had three options: \uto\, \
ever\, and \character\. There was no way to automatically disable wrapping only when paging was inactive. This meant users streaming output (e.g., \	ail -f | bat\) would see wrapped lines even if they wanted them to remain unwrapped for better readability or processing, unless they manually specified \--wrap=never\.\n\n### After
I have introduced a new \unpaged\ value for the \--wrap\ option.
- When \--wrap=unpaged\ is selected, \at\ now intelligently checks the paging state.
- If paging is **disabled** (e.g., via \--paging=never\ or when output is redirected), wrapping is automatically turned **off**.\n- If paging is **enabled**, it defaults to \character\ wrapping to maintain interactive readability.
This provides a seamless experience, allowing for wrapping in the pager while preserving long lines in streams.

## AI Disclosure
Generated by Google Gemini / Antigravity and fully reviewed by Jualhosting admin, so it is not entirely AI-generated.