### PR TITLE
Fix huge `--line-range` offset-from-end panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ## Bugfixes
 - Fix `--list-languages` respecting `--paging=never`, see #3828 (@cyphercodes)
 - Fix `--sanitize` passing through the bidi control characters U+200E, U+200F and U+061C, see #3862 (@lenamonj)
+- Prevent `--line-range=:-N` from panicking when `N` is a very large offset. Closes #3845 (@xenoninja)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ## Bugfixes
 - Fix `--list-languages` respecting `--paging=never`, see #3828 (@cyphercodes)
 - Fix `--sanitize` passing through the bidi control characters U+200E, U+200F and U+061C, see #3862 (@lenamonj)
-- Prevent `--line-range=:-N` from panicking when `N` is a very large offset. Closes #3845 (@xenoninja)
+- Prevent `--line-range=:-N` from panicking when `N` is a very large offset. Closes #3845, see #3848 (@xenoninja)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -259,9 +259,9 @@ impl Controller<'_> {
         let mut current_line_buffer: Vec<u8> = Vec::new();
         let mut current_line_number: usize = 1;
         // Buffer needs to be 1 greater than the offset to have a look-ahead line for EOF
-        let buffer_size: usize = line_ranges.largest_offset_from_end() + 1;
-        // Buffers multiple line data and line number
-        let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::with_capacity(buffer_size);
+        let buffer_size = line_ranges.largest_offset_from_end().saturating_add(1);
+        // Grow the buffer with the input instead of reserving a user-provided offset up front.
+        let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::new();
 
         let mut reached_eof: bool = false;
         let mut first_range: bool = true;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -244,6 +244,18 @@ fn line_range_up_to_2_from_back_single_line_is_empty() {
 }
 
 #[test]
+fn line_range_offset_from_end_does_not_preallocate_offset() {
+    for offset in [usize::MAX - 1, usize::MAX] {
+        bat()
+            .arg("multiline.txt")
+            .arg(format!("--line-range=:-{offset}"))
+            .assert()
+            .success()
+            .stdout("");
+    }
+}
+
+#[test]
 fn line_range_from_back_last_two() {
     bat()
         .arg("multiline.txt")


### PR DESCRIPTION
When an offset-from-end line range used a very large value (for example, `--line-range=:-18446744073709551614`), `print_file_ranges` added one to the parsed `usize` and passed the result directly to `VecDeque::with_capacity`. This either triggered a capacity overflow while allocating or overflowed the addition itself.

Use saturating arithmetic for the look-ahead buffer size and let the `VecDeque` grow with the input instead of reserving the user-provided offset up front. This preserves existing range behavior while making memory usage depend on the actual input; offsets beyond the input now produce an empty range instead of panicking.

Add an integration test covering both `usize::MAX - 1` and `usize::MAX` offsets.

Closes #3845.