### PR TITLE
CI: add Plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: getplumber/plumber@ce2d9603cc9faf10df2b76b276366104a61c68d0 # v0.4.31
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,23 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the toolchain, release
+      # and winget actions this repo already uses on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - dtolnay/rust-toolchain
+        - softprops/action-gh-release
+        - vedantmgoyal9/winget-releaser
+
+    # Off for now: the finding is rustup's own install script inside
+    # rust-toolchain, the standard way every Rust CI bootstraps a
+    # toolchain. Nothing repo-side to fix until upstream ships a
+    # checksummed install path.
+    actionsMustNotExecuteMutableRemoteCode:
+      enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Other
 
+- CI: add Plumber workflow security check, see #3882 (@Totara-thib)
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
   <img src="doc/logo-header.svg" alt="bat - a cat clone with wings"><br>
   <a href="https://github.com/sharkdp/bat/actions?query=workflow%3ACICD"><img src="https://github.com/sharkdp/bat/workflows/CICD/badge.svg" alt="Build Status"></a>
   <img src="https://img.shields.io/crates/l/bat.svg" alt="license">
-  <a href="https://crates.io/crates/bat"><img src="https://img.shields.io/crates/v/bat.svg?colorB=319e8c" alt="Version info"></a><br>
+  <a href="https://crates.io/crates/bat"><img src="https://img.shields.io/crates/v/bat.svg?colorB=319e8c" alt="Version info"></a>
+  <a href="https://score.getplumber.io/github.com/sharkdp/bat"><img src="https://score.getplumber.io/github.com/sharkdp/bat.svg" alt="plumber score"></a><br>
   A <i>cat(1)</i> clone with syntax highlighting and Git integration.
 </p>
 


### PR DESCRIPTION
Companion to https://github.com/sharkdp/bat/pull/3881, merge that one first: the check added here flags the unpinned actions and the missing permission scopes until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to master and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, an unverified remote script, that kind of thing. The gate passes at 85 of 100 points, so one small finding does not block your PRs.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the Security tab as SARIF (skipped on PRs from forks, the report stays as a workflow artifact there).
- `.plumber.yaml`: a small overlay that inherits the tool's built-in baseline; only what differs for this repo is written. The toolchain, release and winget actions already in use are trusted on top of the curated default source list, and one control is off with a comment because its only finding is rustup's own install script, which is how every Rust CI bootstraps. Everything else, including new controls in future releases, follows the defaults automatically.
- `README.md`: one line, the score badge next to the version one. A CHANGELOG entry is included per CONTRIBUTING.

**Score badge**
I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of master. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README line and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I close this PR, the hardening PR stands on its own.
