### PR TITLE
fix: don't hard-wrap with --wrap=auto when --paging=always is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Fix `--wrap=auto` hard-wrapping lines even when `--paging=always` sends output through a pager, producing unreadable double-wrapped output. `auto` now defers to the pager in that case, matching explicit `--terminal-width` (which still takes precedence). Closes #1081, see #TODO (@soy-chrislo)
+- Fix `--wrap=auto` hard-wrapping lines even when `--paging=always` sends output through a pager, producing unreadable double-wrapped output. `auto` now defers to the pager in that case, matching explicit `--terminal-width` (which still takes precedence). Closes #1081, see #3834 (@soy-chrislo)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Fix `--wrap=auto` hard-wrapping lines even when `--paging=always` sends output through a pager, producing unreadable double-wrapped output. `auto` now defers to the pager in that case, matching explicit `--terminal-width` (which still takes precedence). Closes #1081, see #TODO (@soy-chrislo)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -421,7 +421,17 @@ impl App {
                         Some("word") => WrappingMode::Word,
                         Some("never") => WrappingMode::NoWrapping(true),
                         Some("auto") | None => {
-                            if self.interactive_output || maybe_term_width.is_some() {
+                            if maybe_term_width.is_none() && paging_mode == PagingMode::Always {
+                                // `--paging=always` unconditionally sends the output through a
+                                // pager (e.g. `less`), which already has its own line-wrapping
+                                // controls (`-S`/soft wrap). Hard-wrapping here as well produces
+                                // unreadable, doubly-wrapped output inside the pager. Only
+                                // `Always` is special-cased (not `QuitIfOneScreen`) because
+                                // whether `QuitIfOneScreen` actually invokes a pager depends on
+                                // the rendered content length, which isn't known yet at this
+                                // point. See #1081.
+                                WrappingMode::NoWrapping(false)
+                            } else if self.interactive_output || maybe_term_width.is_some() {
                                 if style_components.plain() && maybe_term_width.is_none() {
                                     WrappingMode::NoWrapping(false)
                                 } else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3177,6 +3177,13 @@ fn wrap_auto_does_not_hard_wrap_when_pager_is_always_active() {
     let OpenptyResult { master, slave } = openpty(None, None).expect("Couldn't open pty.");
     let mut master = File::from(master);
     let stdout_file = File::from(slave);
+    // macOS discards data still queued on the pty master once the last slave-side
+    // fd closes, which happens as soon as the child (and its pager) exit. Holding
+    // our own clone of the slave open across the wait+read keeps that queue alive;
+    // see https://developer.apple.com/forums/thread/663632.
+    let slave_keepalive = stdout_file
+        .try_clone()
+        .expect("Couldn't clone slave pty fd.");
 
     let mut child = bat_raw_command()
         .arg(&file_path)
@@ -3190,16 +3197,19 @@ fn wrap_auto_does_not_hard_wrap_when_pager_is_always_active() {
         .spawn()
         .expect("Failed to start.");
 
-    child
+    let exit_status = child
         .wait_timeout(CHILD_WAIT_TIMEOUT)
         .expect("Error polling exit status, this should never happen.")
         .expect("bat (and its pager) should have exited within the timeout.");
+    assert!(
+        exit_status.success(),
+        "bat (and its pager) should have exited successfully, got: {exit_status:?}"
+    );
 
     let mut buf = [0u8; 8192];
-    let mut output = String::new();
-    if let Ok(n) = io::Read::read(&mut master, &mut buf) {
-        output.push_str(&String::from_utf8_lossy(&buf[..n]));
-    }
+    let n = io::Read::read(&mut master, &mut buf).expect("Couldn't read from pty master.");
+    let output = String::from_utf8_lossy(&buf[..n]).into_owned();
+    drop(slave_keepalive);
 
     assert!(
         output.contains(&content),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3155,6 +3155,84 @@ fn s_flag_respected_with_paging_always() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn wrap_auto_does_not_hard_wrap_when_pager_is_always_active() {
+    // Reproduces #1081: with `--paging=always`, bat's output always goes
+    // through a pager (e.g. `less`), which already provides its own
+    // line-wrapping controls. `--wrap=auto` should defer to the pager instead
+    // of hard-wrapping the content itself; previously it wrapped anyway,
+    // producing unreadable, doubly-wrapped output inside the pager.
+    //
+    // A real pty is required: this only diverges from the non-interactive
+    // fallback (which already skips wrapping) when bat's own stdout is
+    // detected as a terminal, which is the common case this bug affected.
+    let content = "a".repeat(300);
+    let dir = tempdir().expect("Couldn't create tempdir");
+    let file_path = dir.path().join("long_line.txt");
+    unix::File::create(&file_path)
+        .and_then(|mut f| unix::Write::write_all(&mut f, format!("{content}\n").as_bytes()))
+        .expect("Couldn't write test file");
+
+    let OpenptyResult { master, slave } = openpty(None, None).expect("Couldn't open pty.");
+    let mut master = File::from(master);
+    let stdout_file = File::from(slave);
+
+    let mut child = bat_raw_command()
+        .arg(&file_path)
+        .arg("--pager=cat")
+        .arg("--paging=always")
+        .arg("--wrap=auto")
+        .arg("--color=never")
+        .arg("--decorations=always")
+        .arg("--style=numbers")
+        .stdout(Stdio::from(stdout_file))
+        .spawn()
+        .expect("Failed to start.");
+
+    child
+        .wait_timeout(CHILD_WAIT_TIMEOUT)
+        .expect("Error polling exit status, this should never happen.")
+        .expect("bat (and its pager) should have exited within the timeout.");
+
+    let mut buf = [0u8; 8192];
+    let mut output = String::new();
+    if let Ok(n) = io::Read::read(&mut master, &mut buf) {
+        output.push_str(&String::from_utf8_lossy(&buf[..n]));
+    }
+
+    assert!(
+        output.contains(&content),
+        "expected the {}-char line to appear unwrapped (contiguous) in the pager output, got:\n{:?}",
+        content.len(),
+        output
+    );
+}
+
+#[test]
+#[serial]
+fn wrap_auto_still_wraps_with_explicit_terminal_width_and_paging_always() {
+    // Regression guard for the #1081 fix above: an explicit `--terminal-width`
+    // is an intentional user override and must still force wrapping even when
+    // `--paging=always` is set, unlike the "auto" default which now defers to
+    // the pager. This one doesn't need a real pty since explicit
+    // `--terminal-width` bypasses the interactive-terminal detection.
+    mocked_pagers::with_mocked_versions_of_more_and_most_in_path(|| {
+        bat()
+            .arg("--pager=cat")
+            .arg("--paging=always")
+            .arg("--wrap=auto")
+            .arg("--terminal-width=40")
+            .arg("--color=never")
+            .arg("--decorations=always")
+            .arg("--style=numbers")
+            .write_stdin("a".repeat(300) + "\n")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("a".repeat(300)).not());
+    });
+}
+
 #[test]
 fn theme_arg_overrides_env() {
     bat()


### PR DESCRIPTION
I hit this while scripting bat with `--paging=always` piped into `less` — the output came out double-wrapped and unreadable, and it turned out to be exactly what #1081 describes.

`--paging=always` unconditionally pipes bat's output through a pager (e.g. `less`), which already has its own line-wrapping controls. `--wrap=auto` was still hard-wrapping at the detected terminal width in that case, since `interactive_output` reflects whether bat's own stdout is a real terminal — which it still is even when piped to a pager — producing unreadable, doubly-wrapped output inside the pager.

This defers to the pager instead when `--paging=always` is active and no explicit `--terminal-width` was given (which still takes precedence, as an intentional override). It doesn't require buffering input or output, since `PagingMode::Always` is known at config-resolution time regardless of content — unlike `QuitIfOneScreen`, whose pager invocation depends on the rendered content length, which isn't known yet at that point. Scoped to `PagingMode::Always` only for that reason; `QuitIfOneScreen` is left untouched and documented as a known limitation rather than guessed at. This doesn't change whether/when bat spawns a pager, only whether bat itself hard-wraps before handing off — no new pager-invocation logic added.

Before writing this I checked what had already been tried: #1081 has been open since 2020, and the only prior attempt at it (#3777) took a different, opt-in approach (a new `--wrap=unpaged` flag) and was closed without merge — it's unclear whether that was a design rejection or just abandoned, so I want to flag that alternative rather than assume mine is preferred. Changing `auto`'s default behavior (this PR) vs. adding an opt-in flag (#3777) is a real tradeoff worth a maintainer call: the opt-in path is strictly additive and zero-risk, while this PR fixes what the original issue describes as broken behavior without requiring a new flag. Separately, `QuitIfOneScreen` has its own open, active thread (#3738, with PRs #3745/#3746 still unresolved) that this PR intentionally doesn't touch, for the reason above.

Verified manually with a real pty (`script`) showing the before/after (hard-wrapped vs. intact line), then covered by a new integration test (`wrap_auto_does_not_hard_wrap_when_pager_is_always_active`) using this repo's existing `openpty` pattern — confirmed it fails without the fix, not a placebo — plus a regression guard (`wrap_auto_still_wraps_with_explicit_terminal_width_and_paging_always`) confirming explicit `--terminal-width` still forces wrapping. Full suite passes: 247 tests, 0 failures.

This is my first contribution to bat — open to feedback on scope or approach.

Closes #1081
