### PR TITLE
Fix capacity overflow panic for huge --line-range offset-from-end

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -258,10 +258,17 @@ impl Controller<'_> {
     ) -> Result<()> {
         let mut current_line_buffer: Vec<u8> = Vec::new();
         let mut current_line_number: usize = 1;
-        // Buffer needs to be 1 greater than the offset to have a look-ahead line for EOF
-        let buffer_size: usize = line_ranges.largest_offset_from_end() + 1;
-        // Buffers multiple line data and line number
-        let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::with_capacity(buffer_size);
+        // Buffer needs to be 1 greater than the offset to have a look-ahead line for EOF.
+        // saturating_add prevents overflow when the offset is near usize::MAX.
+        let offset = line_ranges.largest_offset_from_end();
+        let buffer_size: usize = offset.saturating_add(1);
+        // Buffers multiple line data and line number.
+        // try_reserve reports a clear error instead of aborting with capacity overflow
+        // when the --line-range offset is huge (e.g. :-18446744073709551614).
+        let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::new();
+        buffered_lines.try_reserve(buffer_size).map_err(|_| {
+            format!("--line-range offset from end ({offset}) is too large to buffer")
+        })?;
 
         let mut reached_eof: bool = false;
         let mut first_range: bool = true;


### PR DESCRIPTION
## Summary

`bat --line-range :-N` with `N` near `usize::MAX` aborted with `capacity overflow` (exit 101) instead of reporting an error:

```console
$ printf 'l1\nl2\n' | bat --no-config --paging=never --line-range ':-18446744073709551614' -
thread 'main' panicked at src/controller.rs:264:62:
capacity overflow
$ echo $?
101
```

Two bugs combined to cause this:

1. `largest_offset_from_end() + 1` in `controller.rs:262` overflowed `usize` when the offset was `usize::MAX`.
2. `VecDeque::with_capacity(usize::MAX)` aborted with *capacity overflow* for the `usize::MAX - 1` case.

## Fix

- Replace the plain `+ 1` with `saturating_add(1)` to prevent integer overflow.
- Replace `VecDeque::with_capacity` with `VecDeque::new()` + `try_reserve`, which returns an error instead of panicking when the requested capacity can't be represented.

After the fix:
```console
$ printf 'l1\nl2\n' | bat --no-config --paging=never --line-range ':-18446744073709551614' -
[bat error]: --line-range offset from end (18446744073709551614) is too large to buffer
$ echo $?
1
```

Normal `:-N` ranges continue to work unchanged.

Fixes #3845