### PR TITLE
(feat) Add --colors to override individual theme colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Features
 
+- Add `--colors` to override individual colors of the selected theme, e.g. `--colors 'gutter-foreground=#f5f5f5'`, see #3846 (@Peacanduck). Closes #339
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)
 - Preserve `--diff` change markers and snip separators when `--plain` is set. Closes #3630, see #3643 (@mvanhorn)

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -193,6 +193,21 @@ Use the dark theme specified by \fB-\-theme-dark\fR.
 Use the light theme specified by \fB-\-theme-light\fR.
 .RE
 .HP
+\fB\-\-colors\fR <target=color>
+.IP
+Override individual colors of the selected theme, so that a theme does not have to be copied
+just to change a single color. Several overrides can be given as a comma-separated list, and
+the option can be used more than once. Colors are written in CSS hex notation
+('#f00' or '#ff0000').
+
+The targets \fBforeground\fP, \fBgutter\-foreground\fP and \fBline\-highlight\fP change the
+color of the text, of the line numbers and grid, and of the background of lines highlighted
+with \fB\-\-highlight\-line\fP.
+
+A target of the form \fBscope:\fP<scope> changes the color of a syntax scope and of the scopes
+nested below it. For example, \fB\-\-colors 'scope:string=#98c379'\fP colors strings and nested
+scopes like 'string.regexp'.
+.HP
 \fB\-\-theme\-dark\fR <theme>
 .IP
 Sets the theme name for syntax highlighting used when the terminal uses a dark background.

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -44,6 +44,20 @@ Options:
           
           [aliases: --fallback-language]
 
+      --colors <target=color>
+          Override individual colors of the selected theme, so that a theme does not have to be
+          copied just to change a single color. Several overrides can be given as a comma-separated
+          list, and the option can be used more than once. Colors are written in CSS hex notation
+          ('#f00' or '#ff0000').
+          
+          The targets 'foreground', 'gutter-foreground' and 'line-highlight' change the color of the
+          text, of the line numbers and grid, and of the background of lines highlighted with
+          --highlight-line.
+          
+          A target of the form 'scope:<scope>' changes the color of a syntax scope and of the scopes
+          nested below it. For example, --colors 'scope:string=#98c379' colors strings and nested
+          scopes like 'string.regexp'.
+
   -H, --highlight-line <N:M>
           Highlight the specified line ranges with a different background color For example:
             '--highlight-line 40' highlights line 40

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -19,6 +19,8 @@ Options:
           Set the language for syntax highlighting.
       --fallback-syntax <fallback-syntax>
           Set a fallback language for undetected syntaxes. [aliases: --fallback-language]
