### PR TITLE
fix: disable paging when listing themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 
 ## Bugfixes
 
+- fix: disable paging when listing themes, see #3843 (@Deen3303)
 - Fix hang when using `--list-themes` with an explicit pager, see #3457 (@abhinavcool42)
 - Fix negative values of N not being parsed in <N:M> line ranges without `=` flag value separator, see #3442 (@lmmx)
 - Fix broken Docker syntax preventing use of custom assets, see #3476 (@keith-hall)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2016,9 +2016,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -2130,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -434,7 +434,11 @@ fn run() -> Result<bool> {
                 };
                 run_controller(inputs, &plain_config, cache_dir)
             } else if app.matches.get_flag("list-themes") {
-                list_themes(&config, config_dir, cache_dir, app.theme_options())?;
+                // make a mutable copy of the config to override the paging behavior
+                let mut list_config = config.clone();
+                list_config.paging_mode = bat::PagingMode::Never;
+
+                list_themes(&list_config, config_dir, cache_dir, app.theme_options())?;
                 Ok(true)
             } else if app.matches.get_flag("config-file") {
                 println!("{}", config_file().to_string_lossy());


### PR DESCRIPTION
### Problem
If a user has global paging options configured (for example, via 'BAT_OPTS="--paging=always"' or inside their global configuration file), running 'bat --list-themes' will attempt to pipe the theme list through the pager. 

Because of how the theme preview blocks are printed, this forces the pager to display them one by one, rendering the list completely unusable and swallowing the theme header names.

### Solution
This PR intercepts the execution flow in 'src/bin/bat/main.rs' right before executing the 'list_themes' command. 

Specifically:
1. Create a local mutable copy of the resolved configuration (config) inside the 'list-themes' block.
2. Explicitly override 'paging_mode' to 'bat::PagingMode::Never'.
3. Pass this modified configuration to the 'list_themes' function.

This forces 'bat' to print the entire list of themes cleanly to standard output, ignoring any global paging configurations, while leaving normal file-viewing behaviors completely untouched.

### Verification
Tested locally by setting:
$env:BAT_OPTS="--paging=always"
.\target\debug\bat.exe --list-themes
(Printed cleanly)
<img width="769" height="850" alt="batfix" src="https://github.com/user-attachments/assets/e0f84020-11ec-4169-9b5b-0d589c9068d5" />
