### PR TITLE
fix(syntax): avoid repeated log level scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Avoid repeated scans of long lines in Log syntax highlighting, see #3876 (@Matei02355)
 - Fix `--list-languages` respecting `--paging=never`, see #3828 (@cyphercodes)
 - Fix `--sanitize` passing through the bidi control characters U+200E, U+200F and U+061C, see #3862 (@lenamonj)
 - `--strip-ansi`: also strip 8-bit C1 introducers (U+0090, U+0098, U+009B, U+009D, U+009E, U+009F) and DCS/SOS/PM/APC sequence bodies, which previously passed through. See #3729 (@curious-rabbit)

--- a/assets/syntaxes/02_Extra/log.sublime-syntax
+++ b/assets/syntaxes/02_Extra/log.sublime-syntax
@@ -55,6 +55,24 @@ contexts:
       push:
         - debug_line_meta
         - main_pop_at_eol
+  # For syntaxes that embed Log after consuming a prefix. Call this context once.
+  log_level_lines_at_current_position:
+    - match: (?=.*{{error}})
+      set:
+        - error_line_meta
+        - main_pop_at_eol
+    - match: (?=.*{{warning}})
+      set:
+        - warning_line_meta
+        - main_pop_at_eol
+    - match: (?=.*{{info}})
+      set:
+        - info_line_meta
+        - main_pop_at_eol
+    - match: (?=.*{{debug}})
+      set:
+        - debug_line_meta
+        - main_pop_at_eol
   log_levels:
     - match: '{{error}}'
       scope: markup.error.log

--- a/assets/syntaxes/02_Extra/log.sublime-syntax
+++ b/assets/syntaxes/02_Extra/log.sublime-syntax
@@ -38,19 +38,20 @@ contexts:
       scope: markup.underline.link.scheme.log
       push: url-host
   log_level_lines:
-    - match: (?=.*{{error}})
+    # Prevent retrying each lookahead at every position.
+    - match: \G(?=.*{{error}})
       push:
         - error_line_meta
         - main_pop_at_eol
-    - match: (?=.*{{warning}})
+    - match: \G(?=.*{{warning}})
       push:
         - warning_line_meta
         - main_pop_at_eol
-    - match: (?=.*{{info}})
+    - match: \G(?=.*{{info}})
       push:
         - info_line_meta
         - main_pop_at_eol
-    - match: (?=.*{{debug}})
+    - match: \G(?=.*{{debug}})
       push:
         - debug_line_meta
         - main_pop_at_eol

--- a/assets/syntaxes/02_Extra/log.sublime-syntax
+++ b/assets/syntaxes/02_Extra/log.sublime-syntax
@@ -39,19 +39,19 @@ contexts:
       push: url-host
   log_level_lines:
     # Prevent retrying each lookahead at every position.
-    - match: \G(?=.*{{error}})
+    - match: ^(?=.*{{error}})
       push:
         - error_line_meta
         - main_pop_at_eol
-    - match: \G(?=.*{{warning}})
+    - match: ^(?=.*{{warning}})
       push:
         - warning_line_meta
         - main_pop_at_eol
-    - match: \G(?=.*{{info}})
+    - match: ^(?=.*{{info}})
       push:
         - info_line_meta
         - main_pop_at_eol
-    - match: \G(?=.*{{debug}})
+    - match: ^(?=.*{{debug}})
       push:
         - debug_line_meta
         - main_pop_at_eol

--- a/assets/syntaxes/02_Extra/syslog.sublime-syntax
+++ b/assets/syntaxes/02_Extra/syslog.sublime-syntax
@@ -50,6 +50,17 @@ contexts:
     - match: (?=\])
       pop: true
   text:
+    - include: text_special
+    - match: ''
+      set: classify_log_text
+  classify_log_text:
+    - include: scope:text.log#log_level_lines_at_current_position
+    - match: ''
+      set: text_body
+  text_body:
+    - include: text_special
+    - include: scope:text.log
+  text_special:
     - match: $
       pop: true
     - match: '<\w+>'
@@ -62,4 +73,3 @@ contexts:
       escape: \)$
       escape_captures:
         0: punctuation.section.block.end.syslog
-    - include: scope:text.log


### PR DESCRIPTION
## Summary

- prevent log-level lookaheads from being retried at every character
- use `^` for normal Log lines and classify embedded Syslog messages once
- keep Sublime Text on its custom regex engine while preserving existing highlighting
- fix the severe slowdown reported in #3866

## Root cause

The Log syntax uses zero-width lookaheads to apply a meta scope to an entire line when it contains an error, warning, info, or debug marker. When a lookahead failed, the regex engine retried it at every later character, repeatedly scanning the remainder of long lines.

For normal Log files, anchoring each lookahead with `^` prevents those futile retries. Syslog enters the Log syntax after consuming its prefix, so it invokes a dedicated unanchored context exactly once at the start of the message. This preserves the existing line-wide scopes without using `\G`, which would make Sublime Text fall back to Oniguruma.

## Performance

Using the reporter's 573,835-byte, 3,193-line attachment with the v0.26.1 release binary:

- before: 50.923 seconds
- after: 0.169 seconds

That is approximately a 300× speedup.

## Validation

- `cargo test --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- rebuilt a syntax cache; existing Log and Syslog highlighted fixtures are byte-identical to the baseline
- verified Syslog error, warning, info, debug, structured-data, and `CMD` precedence cases against the original syntax

Fixes #3866.