### PR TITLE
Fix doubled word in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ cargo install --path . --locked --force
 ```
 
 If you want to build an application that uses `bat`'s pretty-printing
-features as a library, check out the [the API documentation](https://docs.rs/bat/).
+features as a library, check out the [API documentation](https://docs.rs/bat/).
 Note that you have to use either `regex-onig` or `regex-fancy` as a feature
 when you depend on `bat` as a library.
 


### PR DESCRIPTION
Small doubled-word fix in the README: "check out the [the API documentation]" renders as "the the API documentation". This removes the duplicate article so it reads "check out the [API documentation]". The link target is unchanged.
