### PR TITLE
CI: pin actions to commit SHAs and declare workflow permissions

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,5 +1,8 @@
 name: CICD
 
+permissions:
+  contents: read
+
 env:
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
   MSRV_FEATURES: --no-default-features --features minimal-application,bugreport,build-assets
@@ -183,6 +186,9 @@ jobs:
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest , dpkg_arch: musl-linux-amd64, use-cross: true }
     env:
       BUILD_CMD: cargo
+    permissions:
+      # Publish the release archives and packages on tag builds.
+      contents: write
     steps:
     - name: Checkout source code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -35,7 +35,7 @@ jobs:
     name: Extract crate metadata
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Extract crate information
       id: crate_metadata
       run: |
@@ -55,10 +55,11 @@ jobs:
     name: Ensure code quality
     runs-on: ubuntu-latest
     steps:
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
+        toolchain: stable
         components: rustfmt,clippy
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - run: cargo fmt -- --check
     - run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
@@ -68,9 +69,9 @@ jobs:
     needs: crate_metadata
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Install rust toolchain (v${{ needs.crate_metadata.outputs.msrv }})
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
         toolchain: ${{ needs.crate_metadata.outputs.msrv }}
     - name: Run tests
@@ -80,7 +81,7 @@ jobs:
     name: License checks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         submodules: true # we especially want to perform license checks on submodules
     - run: tests/scripts/license-checks.sh
@@ -90,11 +91,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         submodules: true # we need all syntax and theme submodules
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+      with:
+        toolchain: stable
     - name: Build and install bat
       run: cargo install --locked --path .
     - name: Rebuild binary assets (syntaxes and themes)
@@ -119,12 +122,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Prepare environment variables
       run: |
         echo "BAT_SYSTEM_CONFIG_PREFIX=$GITHUB_WORKSPACE/tests/examples/system_config" >> $GITHUB_ENV
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+      with:
+        toolchain: stable
     - name: Build and install bat
       run: cargo install --locked --path .
     - name: Run unit tests
@@ -135,9 +140,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+      with:
+        toolchain: stable
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings
@@ -150,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: cargo install cargo-audit --locked
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - run: cargo audit
 
   build:
@@ -178,7 +185,7 @@ jobs:
       BUILD_CMD: cargo
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Install prerequisites
       shell: bash
@@ -189,8 +196,9 @@ jobs:
         esac
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
+        toolchain: stable
         targets: ${{ matrix.job.target }}
 
     - name: Install cross
@@ -422,13 +430,13 @@ jobs:
         fakeroot dpkg-deb --build "${DPKG_DIR}" "${DPKG_PATH}"
 
     - name: "Artifact upload: tarball"
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.package.outputs.PKG_NAME }}
         path: ${{ steps.package.outputs.PKG_PATH }}
 
     - name: "Artifact upload: Debian package"
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: steps.debian-package.outputs.DPKG_NAME
       with:
         name: ${{ steps.debian-package.outputs.DPKG_NAME }}
@@ -442,7 +450,7 @@ jobs:
         echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
     - name: Publish archives and packages
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
       if: steps.is-release.outputs.IS_RELEASE
       with:
         files: |

--- a/.github/workflows/require-changelog-for-PRs.yml
+++ b/.github/workflows/require-changelog-for-PRs.yml
@@ -13,7 +13,7 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       PR_BASE: ${{ github.base_ref }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch PR base
         run: git fetch --no-tags --prune --depth=1 origin
 

--- a/.github/workflows/require-changelog-for-PRs.yml
+++ b/.github/workflows/require-changelog-for-PRs.yml
@@ -3,6 +3,9 @@ name: Changelog
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-changelog:
     name: Check for changelog entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- CI: pin GitHub Actions to commit SHAs and declare workflow permissions, see #3881 (@Totara-thib)
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)


### PR DESCRIPTION
Hi, drive-by CI hardening in two commits, one logical change each, found with the Plumber CLI (https://github.com/getplumber/plumber) and verified on master.

Commit 1 pins every action to its commit sha, versions kept as comments. A tag like @v2 or a branch like @master is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's credentials. The paths that matter here: the build job publishes the release archives people download while holding a contents write token, and the winget job runs with WINGET_TOKEN. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). You already pin winget-releaser by sha, this finishes the job in the same spirit. rust-toolchain's tags are toolchain names, so all six sites point at the same master commit and the toolchain moves to an explicit toolchain: input (stable where the tag implied it, your msrv site already had one), zero behavior change. Your dependabot config already covers the github-actions ecosystem, so the pins keep themselves bumped with the comments in sync.

Commit 2 scopes the GITHUB_TOKEN per workflow, derived from what each job actually uses: everything drops to contents: read, except the build job which keeps contents: write to publish the release archives on tag builds. The winget job pushes with its own token and the changelog check reads the public API unauthenticated, so neither needs anything.

One heads up: if an Actions allowlist is configured in settings, patterns written against tags (like owner/action@v2) stop matching once refs are shas and workflows refuse to start. Entries need the owner/action@* form.

A CHANGELOG entry is included per CONTRIBUTING. I will also open a PR which adds the tool to CI so this does not quietly drift back; that one is a bonus, this PR stands on its own.