### PR TITLE
docs: mention bash completion for help wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- Document Bash completion for the `help` wrapper used to highlight `--help` output, see #3788 (@xfocus3)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,13 @@ help() {
 
 Then you can do `$ help cp` or `$ help git commit`.
 
+If you are using Bash with the `bash-completion` package installed, you can also enable
+completion for the command passed to `help`:
+
+```bash
+complete -F _command help
+```
+
 When you are using `zsh`, you can also use global aliases to override `-h` and `--help` entirely:
 
 ```bash


### PR DESCRIPTION
## Summary
- Document the Bash completion hook for the `help` wrapper in the `--help` highlighting section.
- Note that it depends on the `bash-completion` package.

Closes #3293.

## Verification
- Ran `git diff --check`.

No changelog entry: documentation-only README change.