### PR TITLE
List visible languages that have no file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+
+- Include languages without file extensions in language listings and completion candidates, see #3917 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -104,7 +104,7 @@ pub fn get_languages(config: &Config, cache_dir: &Path) -> Result<String> {
     let mut languages = assets
         .get_syntaxes()?
         .iter()
-        .filter(|syntax| !syntax.hidden && !syntax.file_extensions.is_empty())
+        .filter(|syntax| !syntax.hidden)
         .cloned()
         .collect::<Vec<_>>();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -792,6 +792,34 @@ fn list_languages() {
 }
 
 #[test]
+fn list_languages_includes_syntaxes_without_file_extensions() {
+    bat()
+        .args(["--list-languages", "--paging=never"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("LaTeX Log:\n"));
+
+    bat()
+        .args(["--list-languages", "--paging=never", "--decorations=always"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("LaTeX Log"));
+}
+
+#[test]
+fn list_languages_includes_mappings_for_syntaxes_without_file_extensions() {
+    bat()
+        .args([
+            "--list-languages",
+            "--paging=never",
+            "--map-syntax=*.latex-log:LaTeX Log",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("LaTeX Log:*.latex-log\n"));
+}
+
+#[test]
 #[cfg_attr(
     any(not(feature = "git"), feature = "lessopen", target_os = "windows"),
     ignore


### PR DESCRIPTION
`--list-languages` drops syntaxes with no registered extensions even when users can select them with `--language`. This also prevents their names and configured mappings from reaching completion scripts.

Include every non-hidden syntax. Add regressions for both listing formats and a custom mapping to LaTeX Log, which has no built-in extensions. Existing completion scripts already guard empty extension lists.

Fixes #2354.

Validation: `cargo test --locked --test integration_tests list_languages` — 3 passed; formatting checked. Full GitHub CI is queued.