### PR TITLE
docs: note git submodule requirement for help language syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## Other
-- Add note about git submodule requirement for `help` language syntax to README, see #3800 (@xfocus3)
+- Add note about git submodule requirement for `help` language syntax to README, see #3801 (@xfocus3)
 
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## Other
+- Add note about git submodule requirement for `help` language syntax to README, see #3800 (@xfocus3)
 
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ The [`prettybat`](https://github.com/eth-p/bat-extras/blob/master/doc/prettybat.
 
 You can use `bat` to colorize help text: `$ cp --help | bat -plhelp`
 
+> **Note:** The `help` language syntax is provided as a git submodule. If you build `bat` from source, initialize submodules with `git submodule update --init --recursive` to include it. Pre-built binaries from the [releases page](https://github.com/sharkdp/bat/releases) include it by default.
+
 You can also use a wrapper around this:
 
 ```bash


### PR DESCRIPTION
The README documents using `bat -plhelp` for syntax highlighting of `--help` messages, but the 'help' language is provided as a git submodule (cmd-help-sublime-syntax). Users building from source need to initialize submodules to get this syntax. Pre-built release binaries include it by default.

Fixes #3800