### PR TITLE
Add syntax mapping for DNF config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Include subdirectories in SSH Config syntax mapping, see #3758 (@injust)
 - Add Ghostty syntax mapping, see #3759 (@injust)
 - Add syntax highlighting for `Caddyfile` #3789 (@CosmicHorrorDev)
+- Add syntax mapping for DNF repo configuration files, see #3814 (@injust)
 
 ## Themes
 

--- a/src/syntax_mapping/builtins/linux/50-dnf.toml
+++ b/src/syntax_mapping/builtins/linux/50-dnf.toml
@@ -1,0 +1,2 @@
+[mappings]
+"INI" = ["/etc/dnf/dnf.conf", "/etc/yum.repos.d/*.repo"]


### PR DESCRIPTION
DNF config files are documented as being INI at https://dnf.readthedocs.io/en/latest/conf_ref.html#description.