### PR TITLE
fix(list-themes): ignore BAT_OPTS paging

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -207,6 +207,8 @@ pub fn list_themes(
 ) -> Result<()> {
     let assets = assets_from_cache_or_binary(cfg.use_custom_assets, cache_dir)?;
     let mut config = cfg.clone();
+    // `--list-themes` should always print directly, even if config requests a pager.
+    config.paging_mode = PagingMode::Never;
     let mut style = HashSet::new();
     style.insert(StyleComponent::Plain);
     config.language = Some("Rust");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -25,7 +25,7 @@ mod unix {
 use unix::*;
 
 mod utils;
-use utils::command::{bat, bat_with_config};
+use utils::command::{bat, bat_raw_command_with_config, bat_with_config};
 
 #[cfg(unix)]
 use utils::command::bat_raw_command;
@@ -613,6 +613,21 @@ fn list_themes_without_colors() {
         .stdout(predicate::str::contains("DarkNeon").normalize())
         .stdout(predicate::str::contains(default_theme_chunk).normalize())
         .stdout(predicate::str::contains(default_light_theme_chunk).normalize());
+}
+
+#[test]
+fn list_themes_ignores_bat_opts_paging() {
+    let mut cmd = bat_raw_command_with_config();
+    cmd.env(
+        "BAT_OPTS",
+        "--paging=always --pager='echo pager-output' --theme=TwoDark",
+    );
+
+    cmd.arg("--list-themes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DarkNeon").normalize())
+        .stdout(predicate::str::contains("pager-output").not());
 }
 
 #[test]


### PR DESCRIPTION
Closes #1618

For --list-themes, force paging mode to Never so BAT_OPTS cannot send theme output through a pager.

Verification:
- Source review only in this environment; cargo is not installed here.