### PR TITLE
Fix capacity-overflow panic in snip separator at --terminal-width 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -603,11 +603,23 @@ impl Printer for InteractivePrinter<'_> {
         let title = "8<";
         let title_count = title.chars().count();
 
-        let snip_left = "─ ".repeat((self.config.term_width - panel_count - (title_count / 2)) / 4);
+        let snip_left = "─ ".repeat(
+            self.config
+                .term_width
+                .saturating_sub(panel_count)
+                .saturating_sub(title_count / 2)
+                / 4,
+        );
         let snip_left_count = snip_left.chars().count(); // Can't use .len() with Unicode.
 
-        let snip_right =
-            " ─".repeat((self.config.term_width - panel_count - snip_left_count - title_count) / 2);
+        let snip_right = " ─".repeat(
+            self.config
+                .term_width
+                .saturating_sub(panel_count)
+                .saturating_sub(snip_left_count)
+                .saturating_sub(title_count)
+                / 2,
+        );
 
         writeln!(
             handle,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -306,6 +306,19 @@ fn line_range_multiple() {
 }
 
 #[test]
+fn snip_at_terminal_width_one_does_not_panic() {
+    bat()
+        .arg("multiline.txt")
+        .arg("--style=snip")
+        .arg("--color=always")
+        .arg("--terminal-width=1")
+        .arg("--line-range=1:2")
+        .arg("--line-range=4:4")
+        .assert()
+        .success();
+}
+
+#[test]
 fn line_range_multiple_with_context() {
     bat()
         .arg("multiline.txt")


### PR DESCRIPTION
Fixes #3803.

`InteractivePrinter::print_snip` computes the snip-separator width as `term_width - panel_count - snip_left_count - title_count`. At `--terminal-width 1` the panel is disabled (`panel_count == 0`, `snip_left_count == 0`) and the `"8<"` title gives `title_count == 2`, so the subtraction underflows `usize` (release has no overflow-checks, so it wraps to ~`usize::MAX`); `str::repeat` then aborts with `capacity overflow` whenever a snip separator is emitted — i.e. two or more disjoint line ranges (or a diff gap), which the default style does:

```console
$ printf 'l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\n' > t.txt
$ bat --color=always --terminal-width 1 --line-range 1:2 --line-range 7:8 t.txt
thread 'main' panicked at library/alloc/src/slice.rs:523:50:
capacity overflow
```

This uses `saturating_sub` for the `repeat` counts so they clamp to `0` instead of underflowing. Normal-width snip rendering is unchanged (the separator dashes are simply omitted at width 1).

Added an integration test (`snip_at_terminal_width_one_does_not_panic`) and a CHANGELOG entry.
