### PR TITLE
Fix --wrap=word leaking a leading space onto the continuation line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Fix `--wrap=word` leaking a leading space onto the continuation line when a word ends exactly at the terminal width, so the separating space triggered the wrap (@upuddu)
 - Fix `--list-languages` respecting `--paging=never`, see #3828 (@cyphercodes)
 - Fix `--sanitize` passing through the bidi control characters U+200E, U+200F and U+061C, see #3862 (@lenamonj)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Fix `--wrap=word` leaking a leading space onto the continuation line when a word ends exactly at the terminal width, so the separating space triggered the wrap (@upuddu)
+- Fix `--wrap=word` leaking a leading space onto the continuation line when a word ends exactly at the terminal width, so the separating space triggered the wrap, see #3832 (@upuddu)
 - Fix `--list-languages` respecting `--paging=never`, see #3828 (@cyphercodes)
 - Fix `--sanitize` passing through the bidi control characters U+200E, U+200F and U+061C, see #3862 (@lenamonj)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -919,6 +919,16 @@ impl Printer for InteractivePrinter<'_> {
                                         current_width = cw;
                                     }
                                     last_ws_idx = None;
+
+                                    // If the wrap was triggered by the separating
+                                    // whitespace itself (i.e. the previous word ended
+                                    // exactly at the terminal width), that whitespace is
+                                    // consumed by the line break and must not be rendered
+                                    // as a leading space on the continuation line.
+                                    if word_wrap && c.is_whitespace() {
+                                        current_width = 0;
+                                        continue;
+                                    }
                                 }
 
                                 line_buf.push(c);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4226,6 +4226,23 @@ fn word_wrap_short_line_no_wrap() {
         .stdout("Single Line\n");
 }
 
+#[test]
+fn word_wrap_boundary_space_not_leaked() {
+    // When a word ends exactly at the terminal width, the following space is
+    // what triggers the wrap. That separating space must be consumed by the
+    // line break and must not be rendered as a leading space on the next line.
+    bat()
+        .arg("--wrap=word")
+        .arg("--terminal-width=5")
+        .arg("--style=plain")
+        .arg("--decorations=always")
+        .arg("--color=never")
+        .write_stdin("abcde fg\n")
+        .assert()
+        .success()
+        .stdout("abcde\nfg\n");
+}
+
 #[cfg(unix)]
 #[cfg(feature = "git")]
 fn setup_diff_test_repo() -> tempfile::TempDir {


### PR DESCRIPTION
When a word ends exactly at the terminal width, the separating whitespace is the character that triggers the wrap, and it was being pushed onto the next visual line as a spurious leading space. This consumes that whitespace when it triggers the wrap.