### PR TITLE
Honor --force-colorization when displaying help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Honor `--force-colorization` when displaying help, see #3915 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -93,11 +93,12 @@ impl App {
                 _ => !matches.get_flag("no-paging"),
             };
 
-            let use_color = match matches.get_one::<String>("color").map(|s| s.as_str()) {
-                Some("always") => true,
-                Some("never") => false,
-                _ => interactive_output, // auto: use color if interactive
-            };
+            let use_color = matches.get_flag("force-colorization")
+                || match matches.get_one::<String>("color").map(|s| s.as_str()) {
+                    Some("always") => true,
+                    Some("never") => false,
+                    _ => interactive_output, // auto: use color if interactive
+                };
 
             let pager = matches.get_one::<String>("pager").map(|s| s.as_str());
             let theme_options = Self::theme_options_from_matches(&matches);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -860,14 +860,14 @@ fn help_with_force_colorization() {
 }
 
 #[test]
-fn help_with_force_colorization_overrides_color_never() {
+fn help_with_force_colorization_keeps_color_option_conflict() {
     bat()
         .args(["--help", "--force-colorization", "--color=never"])
         .arg("--paging=never")
         .assert()
-        .success()
-        .stdout(predicate::str::contains("\x1B["))
-        .stderr("");
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("cannot be used with"));
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -841,6 +841,36 @@ fn long_help_with_highlighting() {
         .stdout(predicate::str::contains("Options:"));
 }
 
+
+#[test]
+fn help_with_force_colorization() {
+    for args in [
+        vec!["--help", "--force-colorization"],
+        vec!["-h", "-f"],
+        vec!["-fh"],
+    ] {
+        bat()
+            .args(args)
+            .arg("--paging=never")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\x1B["))
+            .stdout(predicate::str::contains("Usage:"))
+            .stderr("");
+    }
+}
+
+#[test]
+fn help_with_force_colorization_overrides_color_never() {
+    bat()
+        .args(["--help", "--force-colorization", "--color=never"])
+        .arg("--paging=never")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1B["))
+        .stderr("");
+}
+
 #[test]
 fn help_with_color_never() {
     bat()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -841,7 +841,6 @@ fn long_help_with_highlighting() {
         .stdout(predicate::str::contains("Options:"));
 }
 
-
 #[test]
 fn help_with_force_colorization() {
     for args in [


### PR DESCRIPTION
`--force-colorization` enables colors for normal output but was ignored by the separate help-rendering path, so piping `bat --help -f` removed highlighting.

Honor the flag when rendering help. Add regression coverage for short and long help and combined `-fh`, while retaining the conflict with `--color`.

Fixes #2778.

Validation:
- `cargo test --locked --test integration_tests help_with_force_colorization` — 2 passed.
- `cargo fmt --all -- --check` — passed.
- [Full GitHub CI](https://github.com/sharkdp/bat/actions/runs/34066809261) and changelog checks passed, including Linux, macOS, Windows, minimum Rust version, Clippy, and rebuilt syntax assets.