### PR TITLE
Fix capacity-overflow panic wrapping a wide char in a narrow terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)
+- Fix `capacity overflow` panic when character-wrapping a line containing a glyph wider than the terminal with a painted background (e.g. `--terminal-width=1 --wrap=character` on a double-width char). Closes #3844, see #3847 (@leeewee)
 - Pass `--no-paging` to `bat` invocations inside the bash / zsh / fish / PowerShell shell completion scripts so that shell-level pager wiring (e.g. `LESSOPEN='|-bat -f -pp %s'`) cannot inject ANSI escape sequences into the completion candidates. Closes #3760 (@mvanhorn)
 - Quote filenames before substituting them into `$LESSOPEN` / `$LESSCLOSE` templates, preventing shell injection when a filename contains shell metacharacters, see #3726 (@curious-rabbit)
 - Fix `--list-themes` unconditionally probing the terminal via OSC 10/11 even when `--theme` was set to an explicit value, see #3700 (regression introduced in bc42149a). (@optimistiCli)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -819,7 +819,7 @@ impl Printer for InteractivePrinter<'_> {
                             let text = self
                                 .preprocess(text.trim_end_matches(['\r', '\n']), &mut cursor_total);
 
-                            let mut max_width = cursor_max - cursor;
+                            let mut max_width = cursor_max.saturating_sub(cursor);
 
                             // line buffer (avoid calling write! for every character)
                             let mut line_buf = String::with_capacity(max_width * 4);
@@ -958,7 +958,7 @@ impl Printer for InteractivePrinter<'_> {
                 write!(
                     handle,
                     "{}",
-                    ansi_style.paint(" ".repeat(cursor_max - cursor))
+                    ansi_style.paint(" ".repeat(cursor_max.saturating_sub(cursor)))
                 )?;
             }
             writeln!(handle)?;


### PR DESCRIPTION
Fixes #3844.

### Problem

`bat --wrap character --terminal-width 1` aborts with `capacity overflow` (exit 101) when a line contains a glyph wider than the terminal (a double-width CJK char or emoji) **and** a background is painted on the line (e.g. `--highlight-line`, or a theme/style that fills the row).

```console
$ printf '📦📦\n' | bat --highlight-line 1 --terminal-width 1 --wrap character \
                      --color always --paging never --theme OneHalfDark
thread 'main' panicked at library/alloc/src/slice.rs:524:23:
capacity overflow
```

ASCII (width-1) input never exceeds the terminal width, so it prints fine — only a glyph wider than the terminal triggers it.

### Cause

In the character-wrapping path, `cursor` accumulates each chunk's display width and can overshoot `cursor_max` (the terminal width) when a glyph is wider than the remaining space. The end-of-line background fill then computes `" ".repeat(cursor_max - cursor)`, a `usize` subtraction that underflows to ~`usize::MAX` and aborts inside `str::repeat`.

### Fix

Use `cursor_max.saturating_sub(cursor)` so an overshoot clamps the fill to empty. The same underflow is reachable at the start of a following chunk whose predecessor already overshot, so the sibling subtraction is guarded too. This is identical to `-` whenever `cursor <= cursor_max`, so there is no behavior change otherwise.
