### PR TITLE
fix: do not page --list-themes output

### DIFF
--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -207,6 +207,9 @@ pub fn list_themes(
 ) -> Result<()> {
     let assets = assets_from_cache_or_binary(cfg.use_custom_assets, cache_dir)?;
     let mut config = cfg.clone();
+    // Meta-command: never page theme listings. Config/BAT_OPTS often set
+    // --paging=always, which made --list-themes unusable (see #1618).
+    config.paging_mode = PagingMode::Never;
     let mut style = HashSet::new();
     style.insert(StyleComponent::Plain);
     config.language = Some("Rust");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -625,6 +625,25 @@ fn list_themes_to_piped_output() {
     );
 }
 
+/// Regression for #1618: BAT_OPTS=--paging=always must not break --list-themes.
+#[test]
+#[serial]
+fn list_themes_ignores_paging_always_from_bat_opts() {
+    mocked_pagers::with_mocked_versions_of_more_and_most_in_path(|| {
+        bat()
+            .env("BAT_OPTS", "--paging=always --theme=TwoDark")
+            .env("PAGER", mocked_pagers::from("echo pager-output"))
+            .arg("--list-themes")
+            .arg("--color=never")
+            .arg("--decorations=always")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("DarkNeon").normalize())
+            .stdout(predicate::str::contains("TwoDark").normalize())
+            .stdout(predicate::str::contains("pager-output").not());
+    });
+}
+
 #[test]
 #[serial]
 fn list_languages() {


### PR DESCRIPTION
## Summary
When `BAT_OPTS` (or the config file) includes `--paging=always`, `bat --list-themes` became unusable — the theme list was forced through the pager and theme names were hard or impossible to see.

## Changes
- Force `PagingMode::Never` inside `list_themes` so this meta-command always prints the full list in one shot
- Integration test: `BAT_OPTS=--paging=always` still lists theme names and does not invoke the pager

Fixes #1618

## Test plan
- [ ] `BAT_OPTS='--paging=always --pager=less' bat --list-themes` prints theme names without entering less
- [ ] Existing `list_themes_*` integration tests pass
- [ ] New regression test `list_themes_ignores_paging_always_from_bat_opts` passes