### PR TITLE
Revert "docs: clarify Ubuntu and Debian executable name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ bat main.cpp | xclip
 export MANPAGER="bat -plman"
 man 2 select
 ```
-(on some older Debian or Ubuntu releases, the executable is named `batcat` instead of `bat`)
+(replace `bat` with `batcat` if you are on Debian or Ubuntu)
 
 If you prefer to have this bundled in a new command, you can also use [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md).
 
@@ -264,8 +264,8 @@ If your Ubuntu/Debian installation is new enough you can simply run:
 sudo apt install bat
 ```
 
-**Important**: On some older Ubuntu/Debian releases, the executable is installed as `batcat` instead of `bat` (due to [a name
-clash with another package](https://github.com/sharkdp/bat/issues/982)). On newer releases, the executable is available as `bat`. If `bat --version` does not work after installation, try `batcat --version` instead. You can set up a `bat -> batcat` symlink or alias to prevent any issues that may come up because of this and to be consistent with other distributions:
+**Important**: If you install `bat` this way, please note that the executable may be installed as `batcat` instead of `bat` (due to [a name
+clash with another package](https://github.com/sharkdp/bat/issues/982)). You can set up a `bat -> batcat` symlink or alias to prevent any issues that may come up because of this and to be consistent with other distributions:
 ``` bash
 mkdir -p ~/.local/bin
 ln -s /usr/bin/batcat ~/.local/bin/bat


### PR DESCRIPTION
Debian has never shipped the bat project's binary as `bat` in a stable release, but only as `batcat`. It was temporarly named `bat` for a couple of months before getting reverted to `batcat` again, due to another file conflict.

From the Debian package changelog:

    rust-bat (0.22.1-4) unstable; urgency=medium

      * Non-maintainer upload.
      * revert the renaming (closes: #1029504)

     -- Sylvestre Ledru <sylvestre@debian.org>  Mon, 17 Apr 2023 22:26:25 +0200

    rust-bat (0.22.1-3) unstable; urgency=medium

      * Team upload.
      * Package bat 0.22.1 from crates.io using debcargo 2.6.0
      * Ship bat as bat (instead of batcat) (Closes: #1029096)

     -- Sylvestre Ledru <sylvestre@debian.org>  Sat, 21 Jan 2023 11:47:18 +0100

This reverts commit 9fccdbc48420b1bb9de852c275969e838cfbc6ef.