### PR TITLE
fix: bat cache --help exit code and builtin pager search bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Fix `bat cache --help` returning exit code 1 instead of 0. Remove `.arg_required_else_help(true)` from the cache subcommand and show help when no arguments are provided. See #3798, #3831 and #3837 (@Amilliox)
+- Fix builtin pager (minus) not responding to search (`/`, `?`, `n`, `N`) and navigation (`PgUp`, `PgDown`, arrows, `g`, `G`) keys. `HashedEventRegister` was overriding all default `minus` bindings instead of extending them. Add `generate_default_bindings()` before custom bindings. See #3831, #3798 and #3837 (@Amilliox)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -728,7 +728,7 @@ pub fn build_app(interactive_output: bool) -> Command {
             Command::new("cache")
                 .hide(true)
                 .about("Modify the syntax-definition and theme cache")
-                .arg_required_else_help(true)
+                .disable_help_flag(true)
                 .arg(
                     Arg::new("help")
                         .short('h')

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -414,10 +414,12 @@ fn run() -> Result<bool> {
                 )?;
                 Ok(true)
             } else {
-                let inputs = vec![Input::ordinary_file("cache")];
-                let config = app.config(&inputs)?;
-
-                run_controller(inputs, &config, cache_dir)
+                // No arguments provided to cache subcommand - show help
+                let mut cmd = clap_app::build_app(true);
+                if let Some(cache_cmd) = cmd.find_subcommand_mut("cache") {
+                    print!("{}", cache_cmd.render_help());
+                }
+                Ok(true)
             }
         }
         _ => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -25,6 +25,7 @@ impl BuiltinPager {
         let pager = minus::Pager::new();
 
         let mut input_register = minus::input::HashedEventRegister::default();
+        minus::input::generate_default_bindings(&mut input_register);
         input_register.add_key_events(&["home"], |_, _| {
             minus::input::InputEvent::UpdateUpperMark(0)
         });


### PR DESCRIPTION
## Changes

### #3798 — `bat cache --help` exit code fix
- Remove `.arg_required_else_help(true)` from cache subcommand
- Add `.disable_help_flag(true)` since we have a custom `--help` arg
- When cache subcommand is invoked without arguments, show help instead of trying to open a file named "cache"
- `bat cache --help` now returns exit code 0 (was 1)
- `bat cache` (without args) now returns exit code 0 and shows help (was 2)

### #3831 — Builtin pager search/navigation fix
- Add `minus::input::generate_default_bindings(&mut input_register)` before custom key bindings
- This restores all default minus bindings: search (`/`, `?`, `n`, `N`), navigation (`PgUp`, `PgDown`, arrows, `g`, `G`), quit (`q`), etc.
- Custom `home`/`end` overrides are applied after defaults, so they still work correctly

## Testing
- `cargo test` — 427 passed, 0 failed
- `bat cache --help` → exit 0
- `bat cache` → exit 0 (shows help)
- `bat Cargo.toml` → exit 0 (normal operation unaffected)