### PR TITLE
docs: fix broken relative links in translated READMEs

### DIFF
--- a/doc/README-ja.md
+++ b/doc/README-ja.md
@@ -172,7 +172,7 @@ man 2 select
 
 これを新しいコマンドにバンドルしたい場合は [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md) も使用できます。
 
-[Manpage syntax](assets/syntaxes/Manpage.sublime-syntax) はこのリポジトリで開発されており、まだ作業が必要であることに注意してください。
+[Manpage syntax](../assets/syntaxes/02_Extra/Manpage.sublime-syntax) はこのリポジトリで開発されており、まだ作業が必要であることに注意してください。
 
 #### `prettier` / `shfmt` / `rustfmt`
 

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -200,7 +200,7 @@ man 2 select
 [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md)을 쓸
 수도 있습니다. 
 
-참고로 [Manpage 문법](../assets/syntaxes/Manpage.sublime-syntax)은 본 저장소에서
+참고로 [Manpage 문법](../assets/syntaxes/02_Extra/Manpage.sublime-syntax)은 본 저장소에서
 개발 중에 있으며, 아직 더 손봐야 합니다.
 
 또한, 이는 Mandoc의 `man` 구현에서

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -176,7 +176,7 @@ man 2 select
 
 Если вы хотите сделать этой одной командой, вы можете использовать [`batman`](https://github.com/eth-p/bat-extras/blob/master/doc/batman.md).
 
-Обратите внимание, что [синтаксис manpage](assets/syntaxes/02_Extra/Manpage.sublime-syntax) разрабатывается в этом репозитории и все еще находится в разработке.
+Обратите внимание, что [синтаксис manpage](../assets/syntaxes/02_Extra/Manpage.sublime-syntax) разрабатывается в этом репозитории и все еще находится в разработке.
 
 Также заметьте, что это [не заработает](https://github.com/sharkdp/bat/issues/1145) с реализацией `man` через Mandocs.
 
@@ -640,11 +640,11 @@ cargo install --locked --force
 - Полноценная замена `cat`.
 - Дружелюбный интерфейс и аргументы.
 
-Есть очень много альтернатив `bat`. Смотрите [этот документ](doc/alternatives.md) для сравнения.
+Есть очень много альтернатив `bat`. Смотрите [этот документ](alternatives.md) для сравнения.
 
 ## Лицензия
 Copyright (c) 2018-2024 [Разработчики bat](https://github.com/sharkdp/bat).
 
 `bat` распространяется под лицензиями MIT License и Apache License 2.0 (на выбор пользователя).
 
-Смотрите [LICENSE-APACHE](LICENSE-APACHE) и [LICENSE-MIT](LICENSE-MIT) для более подробного ознакомления.
+Смотрите [LICENSE-APACHE](../LICENSE-APACHE) и [LICENSE-MIT](../LICENSE-MIT) для более подробного ознакомления.

--- a/doc/README-zh.md
+++ b/doc/README-zh.md
@@ -186,7 +186,7 @@ man 2 select
 >
 > 请使用 `batman`，或将此 Shell 脚本包装为 [Shebang 可执行文件](https://en.wikipedia.org/wiki/Shebang_(Unix))，并将 `MANPAGER` 指向该文件。
 
-注意，[Manpage 语法](assets/syntaxes/02_Extra/Manpage.sublime-syntax)是在此仓库中开发的，仍需一些改进。
+注意，[Manpage 语法](../assets/syntaxes/02_Extra/Manpage.sublime-syntax)是在此仓库中开发的，仍需一些改进。
 
 #### `prettier` / `shfmt` / `rustfmt`
 
@@ -448,7 +448,7 @@ bat --list-themes | fzf --preview="bat --theme={} --color=always /path/to/file"
    bat cache --clear
    ```
 
-4. 如果你觉得`bat`有必要自带该语法支持，请在阅读[指导](doc/assets.md)后向仓库提交 [Syntax Request](https://github.com/sharkdp/bat/issues/new?labels=syntax-request&template=syntax_request.md)。
+4. 如果你觉得`bat`有必要自带该语法支持，请在阅读[指导](assets.md)后向仓库提交 [Syntax Request](https://github.com/sharkdp/bat/issues/new?labels=syntax-request&template=syntax_request.md)。
 
 ### 添加主题
 
@@ -644,7 +644,7 @@ cargo install --path . --locked --force
 
 ## 贡献指南
 
-请查看 [`CONTRIBUTING.md`](CONTRIBUTING.md) 指南。
+请查看 [`CONTRIBUTING.md`](../CONTRIBUTING.md) 指南。
 
 ## 维护者
 
@@ -666,7 +666,7 @@ cargo install --path . --locked --force
 - 成为 (POSIX) `cat` 的替代品
 - 提供用户友好的命令行界面
 
-如果你在寻找类似的程序，有很多替代方案。请参阅[本文档](doc/alternatives.md)进行比较。
+如果你在寻找类似的程序，有很多替代方案。请参阅[本文档](alternatives.md)进行比较。
 
 ## 许可证
 
@@ -674,4 +674,4 @@ cargo install --path . --locked --force
 
 `bat` 可根据 MIT 许可证或 Apache 许可证 2.0 的条款使用，任选其一。
 
-有关许可证的详细信息，请参阅 [LICENSE-APACHE](LICENSE-APACHE) 和 [LICENSE-MIT](LICENSE-MIT) 文件。
+有关许可证的详细信息，请参阅 [LICENSE-APACHE](../LICENSE-APACHE) 和 [LICENSE-MIT](../LICENSE-MIT) 文件。


### PR DESCRIPTION
The translated READMEs (`doc/README-ja.md`, `-ko.md`, `-ru.md`, `-zh.md`) live one directory deeper than the English `README.md`, but several links were copied over without adjusting for that, so they 404 when viewed on GitHub:

- **Manpage syntax** (ja, ko, ru, zh) — dropped the `02_Extra/` path component and/or the `../` prefix; the file is at `assets/syntaxes/02_Extra/Manpage.sublime-syntax`
- **`doc/alternatives.md` / `doc/assets.md`** (ru, zh) — resolved to `doc/doc/...`; corrected to `alternatives.md` / `assets.md`
- **`CONTRIBUTING.md`, `LICENSE-APACHE`, `LICENSE-MIT`** (ru, zh) — pointed inside `doc/` instead of the repository root; corrected to `../…`

The translations were already inconsistent (ko had `../` but the wrong `02_Extra`; ru/zh had `02_Extra` but no `../`), which is what surfaced this.

## Verification

Resolved every relative link in all `doc/README-*.md` against the filesystem before and after: the four files had 12 broken links; after the change **0 remain**, and no other translated README is affected. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)