### PR TITLE
Include `.code-workspace` as a JSON extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Include subdirectories in SSH Config syntax mapping, see #3758 (@injust)
 - Add Ghostty syntax mapping, see #3759 (@injust)
 - Add syntax highlighting for `Caddyfile` #3789 (@CosmicHorrorDev)
+- Include `.code-workspace` as a JSON extension #3809 (@dhruvkb)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/common/50-json.toml
+++ b/src/syntax_mapping/builtins/common/50-json.toml
@@ -1,3 +1,3 @@
 # JSON Lines is a simple variation of JSON #2535
 [mappings]
-"JSON" = ["*.jsonl", "*.jsonc", "*.jsonld", "*.geojson", "*.ndjson"]
+"JSON" = ["*.jsonl", "*.jsonc", "*.jsonld", "*.geojson", "*.ndjson", "*.code-workspace"]


### PR DESCRIPTION
This PR includes `.code-workspace` which is [used by VS Code](https://code.visualstudio.com/docs/editing/workspaces/workspaces#_multi-root-workspaces) as a JSON extension.

|Before|After|
|-|-|
|<img width="1392" height="930" alt="Screenshot 2026-06-23 at 8 03 03 AM" src="https://github.com/user-attachments/assets/53e44f24-d62d-44da-a075-6b5c7666e162" />|<img width="1392" height="930" alt="Screenshot 2026-06-23 at 8 03 19 AM" src="https://github.com/user-attachments/assets/c1cfa149-46b7-4576-84c9-cd9a6d80b5e0" />|

## Workaround

I have been working around this for some time with this configuration entry:

```txt
--map-syntax='*.code-workspace:JSON'
```
