### PR TITLE
fix(cli): exit with 0 when invoking bat cache --help

### DIFF
--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -219,7 +219,13 @@ impl App {
         if wild::args_os().nth(1) == Some("cache".into()) {
             // Skip the config file and env vars
             let args = wild::args_os().collect::<Vec<_>>();
-            return Ok(clap_app::build_app(interactive_output).get_matches_from(args));
+
+            match clap_app::build_app(interactive_output).try_get_matches_from(args) {
+                Ok(matches) => return Ok(matches),
+                Err(err) => {
+                    err.exit();
+                }
+            }
         }
 
         if wild::args_os().any(|arg| arg == "--no-config") || should_skip_config {


### PR DESCRIPTION
Hey, made some changes to address the issue, a review would be helpful.


### What was causing the bug??

In `src/bin/bat/app.rs`, the application manually intercepts arguments when the first parameter matches "cache" in order to bypass specific configuration files or environment variables. It was using `.get_matches_from(args)`, which passes handling back to a layer that defaults to an error exit state when subcommands miss expected mandatory execution parameters—even if the user explicitly called for the help panel.

### Changes made
Switched from `.get_matches_from(args)` to `.try_get_matches_from(args)`. If a parsing error occurs, we handle it explicitly via `err.exit()`. 


###  Results
Tested locally using the compiled debug binary:
```bash
$ ./target/debug/bat cache --help
# [Help text displays normally]
$ echo $?
0

Closes #3798