### PR TITLE
Fix cache subcommand detection when cache directory exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Keep the `cache` subcommand available when a `cache` directory exists in the working directory, see #3850 (@zhangli091011)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -721,7 +721,7 @@ pub fn build_app(interactive_output: bool) -> Command {
 
     // Check if the current directory contains a file name cache. Otherwise,
     // enable the 'bat cache' subcommand.
-    if Path::new("cache").exists() {
+    if Path::new("cache").is_file() {
         app
     } else {
         app.subcommand(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1970,6 +1970,29 @@ fn can_print_file_named_cache_with_additional_argument() {
 }
 
 #[test]
+fn cache_directory_does_not_hide_cache_subcommand() {
+    let tmp_dir = tempdir().expect("can create temporary directory");
+    let cache_dir = tmp_dir.path().join("cache");
+    std::fs::create_dir(&cache_dir).expect("can create cache directory");
+    let theme_cache = cache_dir.join("themes.bin");
+    std::fs::write(&theme_cache, []).expect("can create theme cache");
+
+    bat_with_config()
+        .current_dir(tmp_dir.path())
+        .arg("cache")
+        .arg("--clear")
+        .arg("--target")
+        .arg(&cache_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Clearing theme set cache ... okay",
+        ));
+
+    assert!(!theme_cache.exists());
+}
+
+#[test]
 fn can_print_file_starting_with_cache() {
     bat_with_config()
         .arg("cache.c")


### PR DESCRIPTION
## Summary

- keep the hidden `cache` subcommand enabled when `./cache` is a directory
- continue treating a regular file named `cache` as input for cat compatibility
- add a deterministic integration test that clears an artifact from a `cache` directory in the working directory

Fixes #1726.

PR #3743 previously proposed the same production fix but was closed unmerged by its author. This version uses a smaller, cross-platform regression test and follows the current changelog workflow.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --test integration_tests cache_`
- `cargo test --test integration_tests can_print_file_named_cache -- --exact`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`

## AI Assistance

This change was implemented with AI assistance. The issue state, repository policies, code, diff, and test results were reviewed by the submitter before submission.