### PR TITLE
docs(zh): fix reversed batcat/bat substitution note in README-zh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- Fix reversed `batcat`/`bat` substitution note in the Chinese README MANPAGER section, see #3780 (@xfocus3). Closes #3730
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -177,7 +177,7 @@ export MANPAGER="sh -c 'awk '\''{ gsub(/\x1B\[[0-9;]*m/, \"\", \$0); gsub(/.\x08
 man 2 select
 ```
 
-（如果你使用 Debian 或 Ubuntu，请将 `batcat` 替换为 `bat`）
+（如果你使用 Debian 或 Ubuntu，请将 `bat` 替换为 `batcat`）
 
 如果你希望将其打包为一个新的命令，也可以使用 [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md)。
 


### PR DESCRIPTION
## Problem

In the Chinese README, the `man` / `MANPAGER` section tells Debian/Ubuntu users to replace `batcat` with `bat`:

> （如果你使用 Debian 或 Ubuntu，请将 `batcat` 替换为 `bat`）
> (if you use Debian or Ubuntu, replace `batcat` with `bat`)

This is reversed. On Debian/Ubuntu the executable is installed as **`batcat`** (due to a name clash, see #982), and the example command uses `bat`, so users on those distros must replace **`bat` → `batcat`**, not the other way around. As written, the instruction is self-contradictory (the example contains no `batcat` to replace) and misleading.

This was reported in #3730.

## Fix

Swap the two terms so the Chinese note matches reality and the other translations:

- Russian: `замените `bat` на `batcat`` (replace bat with batcat) ✓
- Korean: ``bat`을 `batcat`으로 치환하세요` (replace bat with batcat) ✓

```diff
-（如果你使用 Debian 或 Ubuntu，请将 `batcat` 替换为 `bat`）
+（如果你使用 Debian 或 Ubuntu，请将 `bat` 替换为 `batcat`）
```

## Scope

This PR fixes only the clear factual reversal in the Chinese doc. The other part of #3730 — the `MANPAGER` command bodies differing across translations (`awk` vs `col -bx`) — is a separate, more subjective consistency question and is left out of this minimal fix.