### PR TITLE
Fix usize underflow panic with wide chars at --terminal-width 1

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -258,10 +258,17 @@ impl Controller<'_> {
     ) -> Result<()> {
         let mut current_line_buffer: Vec<u8> = Vec::new();
         let mut current_line_number: usize = 1;
-        // Buffer needs to be 1 greater than the offset to have a look-ahead line for EOF
-        let buffer_size: usize = line_ranges.largest_offset_from_end() + 1;
-        // Buffers multiple line data and line number
-        let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::with_capacity(buffer_size);
+        // Buffer needs to be 1 greater than the offset to have a look-ahead line for EOF.
+        // saturating_add prevents overflow when the offset is near usize::MAX.
+        let offset = line_ranges.largest_offset_from_end();
+        let buffer_size: usize = offset.saturating_add(1);
+        // Buffers multiple line data and line number.
+        // try_reserve reports a clear error instead of aborting with capacity overflow
+        // when the --line-range offset is huge (e.g. :-18446744073709551614).
+        let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::new();
+        buffered_lines.try_reserve(buffer_size).map_err(|_| {
+            format!("--line-range offset from end ({offset}) is too large to buffer")
+        })?;
 
         let mut reached_eof: bool = false;
         let mut first_range: bool = true;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -819,7 +819,7 @@ impl Printer for InteractivePrinter<'_> {
                             let text = self
                                 .preprocess(text.trim_end_matches(['\r', '\n']), &mut cursor_total);
 
-                            let mut max_width = cursor_max - cursor;
+                            let mut max_width = cursor_max.saturating_sub(cursor);
 
                             // line buffer (avoid calling write! for every character)
                             let mut line_buf = String::with_capacity(max_width * 4);
@@ -958,7 +958,7 @@ impl Printer for InteractivePrinter<'_> {
                 write!(
                     handle,
                     "{}",
-                    ansi_style.paint(" ".repeat(cursor_max - cursor))
+                    ansi_style.paint(" ".repeat(cursor_max.saturating_sub(cursor)))
                 )?;
             }
             writeln!(handle)?;


### PR DESCRIPTION
## Summary

`bat --terminal-width 1 --wrap character` aborted with `capacity overflow` (exit 101) when a line contained a double-width character (CJK/emoji) **and** a background was painted on that line:

```console
$ printf '📦📦\n' | bat --highlight-line 1 --terminal-width 1 --wrap character \
                       --color always --paging never --theme OneHalfDark
thread 'main' panicked at library/alloc/src/slice.rs:524:23:
capacity overflow
$ echo $?
101
```

## Root Cause

`cursor` accumulates the display width of each chunk. With `--terminal-width 1`, `cursor_max = 1`. A double-width character (display width 2) makes `cursor = 2 > cursor_max = 1`.

Two sites then performed unchecked `cursor_max - cursor` subtraction:

- `printer.rs:822`: `let mut max_width = cursor_max - cursor;` — used to size the text chunk buffer
- `printer.rs:934`: `" ".repeat(cursor_max - cursor)` — used to fill the end-of-line background

Both wrap to `~usize::MAX`, and `" ".repeat(~usize::MAX)` aborts with `capacity overflow`. 

(This is the same defect class as the `--style=snip` width-1 panic in #3803.)

## Fix

Use `saturating_sub` at both sites so an overshot cursor yields a fill/buffer width of 0, matching the guard already applied at `printer.rs:789`.

Fixes #3844