### PR TITLE
docs: clarify batcat fallback for Debian and Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- Clarify Debian and Ubuntu `batcat` fallback wording in README, see #3794 (@ded-furby)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ sudo apt install bat
 ```
 
 **Important**: On some older Ubuntu/Debian releases, the executable is installed as `batcat` instead of `bat` (due to [a name
-clash with another package](https://github.com/sharkdp/bat/issues/982)). On newer releases, the executable is available as `bat`. If `bat --version` does not work after installation, try `batcat --version` instead. You can set up a `bat -> batcat` symlink or alias to prevent any issues that may come up because of this and to be consistent with other distributions:
+clash with another package](https://github.com/sharkdp/bat/issues/982)). Debian 12 and Ubuntu 23.04 and newer install the binary as `bat`; on older releases it may still be `batcat`. If `bat --version` does not work after installation, try `batcat --version` instead. You can set up a `bat -> batcat` symlink or alias to prevent any issues that may come up because of this and to be consistent with other distributions:
 ``` bash
 mkdir -p ~/.local/bin
 ln -s /usr/bin/batcat ~/.local/bin/bat


### PR DESCRIPTION
## Summary
- Update the Ubuntu/Debian installation section in  to clarify the Debian 12 and Ubuntu 23.04+ behavior.
- Keep existing  guidance for older releases while stating that newer releases now install as .

## Issue
Closes #2455

## Validation
- 
- Open-source repo validation command is not currently available in this environment for full bat test/lint suites.