### PR TITLE
chore(deps): group Cargo minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
     interval: monthly
     time: "04:00"
     timezone: Europe/Berlin
+  groups:
+    cargo-minor-patch:
+      applies-to: version-updates
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
   ignore:
   - dependency-name: git2
     versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- Group Cargo minor and patch Dependabot version updates to reduce lockfile conflicts, see #3863 (@TyceHerrman)
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)


### PR DESCRIPTION
## Summary

- group Cargo minor and patch version updates into one Dependabot pull request per run
- keep positional major and security updates outside this version-update group
- preserve the existing `git2` ignore without adding `versioning-strategy` or other update restrictions

## Rationale

The July Dependabot run opened #3819, #3820, #3821, #3822, and #3823 as separate pull requests that all modified `Cargo.lock`. They had to merge serially with repeated rebases and CI runs. Grouping future Cargo minor and patch updates reduces those lockfile conflicts and repeated CI work without suppressing eligible updates.

## Verification

- `git diff --check`
- parsed `.github/dependabot.yml` and asserted the exact group and existing ignore with Ruby YAML
- `cargo fmt -- --check`
- `cargo test --locked`
- confirmed the final diff changes only `.github/dependabot.yml` and `CHANGELOG.md`
