### PR TITLE
chore(deps): resolve current cargo audit failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1178,7 +1178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2016,9 +2016,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -2130,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Summary

Update the lockfile to resolve the current `cargo audit` failures:

- `crossbeam-epoch` 0.9.18 → 0.9.20 fixes `RUSTSEC-2026-0204`
- `plist` 1.9.0 → 1.10.0 permits `quick-xml` 0.39.4 → 0.41.0, fixing `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195`
- `anyhow` 1.0.102 → 1.0.103 removes the `RUSTSEC-2026-0190` unsoundness warning

This keeps dependency resolution changes in `Cargo.lock` and adds a small changelog entry. It does not change dependency requirements, advisory ignores, source code, or Dependabot configuration.

After this merges, rebasing #3857 onto `master` will remove its baseline `cargo audit` failure. That PR's separate formatting failure will still need to be fixed there.

## Verification

- `git diff --check`
- `cargo fmt -- --check`
- `cargo audit` (passes with only the existing allowed `bincode`, `proc-macro-error2`, and `memmap2` warnings)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked`
- GitHub CICD (`cargo audit`, code quality, tests, documentation, MSRV, all platform builds, and `all-jobs`)

`plist` 1.10.0 declares Rust 1.88.0; the repository's MSRV CI job passes against bat's Rust 1.88 minimum.

The changelog entry follows the manual RustSec update precedent in #3581.
