### PR TITLE
fix: force paging=never for --list-themes when BAT_OPTS has paging=always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Force `paging=never` for `--list-themes` when `BAT_OPTS` contains `--paging=always`, see #3779 (@sridhar-3009). Closes #1618
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -289,12 +289,12 @@ impl App {
 
         let paging_mode = match self.matches.get_one::<String>("paging").map(|s| s.as_str()) {
             Some("always") => {
-                // --list-themes must not be paged: each theme would appear in a separate
-                // pager session, making theme names invisible. Ignore paging=always here.
-                if self.matches.get_flag("list-themes") {
-                    PagingMode::Never
-                // Disable paging if the second -p (or -pp) is specified after --paging=always
-                } else if extra_plain && plain_last_index > paging_last_index {
+                // Disable paging when --list-themes is active (each theme would otherwise
+                // open a separate pager session, hiding theme names), or when the user
+                // has overridden paging=always with a later -pp flag.
+                if self.matches.get_flag("list-themes")
+                    || (extra_plain && plain_last_index > paging_last_index)
+                {
                     PagingMode::Never
                 } else {
                     PagingMode::Always

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -289,8 +289,12 @@ impl App {
 
         let paging_mode = match self.matches.get_one::<String>("paging").map(|s| s.as_str()) {
             Some("always") => {
+                // --list-themes must not be paged: each theme would appear in a separate
+                // pager session, making theme names invisible. Ignore paging=always here.
+                if self.matches.get_flag("list-themes") {
+                    PagingMode::Never
                 // Disable paging if the second -p (or -pp) is specified after --paging=always
-                if extra_plain && plain_last_index > paging_last_index {
+                } else if extra_plain && plain_last_index > paging_last_index {
                     PagingMode::Never
                 } else {
                     PagingMode::Always


### PR DESCRIPTION
## Problem

When `BAT_OPTS` contains `--paging=always` (a common personal config), running `bat --list-themes` opens a separate pager session per theme, making theme names invisible and the output entirely unusable.

## Root cause

The `paging=always` branch in `app.rs` had no guard for `--list-themes`, so the pager ran unconditionally.

## Fix

Check `list-themes` flag before applying `paging=always`. Override to `PagingMode::Never` when listing themes, consistent with the existing `--list-themes` guard already present in the `auto` branch (line 306).

## Testing

Manual: set `BAT_OPTS="--paging=always"` and run `bat --list-themes` — all themes now display correctly in a single pass.

Fixes #1618