### PR TITLE
fix: avoid usize underflow in --list-languages at narrow terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Fixed syntax tests path, see #3610 (@foxfromworld)
 - Fix zsh tab completion word-splitting language names containing spaces (e.g. `HTML (Jinja2)`, `Apache Conf`), see #3693 (@YoshKoz)
 - Fix zsh tab completion offering invalid `-l` arguments (file globs, paths, hidden filenames) sourced from the second column of `--list-languages`. Closes #3735, see #3737 (@truffle-dev)
+- Fix `usize` underflow in `--list-languages` when `--terminal-width` is smaller than the longest language name, see #3812 (@greymoth-jp)
 
 ## Other
 - Use git version of cross. See #3533 (@OctopusET)

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -152,7 +152,14 @@ pub fn get_languages(config: &Config, cache_dir: &Path) -> Result<String> {
         let comma_separator = ", ";
         let separator = " ";
         // Line-wrapping for the possible file extension overflow.
-        let desired_width = config.term_width - longest - separator.len();
+        // Clamp instead of subtracting: a tiny `--terminal-width` (smaller than the
+        // longest language name) would otherwise underflow `usize` and wrap to a huge
+        // value, silently disabling wrapping (and panicking in debug/overflow-checked
+        // builds). Mirrors the `saturating_sub` fix applied to `print_snip` in #3804.
+        let desired_width = config
+            .term_width
+            .saturating_sub(longest)
+            .saturating_sub(separator.len());
 
         let style = if config.colored_output {
             Green.normal()


### PR DESCRIPTION
Mirrors #3804 to its remaining sibling site.

#3804 hardened `print_snip` with `saturating_sub` after #3803 reported a `capacity overflow` panic at `--terminal-width 1` (the `term_width - panel_count - title_count` subtraction underflowing `usize`). That fix covered the snip renderer. The `--list-languages` renderer has the identical `term_width - X - Y` shape and was left unhardened:

`src/bin/bat/main.rs:155`
```rust
let desired_width = config.term_width - longest - separator.len();
```

Unlike the `term_width -` sites in `printer.rs` (356/418/731/810), this one sits outside the panel-disable guard at `printer.rs:261`, so nothing clamps it. `bat --list-languages --terminal-width 1` underflows.

Honest scope: in debug / overflow-checked builds this panics (exit 101). In release the subtraction wraps, and since `desired_width` only feeds a `>=` comparison it silently yields wrong column layout rather than crashing. Same class as #3804, narrowed to the language list, latent since the code was introduced.

Verified both directions on a standalone replica of the arithmetic: the old form panics (debug) / wraps to wrong output (release), the patched form is clean, and the two are byte-identical at a normal width (100), so there is zero behavior change away from the edge case. `saturating_sub` is the minimal change and matches the precedent set by #3804.