+      --colors <target=color>
+          Override individual colors of the theme ('gutter-foreground=#f5f5f5').
   -H, --highlight-line <N:M>
           Highlight lines N through M.
       --file-name <name>

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -12,6 +12,7 @@ use crate::{
 use bat::style::StyleComponentList;
 use bat::theme::{theme, ThemeName, ThemeOptions, ThemePreference};
 use bat::BinaryBehavior;
+use bat::ColorOverrides;
 use bat::StripAnsiMode;
 use clap::ArgMatches;
 
@@ -496,6 +497,7 @@ impl App {
             quiet_empty: self.matches.get_flag("quiet-empty"),
             unbuffered: self.matches.get_flag("unbuffered"),
             theme: theme(self.theme_options()).to_string(),
+            color_overrides: self.color_overrides()?,
             visible_lines: match self.matches.try_contains_id("diff").unwrap_or_default()
                 && self.matches.get_flag("diff")
             {
@@ -672,6 +674,17 @@ impl App {
 
     pub(crate) fn theme_options(&self) -> ThemeOptions {
         Self::theme_options_from_matches(&self.matches)
+    }
+
+    fn color_overrides(&self) -> Result<ColorOverrides> {
+        let mut color_overrides = ColorOverrides::default();
+        if let Some(specs) = self.matches.get_many::<String>("colors") {
+            for spec in specs {
+                color_overrides.add(spec)?;
+            }
+        }
+
+        Ok(color_overrides)
     }
 
     fn theme_options_from_matches(matches: &ArgMatches) -> ThemeOptions {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -132,6 +132,26 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("colors")
+                .long("colors")
+                .action(ArgAction::Append)
+                .value_name("target=color")
+                .help("Override individual colors of the theme ('gutter-foreground=#f5f5f5').")
+                .long_help(
+                    "Override individual colors of the selected theme, so that a theme does not \
+                     have to be copied just to change a single color. Several overrides can be \
+                     given as a comma-separated list, and the option can be used more than once. \
+                     Colors are written in CSS hex notation ('#f00' or '#ff0000').\n\n\
+                     The targets 'foreground', 'gutter-foreground' and 'line-highlight' change the \
+                     color of the text, of the line numbers and grid, and of the background of \
+                     lines highlighted with --highlight-line.\n\n\
+                     A target of the form 'scope:<scope>' changes the color of a syntax scope and \
+                     of the scopes nested below it. For example, \
+                     --colors 'scope:string=#98c379' colors strings and nested scopes like \
+                     'string.regexp'.",
+                ),
+        )
+        .arg(
             Arg::new("highlight-line")
                 .long("highlight-line")
                 .short('H')

--- a/src/color_overrides.rs
+++ b/src/color_overrides.rs
@@ -1,0 +1,369 @@
+use std::borrow::Cow;
+
+use syntect::highlighting::{
+    Color, ScopeSelector, ScopeSelectors, StyleModifier, Theme, ThemeItem,
+};
+use syntect::parsing::{Scope, ScopeStack};
+
+use crate::error::*;
+
+/// A theme color that `bat` actually uses when rendering output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ThemeSetting {
+    Foreground,
+    GutterForeground,
+    LineHighlight,
+}
+
+impl ThemeSetting {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "foreground" => Some(ThemeSetting::Foreground),
+            "gutter-foreground" => Some(ThemeSetting::GutterForeground),
+            "line-highlight" => Some(ThemeSetting::LineHighlight),
+            _ => None,
+        }
+    }
+
+    fn apply(self, theme: &mut Theme, color: Color) {
+        match self {
+            ThemeSetting::Foreground => theme.settings.foreground = Some(color),
+            ThemeSetting::GutterForeground => theme.settings.gutter_foreground = Some(color),
+            ThemeSetting::LineHighlight => theme.settings.line_highlight = Some(color),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Target {
+    Setting(ThemeSetting),
+    Scope(Scope),
+}
+
+/// Color overrides that are applied on top of the selected theme.
+#[derive(Debug, Clone, Default)]
+pub struct ColorOverrides {
+    overrides: Vec<(Target, Color)>,
+}
+
+impl ColorOverrides {
+    pub fn is_empty(&self) -> bool {
+        self.overrides.is_empty()
+    }
+
+    /// Add the overrides of a single `--colors` specification, e.g.
+    /// `gutter-foreground=#f5f5f5,scope:comment=#808080`.
+    ///
+    /// Later overrides take precedence over earlier ones.
+    pub fn add(&mut self, spec: &str) -> Result<()> {
+        for entry in spec.split(',') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+
+            let (key, value) = entry
+                .split_once('=')
+                .ok_or_else(|| Error::InvalidColorOverride(entry.to_owned()))?;
+
+            let target = parse_target(key.trim())?;
+            let color = parse_color(value.trim())?;
+
+            self.overrides.push((target, color));
+        }
+
+        Ok(())
+    }
+
+    /// Apply the overrides to `theme`, leaving it untouched if there are none.
+    pub(crate) fn apply<'a>(&self, theme: &'a Theme) -> Cow<'a, Theme> {
+        if self.is_empty() {
+            return Cow::Borrowed(theme);
+        }
+
+        let mut theme = theme.clone();
+        for &(target, color) in &self.overrides {
+            match target {
+                Target::Setting(setting) => setting.apply(&mut theme, color),
+                Target::Scope(scope) => override_scope(&mut theme, scope, color),
+            }
+        }
+
+        Cow::Owned(theme)
+    }
+}
+
+fn parse_target(key: &str) -> Result<Target> {
+    if let Some(scope) = key.strip_prefix("scope:") {
+        let scope = scope.trim();
+        if scope.is_empty() {
+            return Err(Error::UnknownColorOverrideTarget(key.to_owned()));
+        }
+
+        return Scope::new(scope)
+            .map(Target::Scope)
+            .map_err(|_| Error::UnknownColorOverrideTarget(key.to_owned()));
+    }
+
+    ThemeSetting::from_name(key)
+        .map(Target::Setting)
+        .ok_or_else(|| Error::UnknownColorOverrideTarget(key.to_owned()))
+}
+
+fn parse_color(value: &str) -> Result<Color> {
+    let digits = value.strip_prefix('#').unwrap_or(value);
+    if !digits.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(Error::InvalidColorValue(value.to_owned()));
+    }
+
+    // Both the short (#rgb) and the long (#rrggbb) CSS notation are accepted.
+    let component = |i: usize| match digits.len() {
+        3 => u8::from_str_radix(&digits[i..i + 1].repeat(2), 16).ok(),
+        6 => u8::from_str_radix(&digits[2 * i..2 * i + 2], 16).ok(),
+        _ => None,
+    };
+
+    match (component(0), component(1), component(2)) {
+        (Some(r), Some(g), Some(b)) => Ok(Color { r, g, b, a: 0xFF }),
+        _ => Err(Error::InvalidColorValue(value.to_owned())),
+    }
+}
+
+/// Recolor every token that `theme` styles under `scope`.
+///
+/// Adding a single rule is not enough: syntect resolves a token's style by
+/// picking the most specific matching rule, so a rule for `comment` would still
+/// lose against a rule for `comment.line.double-slash` that the theme already
+/// defines. The existing rules are rewritten so that the override applies to
+/// the nested scopes as well.
+fn override_scope(theme: &mut Theme, scope: Scope, color: Color) {
+    let mut scopes = Vec::with_capacity(theme.scopes.len() + 1);
+
+    for item in theme.scopes.drain(..) {
+        let (overridden, kept): (Vec<ScopeSelector>, Vec<ScopeSelector>) = item
+            .scope
+            .selectors
+            .into_iter()
+            .partition(|selector| selector_is_below(selector, scope));
+
+        if !kept.is_empty() {
+            scopes.push(ThemeItem {
+                scope: ScopeSelectors { selectors: kept },
+                style: item.style,
+            });
+        }
+
+        if !overridden.is_empty() {
+            scopes.push(ThemeItem {
+                scope: ScopeSelectors {
+                    selectors: overridden,
+                },
+                style: StyleModifier {
+                    foreground: Some(color),
+                    ..item.style
+                },
+            });
+        }
+    }
+
+    // Tokens which the theme does not style at all are covered by a new rule.
+    scopes.push(ThemeItem {
+        scope: ScopeSelectors {
+            selectors: vec![ScopeSelector {
+                path: ScopeStack::from_vec(vec![scope]),
+                excludes: Vec::new(),
+            }],
+        },
+        style: StyleModifier {
+            foreground: Some(color),
+            background: None,
+            font_style: None,
+        },
+    });
+
+    theme.scopes = scopes;
+}
+
+fn selector_is_below(selector: &ScopeSelector, scope: Scope) -> bool {
+    selector
+        .path
+        .scopes
+        .iter()
+        .any(|&selector_scope| scope.is_prefix_of(selector_scope))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn color(r: u8, g: u8, b: u8) -> Color {
+        Color { r, g, b, a: 0xFF }
+    }
+
+    fn overrides(spec: &str) -> ColorOverrides {
+        let mut overrides = ColorOverrides::default();
+        overrides.add(spec).expect("spec should be valid");
+        overrides
+    }
+
+    #[test]
+    fn default_overrides_are_empty() {
+        assert!(ColorOverrides::default().is_empty());
+    }
+
+    #[test]
+    fn long_and_short_notation_are_equivalent() {
+        assert_eq!(parse_color("#ff0000").unwrap(), color(0xFF, 0x00, 0x00));
+        assert_eq!(parse_color("#f00").unwrap(), color(0xFF, 0x00, 0x00));
+        assert_eq!(parse_color("f5f5f5").unwrap(), color(0xF5, 0xF5, 0xF5));
+    }
+
+    #[test]
+    fn invalid_colors_are_rejected() {
+        for value in ["", "#", "#12345", "#gg0000", "red", "#ff00000"] {
+            assert!(parse_color(value).is_err(), "{value} should be rejected");
+        }
+    }
+
+    #[test]
+    fn unknown_targets_are_rejected() {
+        for spec in ["gutter-forground=#fff", "=#fff", "scope:=#fff", "#fff"] {
+            assert!(
+                ColorOverrides::default().add(spec).is_err(),
+                "{spec} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn settings_are_overridden() {
+        let theme = overrides("foreground=#010203,gutter-foreground=#f5f5f5")
+            .apply(&Theme::default())
+            .into_owned();
+
+        assert_eq!(theme.settings.foreground, Some(color(0x01, 0x02, 0x03)));
+        assert_eq!(
+            theme.settings.gutter_foreground,
+            Some(color(0xF5, 0xF5, 0xF5))
+        );
+    }
+
+    #[test]
+    fn last_override_of_a_target_wins() {
+        let theme = overrides("gutter-foreground=#111111,gutter-foreground=#222222")
+            .apply(&Theme::default())
+            .into_owned();
+
+        assert_eq!(
+            theme.settings.gutter_foreground,
+            Some(color(0x22, 0x22, 0x22))
+        );
+    }
+
+    #[test]
+    fn theme_without_overrides_is_not_cloned() {
+        let theme = Theme::default();
+        assert!(matches!(
+            ColorOverrides::default().apply(&theme),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    fn item(selector: &str, foreground: Color) -> ThemeItem {
+        ThemeItem {
+            scope: selector.parse().unwrap(),
+            style: StyleModifier {
+                foreground: Some(foreground),
+                background: None,
+                font_style: None,
+            },
+        }
+    }
+
+    fn foreground_of(theme: &Theme, selector: &str) -> Vec<Option<Color>> {
+        theme
+            .scopes
+            .iter()
+            .filter(|item| {
+                item.scope.selectors.iter().any(|s| {
+                    s.path.scopes
+                        == ScopeStack::from_vec(vec![Scope::new(selector).unwrap()]).scopes
+                })
+            })
+            .map(|item| item.style.foreground)
+            .collect()
+    }
+
+    fn theme_with(scopes: Vec<ThemeItem>) -> Theme {
+        Theme {
+            scopes,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn nested_scopes_are_recolored() {
+        let theme = theme_with(vec![
+            item("comment", color(0x11, 0x11, 0x11)),
+            item("comment.line.double-slash", color(0x22, 0x22, 0x22)),
+            item("keyword", color(0x33, 0x33, 0x33)),
+        ]);
+
+        let theme = overrides("scope:comment=#808080")
+            .apply(&theme)
+            .into_owned();
+
+        let grey = Some(color(0x80, 0x80, 0x80));
+        assert_eq!(foreground_of(&theme, "comment"), vec![grey, grey]);
+        assert_eq!(
+            foreground_of(&theme, "comment.line.double-slash"),
+            vec![grey]
+        );
+        assert_eq!(
+            foreground_of(&theme, "keyword"),
+            vec![Some(color(0x33, 0x33, 0x33))]
+        );
+    }
+
+    #[test]
+    fn unrelated_selectors_of_a_rule_keep_their_color() {
+        let theme = theme_with(vec![item("comment, keyword", color(0x11, 0x11, 0x11))]);
+
+        let theme = overrides("scope:comment=#808080")
+            .apply(&theme)
+            .into_owned();
+
+        assert_eq!(
+            foreground_of(&theme, "keyword"),
+            vec![Some(color(0x11, 0x11, 0x11))]
+        );
+        assert_eq!(
+            foreground_of(&theme, "comment"),
+            vec![Some(color(0x80, 0x80, 0x80)); 2]
+        );
+    }
+
+    #[test]
+    fn overriding_a_scope_keeps_the_font_style() {
+        let theme = theme_with(vec![ThemeItem {
+            scope: "comment".parse().unwrap(),
+            style: StyleModifier {
+                foreground: Some(color(0x11, 0x11, 0x11)),
+                background: Some(color(0x22, 0x22, 0x22)),
+                font_style: Some(syntect::highlighting::FontStyle::ITALIC),
+            },
+        }]);
+
+        let theme = overrides("scope:comment=#808080")
+            .apply(&theme)
+            .into_owned();
+        let overridden = &theme.scopes[0];
+
+        assert_eq!(overridden.style.foreground, Some(color(0x80, 0x80, 0x80)));
+        assert_eq!(overridden.style.background, Some(color(0x22, 0x22, 0x22)));
+        assert_eq!(
+            overridden.style.font_style,
+            Some(syntect::highlighting::FontStyle::ITALIC)
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::color_overrides::ColorOverrides;
 use crate::line_range::{HighlightedLineRanges, LineRanges};
 use crate::nonprintable_notation::{BinaryBehavior, NonprintableNotation};
 #[cfg(feature = "paging")]
@@ -81,6 +82,9 @@ pub struct Config<'a> {
 
     /// The syntax highlighting theme
     pub theme: String,
+
+    /// Colors which override the ones provided by the theme
+    pub color_overrides: ColorOverrides,
 
     /// File extension/name mappings
     pub syntax_mapping: SyntaxMapping<'a>,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -13,15 +13,19 @@ use crate::output::{OutputHandle, OutputType};
 #[cfg(feature = "paging")]
 use crate::paging::PagingMode;
 use crate::printer::{InteractivePrinter, Printer, SimplePrinter};
+use std::borrow::Cow;
+use std::cell::OnceCell;
 use std::collections::VecDeque;
 use std::io::{self, BufRead, Write};
 use std::mem;
 
 use clircle::{Clircle, Identifier};
+use syntect::highlighting::Theme;
 
 pub struct Controller<'a> {
     config: &'a Config<'a>,
     assets: &'a HighlightingAssets,
+    theme: OnceCell<Cow<'a, Theme>>,
     #[cfg(feature = "lessopen")]
     preprocessor: Option<LessOpenPreprocessor>,
 }
@@ -31,9 +35,20 @@ impl Controller<'_> {
         Controller {
             config,
             assets,
+            theme: OnceCell::new(),
             #[cfg(feature = "lessopen")]
             preprocessor: LessOpenPreprocessor::new().ok(),
         }
+    }
+
+    /// The configured theme with the color overrides applied. It is only
+    /// looked up when something is actually highlighted.
+    fn theme(&self) -> &Theme {
+        self.theme.get_or_init(|| {
+            self.config
+                .color_overrides
+                .apply(self.assets.get_theme(&self.config.theme))
+        })
     }
 
     pub fn run(
@@ -189,12 +204,13 @@ impl Controller<'_> {
             None
         };
 
-        let mut printer: Box<dyn Printer> = if self.config.loop_through {
+        let mut printer: Box<dyn Printer + '_> = if self.config.loop_through {
             Box::new(SimplePrinter::new(self.config))
         } else {
             Box::new(InteractivePrinter::new(
                 self.config,
                 self.assets,
+                self.theme(),
                 &mut opened_input,
                 #[cfg(feature = "git")]
                 &line_changes,

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,12 @@ pub enum Error {
     UnknownSyntax(String),
     #[error("Unknown style '{0}'")]
     UnknownStyle(String),
+    #[error("Invalid color override '{0}', expected 'target=color'")]
+    InvalidColorOverride(String),
+    #[error("Unknown color override target '{0}'")]
+    UnknownColorOverrideTarget(String),
+    #[error("Invalid color '{0}'")]
+    InvalidColorValue(String),
     #[error("Use of bat as a pager is disallowed in order to avoid infinite recursion problems")]
     InvalidPagerValueBat,
     #[error("{0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod assets;
 pub mod assets_metadata {
     pub use super::assets::assets_metadata::*;
 }
+pub mod color_overrides;
 pub mod config;
 pub mod controller;
 mod decorations;
@@ -53,6 +54,7 @@ pub mod theme;
 mod vscreen;
 pub(crate) mod wrapping;
 
+pub use color_overrides::ColorOverrides;
 pub use nonprintable_notation::{BinaryBehavior, NonprintableNotation};
 pub use preprocessor::sanitize_for_terminal;
 pub use preprocessor::StripAnsiMode;

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -5,6 +5,7 @@ use console::Term;
 
 use crate::{
     assets::HighlightingAssets,
+    color_overrides::ColorOverrides,
     config::{Config, VisibleLines},
     controller::Controller,
     error::Result,
@@ -260,6 +261,12 @@ impl<'a> PrettyPrinter<'a> {
     /// and the terminal's background color.
     pub fn theme(&mut self, theme: impl AsRef<str>) -> &mut Self {
         self.config.theme = theme.as_ref().to_owned();
+        self
+    }
+
+    /// Override individual colors of the highlighting theme.
+    pub fn color_overrides(&mut self, color_overrides: ColorOverrides) -> &mut Self {
+        self.config.color_overrides = color_overrides;
         self
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -219,11 +219,10 @@ impl<'a> InteractivePrinter<'a> {
     pub(crate) fn new(
         config: &'a Config,
         assets: &'a HighlightingAssets,
+        theme: &'a Theme,
         input: &mut OpenedInput,
         #[cfg(feature = "git")] line_changes: &'a Option<LineChanges>,
     ) -> Result<Self> {
-        let theme = assets.get_theme(&config.theme);
-
         let background_color_highlight = theme.settings.line_highlight;
 
         let colors = if config.colored_output {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4434,3 +4434,290 @@ fn ignored_suffix_enables_first_line_detection() {
     // ...while the default (extension wins) stays plain and differs.
     assert_ne!(default, forced_bash);
 }
+
+#[test]
+fn color_override_changes_the_line_number_color() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=numbers")
+        .arg("--colors=gutter-foreground=#ff0000")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;255;0;0m   1"));
+}
+
+#[test]
+fn color_override_changes_the_highlighted_line_color() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .arg("--highlight-line=1")
+        .arg("--colors=line-highlight=#00ff00")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[48;2;0;255;0"))
+        .stderr("");
+}
+
+#[test]
+fn color_override_changes_the_default_text_color() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .arg("--colors=foreground=#0000ff")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout("\x1B[38;2;0;0;255mLorem Ipsum\x1B[0m")
+        .stderr("");
+}
+
+#[test]
+fn color_override_changes_a_syntax_scope() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .arg("--language=rust")
+        .arg("--colors=scope:comment=#808080")
+        .write_stdin("// note")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;128;128;128m note"));
+}
+
+#[test]
+fn color_override_of_a_scope_applies_to_nested_scopes() {
+    // The theme colors 'string.regexp' with a rule of its own, which is more
+    // specific than the overridden 'string' scope.
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .arg("--language=js")
+        .arg("--colors=scope:string=#ff0000")
+        .write_stdin("const r = /ab/;\nconst s = \"hi\";\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;255;0;0mab"))
+        .stdout(predicate::str::contains("\x1B[38;2;255;0;0mhi"))
+        .stdout(predicate::str::contains("38;2;86;182;194").not())
+        .stdout(predicate::str::contains("38;2;152;195;121").not());
+}
+
+#[test]
+fn color_override_of_a_scope_keeps_sibling_scopes_unchanged() {
+    // The theme colors 'comment' and 'punctuation.definition.comment' with a
+    // single rule, but only the former is overridden here.
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .arg("--language=rust")
+        .arg("--colors=scope:comment=#808080")
+        .write_stdin("// note")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;92;99;112m//"));
+}
+
+#[test]
+fn color_override_applies_to_the_selected_theme() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=GitHub")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=numbers")
+        .arg("--colors=gutter-foreground=#ff0000")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;255;0;0m   1"));
+}
+
+#[test]
+fn color_override_accepts_several_targets_in_one_argument() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=numbers")
+        .arg("--colors=gutter-foreground=#ff0000,foreground=#0000ff")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;255;0;0m   1"))
+        .stdout(predicate::str::contains("\x1B[38;2;0;0;255mLorem Ipsum"));
+}
+
+#[test]
+fn color_override_can_be_given_more_than_once() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=numbers")
+        .arg("--colors=gutter-foreground=#ff0000")
+        .arg("--colors=foreground=#0000ff")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;255;0;0m   1"))
+        .stdout(predicate::str::contains("\x1B[38;2;0;0;255mLorem Ipsum"));
+}
+
+#[test]
+fn color_override_uses_the_last_value_of_a_target() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=numbers")
+        .arg("--colors=gutter-foreground=#ff0000")
+        .arg("--colors=gutter-foreground=#00ff00")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;0;255;0m   1"))
+        .stdout(predicate::str::contains("38;2;255;0;0").not());
+}
+
+#[test]
+fn color_override_accepts_the_short_hex_notation() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=numbers")
+        .arg("--colors=gutter-foreground=#f00")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;2;255;0;0m   1"));
+}
+
+#[test]
+fn color_override_uses_the_ansi_palette_without_true_color_support() {
+    bat()
+        .env_remove("COLORTERM")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=always")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=numbers")
+        .arg("--colors=gutter-foreground=#ff0000")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B[38;5;196m   1"));
+}
+
+#[test]
+fn color_override_is_ignored_without_colored_output() {
+    bat()
+        .env("COLORTERM", "truecolor")
+        .arg("--theme=TwoDark")
+        .arg("--paging=never")
+        .arg("--color=never")
+        .arg("--terminal-width=80")
+        .arg("--wrap=never")
+        .arg("--decorations=always")
+        .arg("--style=plain")
+        .arg("--colors=foreground=#0000ff")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success()
+        .stdout("Lorem Ipsum")
+        .stderr("");
+}
+
+#[test]
+fn color_override_rejects_invalid_specifications() {
+    // A valid specification is accepted, so that the rejections below cannot be
+    // satisfied by refusing every specification.
+    bat()
+        .arg("--paging=never")
+        .arg("--colors=gutter-foreground=#ff0000")
+        .write_stdin("Lorem Ipsum")
+        .assert()
+        .success();
+
+    for spec in [
+        // Unknown targets.
+        "gutter-forground=#ff0000",
+        "=#ff0000",
+        "scope:=#ff0000",
+        // Invalid colors.
+        "gutter-foreground=nope",
+        "gutter-foreground=#ff00",
+        "gutter-foreground=#gggggg",
+        "gutter-foreground=",
+        // Malformed specifications.
+        "gutter-foreground",
+        "#ff0000",
+    ] {
+        bat()
+            .arg("--paging=never")
+            .arg(format!("--colors={spec}"))
+            .write_stdin("Lorem Ipsum")
+            .assert()
+            .failure();
+    }
+}


### PR DESCRIPTION
Changing the color of the line numbers or of comments currently means copying a whole theme file and rebuilding the cache. Let those colors be overridden directly:

    bat --colors 'gutter-foreground=#f5f5f5,scope:comment=#808080'

Overriding a scope rewrites the theme's own rules rather than appending one, because syntect resolves a style by specificity: a rule for 'comment' would otherwise be outranked by a rule the theme already defines for 'comment.line.double-slash'. Where a theme colors several scopes with a single rule, only the overridden selectors are split out, so overriding 'comment' leaves 'punctuation.definition.comment' alone.

The theme is now resolved once in the Controller instead of per input, and only when something is actually highlighted, so that plain 'cat' mode keeps not looking it up.

Closes #339