### PR TITLE
Honor pager -S / --chop-long-lines and skip pre-wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Do not pre-wrap output to terminal width when the effective pager is `less` and the user has asked it to chop long lines (via `LESS=…S…`, `BAT_PAGER="less -S"`, or `--pager 'less -S'`). Previously `bat` wrapped lines at the terminal edge before piping to `less`, so `-S`/`--chop-long-lines` had nothing left to chop. Closes #2869 (@ChihebBENCHEIKH1)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -421,7 +421,20 @@ impl App {
                         Some("word") => WrappingMode::Word,
                         Some("never") => WrappingMode::NoWrapping(true),
                         Some("auto") | None => {
-                            if self.interactive_output || maybe_term_width.is_some() {
+                            // If we're going to hand output to `less` and the
+                            // user has already told `less` to chop long lines
+                            // (via `--pager`, `BAT_PAGER`, `PAGER`, or the
+                            // `LESS` env var), skip our own wrapping so that
+                            // less has something to chop. Otherwise `-S` looks
+                            // like it does nothing because bat has already
+                            // broken every long line at the terminal edge.
+                            let pager_chops = paging_mode != PagingMode::Never
+                                && bat::config::pager_will_chop_long_lines(
+                                    self.matches.get_one::<String>("pager").map(|s| s.as_str()),
+                                );
+                            if pager_chops {
+                                WrappingMode::NoWrapping(true)
+                            } else if self.interactive_output || maybe_term_width.is_some() {
                                 if style_components.plain() && maybe_term_width.is_none() {
                                     WrappingMode::NoWrapping(false)
                                 } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,6 +135,17 @@ pub fn get_pager_executable(config_pager: Option<&str>) -> Option<String> {
         })
 }
 
+/// Returns `true` when the effective pager is `less` and it has been told to
+/// chop (truncate) long lines, either through the pager command's own arguments
+/// (from `--pager`, `BAT_PAGER`, or `PAGER`) or through the `LESS` environment
+/// variable. The application uses this to skip `bat`'s own line wrapping so
+/// that `less -S` can actually chop overflow instead of receiving already-wrapped
+/// output.
+#[cfg(all(feature = "minimal-application", feature = "paging"))]
+pub fn pager_will_chop_long_lines(config_pager: Option<&str>) -> bool {
+    crate::pager::pager_will_chop_long_lines(config_pager)
+}
+
 #[test]
 fn default_config_should_include_all_lines() {
     use crate::line_range::MaxBufferedLineNumber;

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -96,6 +96,92 @@ impl Pager {
     }
 }
 
+/// Whether the given text (a `less` short-flag token with its leading `-`
+/// already stripped) contains a real, un-consumed `-S`.
+///
+/// Some `less` short options take an argument that is glued to the letter
+/// with no separator (`-P<prompt>`, `-o<file>`, `-t<tag>`, `-p<pattern>`,
+/// `-D<color>`, ...). Once such a letter is seen, everything after it in the
+/// same token is the value and must not be re-parsed as further flags — any
+/// `S` inside it is coincidence, not a chop request. We walk the bundle
+/// character by character and either return true when we hit `S`, return
+/// false when we hit a value-taking letter (its argument follows), or ignore
+/// no-arg letters. Any non-alphabetic character means the token isn't a
+/// plain short-flag bundle at all.
+fn short_bundle_signals_chop(bundle: &str) -> bool {
+    for c in bundle.chars() {
+        match c {
+            'S' => return true,
+            // less(1) short options that consume a glued value.
+            'b' | 'D' | 'h' | 'j' | 'k' | 'o' | 'O' | 'p' | 'P' | 't' | 'T' | 'x' | 'y' | 'z'
+            | '#' => return false,
+            c if c.is_ascii_alphabetic() => continue,
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// Whether a single pager argument selects `less`'s chop-long-lines behavior
+/// (either the `-S` short flag, possibly inside a bundle like `-RSF`, or the
+/// long form `--chop-long-lines`).
+fn arg_signals_chop_long_lines(arg: &str) -> bool {
+    if arg == "--chop-long-lines" {
+        return true;
+    }
+    // Long options that aren't `--chop-long-lines` never signal chop, so skip
+    // anything with a `--` prefix before checking short-flag bundles.
+    if let Some(rest) = arg.strip_prefix("--") {
+        return rest == "chop-long-lines";
+    }
+    if let Some(rest) = arg.strip_prefix('-') {
+        return short_bundle_signals_chop(rest);
+    }
+    false
+}
+
+/// Whether the `LESS` environment variable's contents ask `less` to chop long
+/// lines. The variable is a whitespace-separated list of options; each token
+/// may or may not carry a leading `-` (e.g. `LESS=-RS` and `LESS=RS` are both
+/// legal short-flag bundles).
+fn less_env_signals_chop_long_lines(less: &str) -> bool {
+    less.split_whitespace().any(|token| {
+        if token == "--chop-long-lines" {
+            return true;
+        }
+        if let Some(rest) = token.strip_prefix("--") {
+            return rest == "chop-long-lines";
+        }
+        // A leading `-` is optional in $LESS; treat the token as a short-flag
+        // bundle either way.
+        let bundle = token.strip_prefix('-').unwrap_or(token);
+        short_bundle_signals_chop(bundle)
+    })
+}
+
+/// Returns true when the effective pager is `less` and it has been told to
+/// chop long lines (via the pager's own arguments or the `LESS` environment
+/// variable). The application uses this to skip its own line-wrapping so that
+/// `less -S` actually has something to chop.
+pub(crate) fn pager_will_chop_long_lines(config_pager: Option<&str>) -> bool {
+    let pager = match get_pager(config_pager) {
+        Ok(Some(pager)) => pager,
+        _ => return false,
+    };
+    if pager.kind != PagerKind::Less {
+        return false;
+    }
+    if pager.args.iter().any(|a| arg_signals_chop_long_lines(a)) {
+        return true;
+    }
+    // `less` always merges options from the `LESS` env var with its argv, so
+    // consult it regardless of whether the pager command specified args.
+    env::var("LESS")
+        .ok()
+        .as_deref()
+        .is_some_and(less_env_signals_chop_long_lines)
+}
+
 /// Returns what pager to use, after looking at both config and environment variables.
 pub(crate) fn get_pager(config_pager: Option<&str>) -> Result<Option<Pager>, ParseError> {
     let bat_pager = env::var("BAT_PAGER");
@@ -134,5 +220,82 @@ pub(crate) fn get_pager(config_pager: Option<&str>) -> Result<Option<Pager>, Par
             }))
         }
         None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod chop_detection_tests {
+    use super::{arg_signals_chop_long_lines, less_env_signals_chop_long_lines};
+
+    #[test]
+    fn arg_short_flag_alone_is_chop() {
+        assert!(arg_signals_chop_long_lines("-S"));
+    }
+
+    #[test]
+    fn arg_short_flag_bundle_is_chop() {
+        assert!(arg_signals_chop_long_lines("-RSF"));
+    }
+
+    #[test]
+    fn arg_long_flag_is_chop() {
+        assert!(arg_signals_chop_long_lines("--chop-long-lines"));
+    }
+
+    #[test]
+    fn arg_lowercase_s_is_not_chop() {
+        // `-s` is `--squeeze-blank-lines`; only `-S` chops.
+        assert!(!arg_signals_chop_long_lines("-s"));
+    }
+
+    #[test]
+    fn arg_unrelated_long_option_is_not_chop() {
+        assert!(!arg_signals_chop_long_lines("--RAW-CONTROL-CHARS"));
+    }
+
+    #[test]
+    fn less_env_bundle_without_leading_dash_is_chop() {
+        // `LESS=RS` is a legal option bundle for `less`.
+        assert!(less_env_signals_chop_long_lines("RS"));
+    }
+
+    #[test]
+    fn less_env_reproduces_issue_2869_bundle() {
+        // Exact reproduction of the `LESS` value reported in sharkdp/bat#2869.
+        assert!(less_env_signals_chop_long_lines("-XQRSia"));
+    }
+
+    #[test]
+    fn less_env_split_tokens_can_signal_chop() {
+        assert!(less_env_signals_chop_long_lines("-R --chop-long-lines"));
+    }
+
+    #[test]
+    fn less_env_without_chop_flag_returns_false() {
+        assert!(!less_env_signals_chop_long_lines("-RFX"));
+    }
+
+    // Options with a glued string argument (`less -P<prompt>`, `-o<file>`,
+    // `-t<tag>`, `-p<pattern>`) must not be misread as short-flag bundles
+    // just because their value happens to contain an uppercase `S`.
+    #[test]
+    fn arg_custom_prompt_containing_s_is_not_chop() {
+        assert!(!arg_signals_chop_long_lines("-PSpecial-Prompt"));
+    }
+
+    #[test]
+    fn arg_log_output_path_containing_s_is_not_chop() {
+        assert!(!arg_signals_chop_long_lines("-o/tmp/Session.log"));
+    }
+
+    #[test]
+    fn arg_tag_value_starting_with_s_is_not_chop() {
+        assert!(!arg_signals_chop_long_lines("-tSet"));
+    }
+
+    #[test]
+    fn less_env_prompt_format_containing_s_is_not_chop() {
+        // Custom LESS prompt format tokens (see `PROMPTS` in less(1)).
+        assert!(!less_env_signals_chop_long_lines("-P%pB:S"));
     }
 }


### PR DESCRIPTION
Closes #2869.

When `--style` includes decorations (grid, line numbers, header) bat resolves `WrappingMode::Character` on an interactive terminal and hard-wraps each line at the terminal edge before the pager sees it. If the user has told `less` to chop long lines — most commonly through the `LESS` environment variable, but also via `BAT_PAGER="less -S"` or `--pager 'less -S'` — `less -S` then has nothing left to chop and the interactive toggle appears dead. The exact `LESS=-XQRSia` from the issue is one such case.

A new helper `pager_will_chop_long_lines()` in `pager.rs` looks at the effective pager command's arguments and, when the pager is `less`, also at the `LESS` environment variable. It handles the `-S` short flag, bundled short flags such as `-RSF` or the `RSia` form (leading `-` is optional inside `LESS`), and the long form `--chop-long-lines`.

The bundle parser walks the token character by character and stops at value-taking short options (`-P`, `-o`, `-t`, `-T`, `-D`, `-p`, `-b`, `-h`, `-j`, `-k`, `-x`, `-y`, `-z`, `-#`), so `LESS=-PSpecial-Prompt` or `--pager 'less -o/tmp/Session.log'` do not spuriously match the `S` inside the value. Lowercase `-s` (`--squeeze-blank-lines`) is left alone.

`App::config` consults the helper only in the `--wrap=auto`/unset branch, so the existing `--chop-long-lines` CLI flag and explicit `--wrap=character|word|never` values continue to take precedence unchanged. When paging is enabled and the pager will chop, bat now resolves `WrappingMode::NoWrapping(true)`, emits full-width lines, and lets `less` do the truncation.

Thirteen focused unit tests cover the parse: the `-S` cases from the issue, bundled short flags, the `LESS=-XQRSia` bundle verbatim, the value-glued false positives (`-PSpecial-Prompt`, `-o/tmp/Session.log`, `-tSet`, `LESS=-P%pB:S`), and the negative cases (`-s`, `-RFX`, unrelated long options).
