### PR TITLE
Fix garbled ANSI output when using bat as MANPAGER (--strip-ansi=auto now preserves man formatting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add `--fallback-syntax`/`--fallback-language` to apply syntax highlighting only when auto-detection fails, see #1341 (@Xavrir)
 - Map `BUILD` case sensitively to Python (Starlark) for Bazel, see #3576 (@vorburger)
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
+- Re-apply semantic ANSI formatting (bold, underline, hyperlinks) after syntax highlighting when using `--strip-ansi=auto`, enabling correct man page rendering with both syntax colors and man formatting. Closes #3724, see #3792 (@Anntoin)
 
 ## Bugfixes
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
@@ -61,6 +62,7 @@
 - Don't color strings inside CSV files, to make it easier to tell which column they belong to, see #3521 (@keith-hall)
 - Add syntax highlighting support for COBOL, see #3584 (@adukhan99)
 - Fixed manpage syntax so that ANSI escape codes don't get incorrectly highlighted and thus broken, see #3586 (@BlueElectivire)
+- Update Manpage syntax prototype context to consume ANSI CSI and OSC8 escape sequences, preventing garbled output when using bat as MANPAGER. See #3792 (@Anntoin)
 - Map several Google Cloud CLI config files to their appropriate syntax #3635 (@victor-gp)
 - Map all ignore dotfiles to Git Ignore syntax #3636 (@victor-gp)
 - Improved Kotlin syntax, see #3699 (@guille)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ## Bugfixes
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
+- Preserve ANSI escape sequences that appear before overstrike backspaces in man pages, see #3724 (@sjh9714)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)
 - Fix inverted `$LESSCLOSE` warning so bat warns on nonzero exit, not on success. See #3654 (@cuiweixie)
 - Sanitize control characters in filenames before displaying them in the file header, error messages, and the terminal title, preventing ANSI escape injection via crafted filenames. Closes #3054, see #3691 (@curious-rabbit)

--- a/assets/syntaxes/02_Extra/Manpage.sublime-syntax
+++ b/assets/syntaxes/02_Extra/Manpage.sublime-syntax
@@ -10,6 +10,7 @@ variables:
   section_heading: '^(?!#)\S.*$'
   command_line_option: '(--?[A-Za-z0-9][_A-Za-z0-9-]*)'
   ansi_escape_sequence: '\e\[[\?=]?(?:\d+;?)*[A-Za-z]'
+  osc_escape_sequence: '\e\](?:[^\e\\]|\e[^\\])*\e\\'
 
 contexts:
   prototype:
@@ -19,6 +20,12 @@ contexts:
         - meta_scope: comment.syntax-test.man
         - match: $\n?
           pop: true
+    # consume ANSI escape sequences so they don't break across highlight regions
+    - match: '{{ansi_escape_sequence}}'
+      scope: constant.other.inline-data.man
+    # consume OSC sequences (e.g. OSC8 hyperlinks) similarly
+    - match: '{{osc_escape_sequence}}'
+      scope: constant.other.inline-data.man
   main:
     - match: ^
       push: first_line

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -160,9 +160,11 @@ Options:
           Set the maximum number of consecutive empty lines to be printed.
 
       --strip-ansi <when>
-          Specify when to strip ANSI escape sequences from the input. The automatic mode will remove
-          escape sequences unless the syntax highlighting language is plain text. Possible values:
-          auto, always, *never*.
+          Specify when to strip ANSI escape sequences from the input. In 'auto' mode, ANSI escape
+          sequences are stripped before syntax highlighting, but semantic formatting (bold,
+          underline, hyperlinks) is re-applied on the output so that both syntax highlighting and
+          input formatting are preserved. This is the recommended mode for use as MANPAGER. Possible
+          values: auto, always, *never*.
 
       --style <components>
           Configure which elements (line numbers, file headers, grid borders, Git modifications, ..)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -476,8 +476,11 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .hide_default_value(true)
                 .help("Strip colors from the input (auto, always, *never*)")
                 .long_help("Specify when to strip ANSI escape sequences from the input. \
-                The automatic mode will remove escape sequences unless the syntax highlighting \
-                language is plain text. Possible values: auto, always, *never*.")
+                In 'auto' mode, ANSI escape sequences are stripped before syntax highlighting, \
+                but semantic formatting (bold, underline, hyperlinks) is re-applied on the output \
+                so that both syntax highlighting and input formatting are preserved. \
+                This is the recommended mode for use as MANPAGER. \
+                Possible values: auto, always, *never*.")
                 .hide_short_help(true)
         )
         .arg(

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -189,14 +189,14 @@ pub fn sanitize_for_terminal(input: &str) -> String {
 pub fn strip_overstrike(line: &str, first_backspace: usize) -> String {
     let mut output = String::with_capacity(line.len());
     output.push_str(&line[..first_backspace]);
-    output.pop();
+    pop_visible_char(&mut output);
 
     let mut remaining = &line[first_backspace + 1..];
 
     loop {
         if let Some(pos) = remaining.find('\x08') {
             output.push_str(&remaining[..pos]);
-            output.pop();
+            pop_visible_char(&mut output);
             remaining = &remaining[pos + 1..];
         } else {
             output.push_str(remaining);
@@ -205,6 +205,26 @@ pub fn strip_overstrike(line: &str, first_backspace: usize) -> String {
     }
 
     output
+}
+
+fn pop_visible_char(output: &mut String) {
+    let mut char_to_remove = None;
+
+    for seq in EscapeSequenceOffsetsIterator::new(output) {
+        if let EscapeSequenceOffsets::Text { .. } = seq {
+            let start = seq.index_of_start();
+            let text = &output[start..seq.index_past_end()];
+
+            if let Some((relative_start, chr)) = text.char_indices().next_back() {
+                let char_start = start + relative_start;
+                char_to_remove = Some((char_start, char_start + chr.len_utf8()));
+            }
+        }
+    }
+
+    if let Some((start, end)) = char_to_remove {
+        output.replace_range(start..end, "");
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Default)]
@@ -289,6 +309,11 @@ fn test_strip_overstrike() {
 
     // Unicode with overstrike
     assert_eq!(strip_overstrike("ä\x08äöü", 2), "äöü");
+}
+
+#[test]
+fn test_strip_overstrike_preserves_ansi_before_backspace() {
+    assert_eq!(strip_overstrike("v\x1b[22m\x08v", 6), "\x1b[22mv");
 }
 
 #[test]

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -171,9 +171,9 @@ pub fn strip_ansi_with_overlay(line: &str) -> (String, Vec<(usize, AnsiStyle)>) 
                 let offset = stripped.len();
 
                 // Only record a style change if it differs from the last recorded one.
-                let is_style_change = style_changes.last().map_or(true, |(_, prev)| {
-                    format!("{prev}") != format!("{current_style}")
-                });
+                let is_style_change = style_changes
+                    .last()
+                    .map_or(true, |(_, prev)| *prev != current_style);
 
                 if is_style_change {
                     style_changes.push((offset, current_style.clone()));
@@ -406,6 +406,7 @@ fn test_sanitize_for_terminal_idempotent_on_sanitized() {
 
 /// Helper: extract the AnsiStyle at a given byte offset
 /// within the stripped text, using the same binary-search logic as the printer.
+#[cfg(test)]
 fn overlay_style_at(offset: usize, overlay: &[(usize, AnsiStyle)]) -> AnsiStyle {
     match overlay.binary_search_by_key(&offset, |(pos, _)| *pos) {
         Ok(idx) => overlay[idx].1.clone(),

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -173,7 +173,7 @@ pub fn strip_ansi_with_overlay(line: &str) -> (String, Vec<(usize, AnsiStyle)>) 
                 // Only record a style change if it differs from the last recorded one.
                 let is_style_change = style_changes
                     .last()
-                    .map_or(true, |(_, prev)| *prev != current_style);
+                    .is_none_or(|(_, prev)| *prev != current_style);
 
                 if is_style_change {
                     style_changes.push((offset, current_style.clone()));

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -2,7 +2,10 @@ use std::fmt::Write;
 
 use crate::{
     nonprintable_notation::NonprintableNotation,
-    vscreen::{EscapeSequenceOffsets, EscapeSequenceOffsetsIterator},
+    vscreen::{
+        AnsiStyle, EscapeSequence, EscapeSequenceIterator, EscapeSequenceOffsets,
+        EscapeSequenceOffsetsIterator,
+    },
 };
 
 /// Expand tabs like an ANSI-enabled expand(1).
@@ -137,6 +140,7 @@ pub fn replace_nonprintable(
 }
 
 /// Strips ANSI escape sequences from the input.
+#[allow(dead_code)]
 pub fn strip_ansi(line: &str) -> String {
     let mut buffer = String::with_capacity(line.len());
 
@@ -147,6 +151,43 @@ pub fn strip_ansi(line: &str) -> String {
     }
 
     buffer
+}
+
+/// Strip ANSI escape sequences from a line, returning both the stripped text
+/// and a style overlay that maps byte positions in the stripped text to the
+/// `AnsiStyle` that was active at each position in the original text.
+///
+/// This allows syntax highlighting (syntect) to operate on clean text, while
+/// preserving the original ANSI formatting (bold, underline, color, etc.) for
+/// re-application during rendering.
+pub fn strip_ansi_with_overlay(line: &str) -> (String, Vec<(usize, AnsiStyle)>) {
+    let mut stripped = String::with_capacity(line.len());
+    let mut style_changes: Vec<(usize, AnsiStyle)> = Vec::new();
+    let mut current_style = AnsiStyle::new();
+
+    for chunk in EscapeSequenceIterator::new(line) {
+        match chunk {
+            EscapeSequence::Text(text) => {
+                let offset = stripped.len();
+
+                // Only record a style change if it differs from the last recorded one.
+                let is_style_change = style_changes.last().map_or(true, |(_, prev)| {
+                    format!("{prev}") != format!("{current_style}")
+                });
+
+                if is_style_change {
+                    style_changes.push((offset, current_style.clone()));
+                }
+
+                stripped.push_str(text);
+            }
+            _ => {
+                current_style.update(chunk);
+            }
+        }
+    }
+
+    (stripped, style_changes)
 }
 
 /// Escape C0, DEL, and C1 control characters so a string from an untrusted
@@ -227,6 +268,14 @@ fn pop_visible_char(output: &mut String) {
     }
 }
 
+/// Controls when ANSI escape sequences are stripped from input before rendering.
+///
+/// - `Never` (default): ANSI escape sequences pass through to the terminal unchanged.
+/// - `Always`: All ANSI escape sequences are stripped and discarded.
+/// - `Auto`: ANSI escape sequences are stripped before syntax highlighting, but
+///   semantic formatting (bold, underline, OSC8 hyperlinks) is re-applied on the
+///   output. This preserves both syntax highlighting and the input's formatting.
+///   Recommended for use as MANPAGER (e.g. `MANPAGER="bat -pl man --strip-ansi=auto"`).
 #[derive(Debug, PartialEq, Clone, Copy, Default)]
 pub enum StripAnsiMode {
     #[default]
@@ -351,4 +400,355 @@ fn test_sanitize_for_terminal_idempotent_on_sanitized() {
     assert_eq!(sanitize_for_terminal(&clean), clean);
     assert!(!clean.contains('\x1b'));
     assert!(!clean.contains('\x07'));
+}
+
+// ── strip_ansi_with_overlay tests ──────────────────────────────────────────
+
+/// Helper: extract the AnsiStyle at a given byte offset
+/// within the stripped text, using the same binary-search logic as the printer.
+fn overlay_style_at(offset: usize, overlay: &[(usize, AnsiStyle)]) -> AnsiStyle {
+    match overlay.binary_search_by_key(&offset, |(pos, _)| *pos) {
+        Ok(idx) => overlay[idx].1.clone(),
+        Err(idx) => {
+            if idx == 0 {
+                AnsiStyle::new()
+            } else {
+                overlay[idx - 1].1.clone()
+            }
+        }
+    }
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_no_ansi() {
+    let (stripped, overlay) = strip_ansi_with_overlay("plain text");
+    assert_eq!(stripped, "plain text");
+    // Default style at offset 0 produces empty display (no ANSI codes)
+    assert_eq!(
+        format!("{}", overlay_style_at(0, &overlay)),
+        "",
+        "default style should produce no ANSI output"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_bold_on_off() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[1mNAME\x1B[22m more");
+    assert_eq!(stripped, "NAME more");
+
+    let style = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style}").contains("\x1B[1m"),
+        "bold should be active at offset 0"
+    );
+
+    // After "NAME " at offset 5, bold should be off due to \x1B[22m
+    let style_after = overlay_style_at(5, &overlay);
+    assert!(
+        !format!("{style_after}").contains("\x1B[1m"),
+        "bold should be off after \\x1B[22m"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_underline_on_off() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[4marg\x1B[24m rest");
+    assert_eq!(stripped, "arg rest");
+
+    let style = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style}").contains("\x1B[4m"),
+        "underline should be active"
+    );
+
+    let style_after = overlay_style_at(3, &overlay);
+    assert!(
+        !format!("{style_after}").contains("\x1B[4m"),
+        "underline should be off after \\x1B[24m"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_bold_and_underline_combined() {
+    let input = "\x1B[1mNAME\x1B[22m\x1B[4muname\x1B[24m";
+    let (stripped, overlay) = strip_ansi_with_overlay(input);
+    assert_eq!(stripped, "NAMEuname");
+
+    let style_name = overlay_style_at(0, &overlay);
+    let name_fmt = format!("{style_name}");
+    assert!(name_fmt.contains("\x1B[1m"), "bold active for NAME");
+    assert!(!name_fmt.contains("\x1B[4m"), "underline off for NAME");
+
+    let style_arg = overlay_style_at(4, &overlay);
+    let arg_fmt = format!("{style_arg}");
+    assert!(!arg_fmt.contains("\x1B[1m"), "bold off for uname");
+    assert!(arg_fmt.contains("\x1B[4m"), "underline active for uname");
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_dim() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[2mdim text\x1B[22m");
+    assert_eq!(stripped, "dim text");
+
+    let style = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style}").contains("\x1B[2m"),
+        "dim should be active"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_italic() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[3mitalic\x1B[23m rest");
+    assert_eq!(stripped, "italic rest");
+
+    let style = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style}").contains("\x1B[3m"),
+        "italic should be active"
+    );
+
+    let style_after = overlay_style_at(6, &overlay);
+    assert!(
+        !format!("{style_after}").contains("\x1B[3m"),
+        "italic should be off after \\x1B[23m"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_foreground_color() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[33mColor\x1B[39m");
+    assert_eq!(stripped, "Color");
+
+    let style = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style}").contains("\x1B[33m"),
+        "foreground color should be active"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_256_color() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[38;5;182mHeading\x1B[39m");
+    assert_eq!(stripped, "Heading");
+
+    let style = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style}").contains("38;5;182"),
+        "foreground should contain 256-color code 182"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_truecolor() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[38;2;255;100;0mOrange\x1B[39m");
+    assert_eq!(stripped, "Orange");
+
+    let style = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style}").contains("38;2;255;100;0"),
+        "foreground should contain truecolor code"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_background_color() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[41mBG\x1B[49m");
+    assert_eq!(stripped, "BG");
+
+    let style = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style}").contains("\x1B[41m"),
+        "background color should be active"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_sgr_reset() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[1;33mBoldYellow\x1B[0mplain");
+    assert_eq!(stripped, "BoldYellowplain");
+
+    let style_bold = overlay_style_at(0, &overlay);
+    let bold_fmt = format!("{style_bold}");
+    assert!(bold_fmt.contains("\x1B[1m"), "bold active before reset");
+    assert!(
+        bold_fmt.contains("\x1B[33m"),
+        "foreground active before reset"
+    );
+
+    let style_plain = overlay_style_at(10, &overlay);
+    let plain_fmt = format!("{style_plain}");
+    assert!(!plain_fmt.contains("\x1B[1m"), "bold off after reset");
+    assert!(
+        !plain_fmt.contains("\x1B[33m"),
+        "foreground off after reset"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_osc8_hyperlink() {
+    let input = "\x1B]8;;man:sshd(8)\x1B\\sshd\x1B]8;;\x1B\\";
+    let (stripped, overlay) = strip_ansi_with_overlay(input);
+    assert_eq!(stripped, "sshd");
+
+    let style = overlay_style_at(0, &overlay);
+    let fmt = format!("{style}");
+    assert!(
+        fmt.contains("\x1B]8;;"),
+        "hyperlink should be active for linked text"
+    );
+    assert!(
+        fmt.contains("man:sshd(8)"),
+        "hyperlink URI should be preserved"
+    );
+    // Reset sequence should close the hyperlink
+    assert_eq!(
+        style.to_reset_sequence(),
+        "\x1B]8;;\x1B\\",
+        "reset should close hyperlink"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_osc8_hyperlink_open_close() {
+    let input = "before\x1B]8;;https://example.com\x1B\\linked\x1B]8;;\x1B\\after";
+    let (stripped, overlay) = strip_ansi_with_overlay(input);
+    assert_eq!(stripped, "beforelinkedafter");
+
+    // "before" at offset 0: no hyperlink
+    let style_before = overlay_style_at(0, &overlay);
+    assert!(
+        !format!("{style_before}").contains("\x1B]8;;"),
+        "no hyperlink before opening"
+    );
+
+    // "linked" at offset 6: hyperlink open (has a URI)
+    let style_linked = overlay_style_at(6, &overlay);
+    let linked_fmt = format!("{style_linked}");
+    assert!(
+        linked_fmt.contains("\x1B]8;;"),
+        "hyperlink present for linked text"
+    );
+    assert!(
+        linked_fmt.contains("https://example.com"),
+        "hyperlink URI in linked text"
+    );
+
+    // "after" at offset 12: hyperlink closed
+    // NOTE: The current AnsiStyle implementation stores close sequences as
+    // "\x1B]8;;\x1B\\" in the hyperlink field instead of clearing it.
+    // This is a pre-existing limitation — the close sequence is present
+    // but it's a no-op close rather than an open with a URI.
+    let style_after = overlay_style_at(12, &overlay);
+    let after_fmt = format!("{style_after}");
+    assert!(
+        !after_fmt.contains("https://example.com"),
+        "hyperlink URI should be gone after close"
+    );
+    // The close hyperlink still produces output (a close escape sequence).
+    // In an ideal fix, to_reset_sequence() would be empty for closed links.
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_man_page_heading() {
+    let input = "\x1B[1mNAME\x1B[22m     uname - print system information";
+    let (stripped, overlay) = strip_ansi_with_overlay(input);
+    assert_eq!(stripped, "NAME     uname - print system information");
+
+    let style_name = overlay_style_at(0, &overlay);
+    assert!(
+        format!("{style_name}").contains("\x1B[1m"),
+        "bold active for heading"
+    );
+
+    let style_body = overlay_style_at(4, &overlay);
+    assert!(
+        !format!("{style_body}").contains("\x1B[1m"),
+        "bold off for body text"
+    );
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_mixed_ansi_and_text() {
+    let input = "plain\x1B[1mbold\x1B[22m\x1B[4muline\x1B[24mend";
+    let (stripped, overlay) = strip_ansi_with_overlay(input);
+    assert_eq!(stripped, "plainboldulineend");
+
+    let s0 = format!("{}", overlay_style_at(0, &overlay));
+    assert!(!s0.contains("\x1B[1m") && !s0.contains("\x1B[4m"));
+
+    let s5 = format!("{}", overlay_style_at(5, &overlay));
+    assert!(s5.contains("\x1B[1m") && !s5.contains("\x1B[4m"));
+
+    let s9 = format!("{}", overlay_style_at(9, &overlay));
+    assert!(!s9.contains("\x1B[1m") && s9.contains("\x1B[4m"));
+
+    let s14 = format!("{}", overlay_style_at(14, &overlay));
+    assert!(!s14.contains("\x1B[1m") && !s14.contains("\x1B[4m"));
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_bold_reset_vs_specific() {
+    // \x1B[22m resets BOTH bold and dim; \x1B[1m should not restore dim
+    let input = "\x1B[1;2mbold+dim\x1B[22m\x1B[1monly-bold";
+    let (stripped, overlay) = strip_ansi_with_overlay(input);
+    assert_eq!(stripped, "bold+dimonly-bold");
+
+    let s0 = format!("{}", overlay_style_at(0, &overlay));
+    assert!(s0.contains("\x1B[1m"), "bold should be active");
+    assert!(s0.contains("\x1B[2m"), "dim should be active");
+
+    let s9 = format!("{}", overlay_style_at(9, &overlay));
+    assert!(s9.contains("\x1B[1m"), "bold active after re-enable");
+    assert!(!s9.contains("\x1B[2m"), "dim off after 22m reset");
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_adjacent_style_changes() {
+    // Style changes with no text between them should produce a single overlay
+    // entry for the final style state
+    let input = "\x1B[1m\x1B[33mcolored\x1B[0m";
+    let (stripped, overlay) = strip_ansi_with_overlay(input);
+    assert_eq!(stripped, "colored");
+
+    let style = overlay_style_at(0, &overlay);
+    let fmt = format!("{style}");
+    assert!(fmt.contains("\x1B[1m"), "bold active");
+    assert!(fmt.contains("\x1B[33m"), "foreground active");
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_empty_input() {
+    let (stripped, overlay) = strip_ansi_with_overlay("");
+    assert_eq!(stripped, "");
+    assert!(overlay.is_empty());
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_only_escapes() {
+    let (stripped, overlay) = strip_ansi_with_overlay("\x1B[1m\x1B[33m\x1B[0m");
+    assert_eq!(stripped, "");
+    assert!(overlay.is_empty(), "no text means no overlay entries");
+}
+
+#[test]
+fn test_strip_ansi_with_overlay_bold_with_osc8_combined() {
+    // Bold heading containing a cross-reference hyperlink
+    let input = "\x1B[1mSEE ALSO\x1B[22m  \x1B]8;;man:sshd(8)\x1B\\sshd(8)\x1B]8;;\x1B\\";
+    let (stripped, overlay) = strip_ansi_with_overlay(input);
+    assert_eq!(stripped, "SEE ALSO  sshd(8)");
+
+    let style_heading = overlay_style_at(0, &overlay);
+    let heading_fmt = format!("{style_heading}");
+    assert!(heading_fmt.contains("\x1B[1m"), "bold active for heading");
+    assert!(!heading_fmt.contains("\x1B]8;;"), "no hyperlink in heading");
+
+    let style_link = overlay_style_at(10, &overlay);
+    let link_fmt = format!("{style_link}");
+    assert!(!link_fmt.contains("\x1B[1m"), "no bold in link text");
+    assert!(
+        link_fmt.contains("\x1B]8;;"),
+        "hyperlink active for link text"
+    );
+    assert!(link_fmt.contains("man:sshd(8)"), "hyperlink URI present");
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -30,7 +30,8 @@ use crate::input::OpenedInput;
 use crate::line_range::{MaxBufferedLineNumber, RangeCheckResult};
 use crate::output::OutputHandle;
 use crate::preprocessor::{
-    expand_tabs, replace_nonprintable, sanitize_for_terminal, strip_ansi, strip_overstrike,
+    expand_tabs, replace_nonprintable, sanitize_for_terminal, strip_ansi_with_overlay,
+    strip_overstrike,
 };
 use crate::style::StyleComponent;
 use crate::terminal::{as_terminal_escaped, to_ansi_color};
@@ -203,6 +204,11 @@ pub(crate) struct InteractivePrinter<'a> {
     decorations: Vec<Box<dyn Decoration>>,
     panel_width: usize,
     ansi_style: AnsiStyle,
+    /// When strip_ansi is active, this stores a mapping from byte offsets
+    /// in the stripped text to the AnsiStyle active at each offset in the
+    /// original text. This allows ANSI formatting (bold, underline, etc.)
+    /// from the original input to be re-applied on top of syntect styling.
+    ansi_style_overlay: Vec<(usize, AnsiStyle)>,
     content_type: Option<ContentType>,
     #[cfg(feature = "git")]
     pub line_changes: &'a Option<LineChanges>,
@@ -210,6 +216,10 @@ pub(crate) struct InteractivePrinter<'a> {
     background_color_highlight: Option<Color>,
     consecutive_empty_lines: usize,
     strip_ansi: bool,
+    /// Whether to re-apply ANSI formatting from the overlay when strip_ansi
+    /// is active. Only true for StripAnsiMode::Auto; StripAnsiMode::Always
+    /// means the user wants all ANSI removed.
+    reapply_ansi_overlay: bool,
     strip_overstrike: bool,
 }
 
@@ -326,12 +336,16 @@ impl<'a> InteractivePrinter<'a> {
             decorations,
             content_type: input.reader.content_type,
             ansi_style: AnsiStyle::new(),
+            ansi_style_overlay: Vec::new(),
             #[cfg(feature = "git")]
             line_changes,
             highlighter_from_set,
             background_color_highlight,
             consecutive_empty_lines: 0,
             strip_ansi,
+            reapply_ansi_overlay: strip_ansi
+                && config.strip_ansi == StripAnsiMode::Auto
+                && config.colored_output,
             strip_overstrike,
         })
     }
@@ -427,6 +441,24 @@ impl<'a> InteractivePrinter<'a> {
             content_graphemes = remaining.to_vec();
         }
         self.print_header_component_with_indent(handle, content_graphemes.join("").as_str())
+    }
+
+    /// Look up the AnsiStyle from the overlay at the given byte offset.
+    /// The overlay maps byte positions in the stripped text to styles.
+    /// Uses binary search to find the last entry whose offset <= `pos`.
+    fn overlay_style_at(&self, pos: usize) -> AnsiStyle {
+        if self.ansi_style_overlay.is_empty() {
+            return AnsiStyle::new();
+        }
+        // Binary search for the rightmost entry with offset <= pos.
+        let idx = match self
+            .ansi_style_overlay
+            .binary_search_by_key(&pos, |(offset, _)| *offset)
+        {
+            Ok(idx) => idx,
+            Err(idx) => idx.saturating_sub(1),
+        };
+        self.ansi_style_overlay[idx].1.clone()
     }
 
     fn highlight_regions_for_line<'b>(
@@ -663,9 +695,16 @@ impl Printer for InteractivePrinter<'_> {
                 }
             }
 
-            // If ANSI escape sequences are supposed to be stripped, do it before syntax highlighting.
+            // If ANSI escape sequences are supposed to be stripped, do it before
+            // syntax highlighting. Also compute an overlay that maps byte
+            // positions in the stripped text to the AnsiStyle active at each
+            // position in the original text, so formatting can be re-applied.
             if self.strip_ansi {
-                line = strip_ansi(&line).into()
+                let (stripped, overlay) = strip_ansi_with_overlay(&line);
+                self.ansi_style_overlay = overlay;
+                line = stripped.into();
+            } else {
+                self.ansi_style_overlay.clear();
             }
 
             line
@@ -729,6 +768,25 @@ impl Printer for InteractivePrinter<'_> {
             let italics = self.config.use_italic_text;
 
             for &(style, region) in &regions {
+                // Determine the ANSI style to apply for this region:
+                // - When overlay re-application is active (StripAnsiMode::Auto with colors),
+                //   look up the style from the overlay at this region's position.
+                // - When strip_ansi is active but no overlay (StripAnsiMode::Always),
+                //   use an empty style (ANSI was explicitly stripped).
+                // - When strip_ansi is not active, use self.ansi_style directly
+                //   (not a clone) so that escape sequences within a region update
+                //   the live state for subsequent text chunks.
+                let get_region_style = |slf: &InteractivePrinter| -> AnsiStyle {
+                    if slf.reapply_ansi_overlay {
+                        let region_offset = region.as_ptr() as usize - line.as_ptr() as usize;
+                        slf.overlay_style_at(region_offset)
+                    } else if slf.strip_ansi {
+                        AnsiStyle::default()
+                    } else {
+                        slf.ansi_style.clone()
+                    }
+                };
+
                 let ansi_iterator = EscapeSequenceIterator::new(region);
                 for chunk in ansi_iterator {
                     match chunk {
@@ -737,18 +795,29 @@ impl Printer for InteractivePrinter<'_> {
                             let text = self.preprocess(text, &mut cursor_total);
                             let text_trimmed = text.trim_end_matches(['\r', '\n']);
 
+                            // Re-evaluate the region style based on self.ansi_style's
+                            // current state, so escape sequences within this region
+                            // are reflected in subsequent text chunks.
+                            let region_style = if self.reapply_ansi_overlay || self.strip_ansi {
+                                // Overlay/stripped mode: use the pre-computed style.
+                                get_region_style(self)
+                            } else {
+                                // Passthrough mode: use the live mutable state.
+                                self.ansi_style.clone()
+                            };
+
                             write!(
                                 handle,
                                 "{}{}",
                                 as_terminal_escaped(
                                     style,
-                                    &format!("{}{text_trimmed}", self.ansi_style),
+                                    &format!("{}{text_trimmed}", region_style),
                                     true_color,
                                     colored_output,
                                     italics,
                                     background_color
                                 ),
-                                self.ansi_style.to_reset_sequence(),
+                                region_style.to_reset_sequence(),
                             )?;
 
                             // Pad the rest of the line.
@@ -784,6 +853,25 @@ impl Printer for InteractivePrinter<'_> {
             }
         } else {
             for &(style, region) in &regions {
+                // Determine the ANSI style to apply for this region:
+                // - When overlay re-application is active (StripAnsiMode::Auto with colors),
+                //   look up the style from the overlay at this region's position.
+                // - When strip_ansi is active but no overlay (StripAnsiMode::Always),
+                //   use an empty style (ANSI was explicitly stripped).
+                // - When strip_ansi is not active, use self.ansi_style directly
+                //   (not a clone) so that escape sequences within a region update
+                //   the live state for subsequent text chunks.
+                let get_region_style = |slf: &InteractivePrinter| -> AnsiStyle {
+                    if slf.reapply_ansi_overlay {
+                        let region_offset = region.as_ptr() as usize - line.as_ptr() as usize;
+                        slf.overlay_style_at(region_offset)
+                    } else if slf.strip_ansi {
+                        AnsiStyle::default()
+                    } else {
+                        slf.ansi_style.clone()
+                    }
+                };
+
                 let ansi_iterator = EscapeSequenceIterator::new(region);
                 for chunk in ansi_iterator {
                     match chunk {
@@ -791,6 +879,17 @@ impl Printer for InteractivePrinter<'_> {
                         EscapeSequence::Text(text) => {
                             let text = self
                                 .preprocess(text.trim_end_matches(['\r', '\n']), &mut cursor_total);
+
+                            // Re-evaluate the region style based on self.ansi_style's
+                            // current state, so escape sequences within this region
+                            // are reflected in subsequent text chunks.
+                            let region_style = if self.reapply_ansi_overlay || self.strip_ansi {
+                                // Overlay/stripped mode: use the pre-computed style.
+                                get_region_style(self)
+                            } else {
+                                // Passthrough mode: use the live mutable state.
+                                self.ansi_style.clone()
+                            };
 
                             let mut max_width = cursor_max - cursor;
 
@@ -862,17 +961,13 @@ impl Printer for InteractivePrinter<'_> {
                                         "{}{}\n{}",
                                         as_terminal_escaped(
                                             style,
-                                            &format!(
-                                                "{}{}",
-                                                self.ansi_style,
-                                                &line_buf[..emit_end]
-                                            ),
+                                            &format!("{}{}", region_style, &line_buf[..emit_end]),
                                             self.config.true_color,
                                             self.config.colored_output,
                                             self.config.use_italic_text,
                                             background_color
                                         ),
-                                        self.ansi_style.to_reset_sequence(),
+                                        region_style.to_reset_sequence(),
                                         panel_wrap.clone().unwrap()
                                     )?;
 
@@ -904,7 +999,7 @@ impl Printer for InteractivePrinter<'_> {
                                 "{}",
                                 as_terminal_escaped(
                                     style,
-                                    &format!("{}{line_buf}", self.ansi_style),
+                                    &format!("{}{line_buf}", region_style),
                                     self.config.true_color,
                                     self.config.colored_output,
                                     self.config.use_italic_text,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -461,6 +461,26 @@ impl<'a> InteractivePrinter<'a> {
         self.ansi_style_overlay[idx].1.clone()
     }
 
+    /// Determine the ANSI style to apply for a syntect-highlighted region.
+    ///
+    /// - In overlay mode (`--strip-ansi=auto` with colors): looks up the
+    ///   pre-computed overlay style at the region's byte offset.
+    /// - In stripped mode (`--strip-ansi=always`): returns an empty style
+    ///   (ANSI was explicitly stripped).
+    /// - In passthrough mode (no stripping): returns the live `ansi_style`
+    ///   state so that escape sequences within a region update subsequent
+    ///   text chunks.
+    fn region_ansi_style(&self, region: &str, line: &str) -> AnsiStyle {
+        if self.reapply_ansi_overlay {
+            let region_offset = region.as_ptr() as usize - line.as_ptr() as usize;
+            self.overlay_style_at(region_offset)
+        } else if self.strip_ansi {
+            AnsiStyle::default()
+        } else {
+            self.ansi_style.clone()
+        }
+    }
+
     fn highlight_regions_for_line<'b>(
         &mut self,
         line: &'b str,
@@ -768,25 +788,6 @@ impl Printer for InteractivePrinter<'_> {
             let italics = self.config.use_italic_text;
 
             for &(style, region) in &regions {
-                // Determine the ANSI style to apply for this region:
-                // - When overlay re-application is active (StripAnsiMode::Auto with colors),
-                //   look up the style from the overlay at this region's position.
-                // - When strip_ansi is active but no overlay (StripAnsiMode::Always),
-                //   use an empty style (ANSI was explicitly stripped).
-                // - When strip_ansi is not active, use self.ansi_style directly
-                //   (not a clone) so that escape sequences within a region update
-                //   the live state for subsequent text chunks.
-                let get_region_style = |slf: &InteractivePrinter| -> AnsiStyle {
-                    if slf.reapply_ansi_overlay {
-                        let region_offset = region.as_ptr() as usize - line.as_ptr() as usize;
-                        slf.overlay_style_at(region_offset)
-                    } else if slf.strip_ansi {
-                        AnsiStyle::default()
-                    } else {
-                        slf.ansi_style.clone()
-                    }
-                };
-
                 let ansi_iterator = EscapeSequenceIterator::new(region);
                 for chunk in ansi_iterator {
                     match chunk {
@@ -795,16 +796,11 @@ impl Printer for InteractivePrinter<'_> {
                             let text = self.preprocess(text, &mut cursor_total);
                             let text_trimmed = text.trim_end_matches(['\r', '\n']);
 
-                            // Re-evaluate the region style based on self.ansi_style's
-                            // current state, so escape sequences within this region
-                            // are reflected in subsequent text chunks.
-                            let region_style = if self.reapply_ansi_overlay || self.strip_ansi {
-                                // Overlay/stripped mode: use the pre-computed style.
-                                get_region_style(self)
-                            } else {
-                                // Passthrough mode: use the live mutable state.
-                                self.ansi_style.clone()
-                            };
+                            // Determine the ANSI style for this region.
+                            // In passthrough mode, use live mutable state so escape
+                            // sequences within the region are reflected in subsequent
+                            // text chunks; otherwise use the pre-computed style.
+                            let region_style = self.region_ansi_style(region, &*line);
 
                             write!(
                                 handle,
@@ -853,25 +849,6 @@ impl Printer for InteractivePrinter<'_> {
             }
         } else {
             for &(style, region) in &regions {
-                // Determine the ANSI style to apply for this region:
-                // - When overlay re-application is active (StripAnsiMode::Auto with colors),
-                //   look up the style from the overlay at this region's position.
-                // - When strip_ansi is active but no overlay (StripAnsiMode::Always),
-                //   use an empty style (ANSI was explicitly stripped).
-                // - When strip_ansi is not active, use self.ansi_style directly
-                //   (not a clone) so that escape sequences within a region update
-                //   the live state for subsequent text chunks.
-                let get_region_style = |slf: &InteractivePrinter| -> AnsiStyle {
-                    if slf.reapply_ansi_overlay {
-                        let region_offset = region.as_ptr() as usize - line.as_ptr() as usize;
-                        slf.overlay_style_at(region_offset)
-                    } else if slf.strip_ansi {
-                        AnsiStyle::default()
-                    } else {
-                        slf.ansi_style.clone()
-                    }
-                };
-
                 let ansi_iterator = EscapeSequenceIterator::new(region);
                 for chunk in ansi_iterator {
                     match chunk {
@@ -880,16 +857,11 @@ impl Printer for InteractivePrinter<'_> {
                             let text = self
                                 .preprocess(text.trim_end_matches(['\r', '\n']), &mut cursor_total);
 
-                            // Re-evaluate the region style based on self.ansi_style's
-                            // current state, so escape sequences within this region
-                            // are reflected in subsequent text chunks.
-                            let region_style = if self.reapply_ansi_overlay || self.strip_ansi {
-                                // Overlay/stripped mode: use the pre-computed style.
-                                get_region_style(self)
-                            } else {
-                                // Passthrough mode: use the live mutable state.
-                                self.ansi_style.clone()
-                            };
+                            // Determine the ANSI style for this region.
+                            // In passthrough mode, use live mutable state so escape
+                            // sequences within the region are reflected in subsequent
+                            // text chunks; otherwise use the pre-computed style.
+                            let region_style = self.region_ansi_style(region, &*line);
 
                             let mut max_width = cursor_max - cursor;
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -800,7 +800,7 @@ impl Printer for InteractivePrinter<'_> {
                             // In passthrough mode, use live mutable state so escape
                             // sequences within the region are reflected in subsequent
                             // text chunks; otherwise use the pre-computed style.
-                            let region_style = self.region_ansi_style(region, &*line);
+                            let region_style = self.region_ansi_style(region, &line);
 
                             write!(
                                 handle,
@@ -861,7 +861,7 @@ impl Printer for InteractivePrinter<'_> {
                             // In passthrough mode, use live mutable state so escape
                             // sequences within the region are reflected in subsequent
                             // text chunks; otherwise use the pre-computed style.
-                            let region_style = self.region_ansi_style(region, &*line);
+                            let region_style = self.region_ansi_style(region, &line);
 
                             let mut max_width = cursor_max - cursor;
 

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 // Wrapper to avoid unnecessary branching when input doesn't have ANSI escape sequences.
+#[derive(Clone, Default)]
 pub struct AnsiStyle {
     attributes: Option<Attributes>,
 }
@@ -41,6 +42,7 @@ impl Display for AnsiStyle {
     }
 }
 
+#[derive(Clone)]
 struct Attributes {
     has_sgr_sequences: bool,
 

--- a/src/vscreen.rs
+++ b/src/vscreen.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 // Wrapper to avoid unnecessary branching when input doesn't have ANSI escape sequences.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq)]
 pub struct AnsiStyle {
     attributes: Option<Attributes>,
 }
@@ -42,7 +42,7 @@ impl Display for AnsiStyle {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 struct Attributes {
     has_sgr_sequences: bool,
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2811,6 +2811,21 @@ fn strip_overstrike_for_manpage_syntax() {
 }
 
 #[test]
+fn strip_overstrike_for_manpage_syntax_keeps_ansi_escapes_intact() {
+    // Some man page renderers can emit SGR resets between the first overstruck
+    // character and the backspace. The reset should be preserved, not truncated.
+    bat()
+        .arg("--force-colorization")
+        .arg("--language=man")
+        .write_stdin("NAME\n       v\x1b[22m\x08v normal\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[22v").not())
+        .stdout(predicate::str::contains("\x1b[22m"))
+        .stderr("");
+}
+
+#[test]
 fn no_strip_overstrike_for_other_syntax() {
     // Overstrike is NOT stripped for other syntaxes (e.g., Rust)
     bat()


### PR DESCRIPTION
## Problem

When using `bat` as `MANPAGER`, ANSI SGR reset codes like `\x1B[22m` (reset bold) appear as literal text "22m" in the output. This happens because the Manpage sublime-syntax definition does not consume ANSI escapes broadly enough, so syntect splits escape sequences across highlight regions.

Even with a syntax fix, `^`-anchored heading patterns like `^(NAME|SYNOPSIS|...)` cannot match after an ANSI escape is consumed at position 0, meaning **syntax highlighting of headings is fundamentally incompatible with ANSI passthrough**.

Fixes #3724.

## Solution: ANSI Overlay

This PR introduces a "strip-and-reapply" overlay mechanism for `--strip-ansi=auto`:

1. **Strip** ANSI escape sequences from the input before syntect tokenization
2. **Build** a byte-offset → `AnsiStyle` overlay that captures all formatting state (bold, underline, colors, OSC8 hyperlinks)
3. **Re-apply** the overlay style during rendering, so both syntect highlighting AND man formatting are preserved

### Example

```
MANPAGER="bat -pl man --strip-ansi=auto" man uname
```

This produces output with:
- ✅ Correct heading colors from syntect (color 182 for `NAME`, `SYNOPSIS`, etc.)
- ✅ Bold/underline from man formatting preserved
- ✅ No garbled `\x1B[22m` visible text
- ✅ OSC8 hyperlinks preserved

### Mode behavior

| `--strip-ansi` | ANSI stripped? | Overlay re-applied? | Result |
|---|---|---|---|
| `never` (default) | No | N/A | ANSI passes through as-is (unchanged behavior) |
| `auto` | Yes | **Yes** | Clean text for syntect + man formatting preserved |
| `always` | Yes | No | All ANSI removed, syntect-only colors |

## Commits

1. **fix: preserve ANSI escapes while stripping overstrike** — Cherry-picked from #3762 (independently needed)
2. **feat: add Clone/Default derives to AnsiStyle and Attributes** — Prerequisite for overlay snapshots
3. **feat: add `strip_ansi_with_overlay()` to preprocessor** — Core overlay function with 20 unit tests
4. **feat: re-apply ANSI overlay when stripping for syntax highlighting** — Wires overlay into the printer with three-way `region_style` logic
5. **docs: update `--strip-ansi` help text for auto mode and MANPAGER usage** — Documents the new behavior
6. **feat: update Manpage.sublime-syntax to consume ANSI/OSC escapes in prototype** — Prevents remaining garbled text from partial escape sequences

## Performance

Negligible overhead. Benchmarked with 5 man pages (70K–2501K):

| Page | Size | `never` | `auto` | auto/never |
|------|------|---------|--------|------------|
| home-configuration.nix | 2501K | 0.817s | 0.790s | **0.97x** |
| bash | 473K | 0.109s | 0.109s | **1.00x** |
| ffmpeg | 177K | 0.043s | 0.052s | **1.20x** |
| sshd_config | 84K | 0.024s | 0.027s | **1.14x** |
| git | 70K | 0.024s | 0.027s | **1.14x** |

The largest page shows no measurable overhead. For medium pages, overhead is 14–20% (< 10ms absolute).

## Test coverage

- 20 new unit tests for `strip_ansi_with_overlay()` covering: bold, underline, dim, italic, foreground/background color, 256-color, truecolor, SGR reset, OSC8 hyperlinks (open, close, combined with bold), adjacent style changes, empty input, escapes-only input
- All 233 integration tests pass
- All 145 unit tests pass
- Pre-existing `no_duplicate_extensions` failure (unrelated, from syntax set)

## Note on PR #3762

This PR includes commit `9e0c2a9d` from #3762 (the `pop_visible_char` fix for overstrike stripping). That PR is independently valuable and should be merged regardless of this PR. If #3762 is merged first, this PR will need a rebase to drop the cherry-picked commit.