### PR TITLE
Reject huge line-range offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Reject huge `--line-range` offset-from-end values before allocating buffer, see #3860 (@vigneshakaviki)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)
 - Fix `--ignored-suffix` not falling back to first-line/shebang detection when the ignored suffix is also a registered extension (e.g. `--ignored-suffix .txt` on a shebang script), see #2745 and #3816 (@adnrivera)
 - Fix `capacity overflow` panic when printing a snip separator at `--terminal-width=1` with multiple line ranges. Closes #3803, see #3804 (@leeewee)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -259,7 +259,10 @@ impl Controller<'_> {
         let mut current_line_buffer: Vec<u8> = Vec::new();
         let mut current_line_number: usize = 1;
         // Buffer needs to be 1 greater than the offset to have a look-ahead line for EOF
-        let buffer_size: usize = line_ranges.largest_offset_from_end() + 1;
+        let buffer_size: usize = line_ranges
+            .largest_offset_from_end()
+            .checked_add(1)
+            .ok_or("Line range offset from end is too large")?;
         // Buffers multiple line data and line number
         let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::with_capacity(buffer_size);
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -263,6 +263,9 @@ impl Controller<'_> {
             .largest_offset_from_end()
             .checked_add(1)
             .ok_or("Line range offset from end is too large")?;
+        if buffer_size == usize::MAX {
+            return Err("Line range offset from end is too large".into());
+        }
         // Buffers multiple line data and line number
         let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::with_capacity(buffer_size);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -450,6 +450,18 @@ fn line_range_context_very_large() {
 }
 
 #[test]
+fn line_range_offset_from_end_too_large_fails_cleanly() {
+    let too_large = format!(":-{}", usize::MAX - 1);
+
+    bat()
+        .arg("multiline.txt")
+        .arg(format!("--line-range={too_large}"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Line range offset from end is too large"));
+}
+
+#[test]
 fn piped_output_with_implicit_auto_style() {
     bat()
         .write_stdin("hello\nworld\n")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -458,7 +458,9 @@ fn line_range_offset_from_end_too_large_fails_cleanly() {
         .arg(format!("--line-range={too_large}"))
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Line range offset from end is too large"));
+        .stderr(predicate::str::contains(
+            "Line range offset from end is too large",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #3845.

Prevent line-range offset-from-end from overflowing buffer sizing and aborting in VecDeque::with_capacity.

Changes:
- use checked_add(1) for buffer sizing
- return a normal error when offset is too large
- add regression test for huge offset-from-end input