### PR TITLE
fix: respect --paging=never for --list-languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## Bugfixes
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
-- Fix `--list-languages` ignoring `--paging=never`, see #3825 (@ychampion)
+- Fix `--list-languages` ignoring `--paging=never`. Closes #3825, see #3835 (@ychampion)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ## Bugfixes
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
+- Fix `--list-languages` ignoring `--paging=never`, see #3825 (@ychampion)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -429,7 +429,7 @@ fn run() -> Result<bool> {
                 let inputs: Vec<Input> = vec![Input::from_reader(Box::new(languages.as_bytes()))];
                 let plain_config = Config {
                     style_components: StyleComponents::new(StyleComponent::Plain.components(false)),
-                    paging_mode: PagingMode::QuitIfOneScreen,
+                    paging_mode: config.paging_mode,
                     ..Default::default()
                 };
                 run_controller(inputs, &plain_config, cache_dir)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -635,6 +635,21 @@ fn list_languages() {
 }
 
 #[test]
+fn list_languages_respects_paging_never() {
+    bat()
+        .env("PAGER", "echo pager-output")
+        .arg("--list-languages")
+        .arg("--paging=never")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Rust")
+                .and(predicate::str::contains("pager-output").not())
+                .normalize(),
+        );
+}
+
+#[test]
 #[cfg_attr(
     any(not(feature = "git"), feature = "lessopen", target_os = "windows"),
     ignore


### PR DESCRIPTION
## Summary

- Respect the resolved paging mode when rendering `--list-languages`.
- Add a regression for `--list-languages --paging=never`.

## Why

`--list-languages` built a temporary plain config with `PagingMode::QuitIfOneScreen`, so an explicit `--paging=never` was ignored and the command still used the pager. Fixes #3825.

## Validation

- `PAGER='echo pager-output' cargo run --quiet -- --list-languages --paging=never | head -n 5` — reproduced `pager-output` before the fix
- `cargo test list_languages --test integration_tests -- --nocapture` — passed
- `cargo fmt -- --check` — passed
- `cargo clippy --locked --bin bat --test integration_tests -- -D warnings` — passed
- `git diff --check` — passed