### PR TITLE
Wrap colored headers by visible terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+
+- Wrap colored headers using terminal display width and preserve their styling, see #3918 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -16,7 +16,7 @@ use content_inspector::ContentType;
 use encoding_rs::{UTF_16BE, UTF_16LE};
 
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::assets::{HighlightingAssets, SyntaxReferenceInSet};
 use crate::config::Config;
@@ -414,32 +414,39 @@ impl<'a> InteractivePrinter<'a> {
         }
     }
 
-    fn print_header_component_with_indent(
-        &mut self,
-        handle: &mut OutputHandle,
-        content: &str,
-    ) -> Result<()> {
-        self.print_header_component_indent(handle)?;
-        writeln!(handle, "{content}")
-    }
-
     fn print_header_multiline_component(
         &mut self,
         handle: &mut OutputHandle,
         content: &str,
     ) -> Result<()> {
-        let content_width = self.config.term_width - self.get_header_component_indent_length();
-        if content.chars().count() <= content_width {
-            return self.print_header_component_with_indent(handle, content);
-        }
+        let content_width = self
+            .config
+            .term_width
+            .saturating_sub(self.get_header_component_indent_length())
+            .max(1);
+        let mut column = 0;
+        let mut style = AnsiStyle::new();
+        self.print_header_component_indent(handle)?;
 
-        let mut content_graphemes: Vec<&str> = content.graphemes(true).collect();
-        while content_graphemes.len() > content_width {
-            let (content_line, remaining) = content_graphemes.split_at(content_width);
-            self.print_header_component_with_indent(handle, content_line.join("").as_str())?;
-            content_graphemes = remaining.to_vec();
+        for chunk in EscapeSequenceIterator::new(content) {
+            if let EscapeSequence::Text(text) = chunk {
+                for grapheme in text.graphemes(true) {
+                    let width = UnicodeWidthStr::width(grapheme);
+                    if column > 0 && column + width > content_width {
+                        writeln!(handle, "{}", style.to_reset_sequence())?;
+                        self.print_header_component_indent(handle)?;
+                        write!(handle, "{style}")?;
+                        column = 0;
+                    }
+                    write!(handle, "{grapheme}")?;
+                    column += width;
+                }
+            } else {
+                write!(handle, "{}", chunk.raw())?;
+                style.update(chunk);
+            }
         }
-        self.print_header_component_with_indent(handle, content_graphemes.join("").as_str())
+        writeln!(handle)
     }
 
     fn highlight_regions_for_line<'b>(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2434,6 +2434,67 @@ fn header_narrow_terminal_with_multibyte_chars() {
 }
 
 #[test]
+fn header_wrapping_uses_display_width_and_preserves_escape_sequences() {
+    for (label, width, expected) in [
+        ("abcdefghijk", 12, "File: abcdef\nghijk\nx\n"),
+        ("界界界界", 11, "File: 界界\n界界\nx\n"),
+        (
+            "e\u{301}e\u{301}e\u{301}",
+            8,
+            "File: e\u{301}e\u{301}\ne\u{301}\nx\n",
+        ),
+    ] {
+        for color in ["never", "always"] {
+            let result = bat()
+                .args(["--style=header", "--decorations=always", "--paging=never"])
+                .arg(format!("--color={color}"))
+                .arg(format!("--terminal-width={width}"))
+                .args(["--file-name", label])
+                .write_stdin("x\n")
+                .assert()
+                .success();
+            let output = String::from_utf8_lossy(&result.get_output().stdout);
+            assert_eq!(
+                console::strip_ansi_codes(&output),
+                expected,
+                "{color}: {label}"
+            );
+            if color == "always" {
+                assert!(output.contains('\u{1b}'));
+            }
+        }
+    }
+}
+
+#[test]
+fn header_wrapping_preserves_colored_sidebar_alignment() {
+    let output = |color: &str| {
+        bat()
+            .args([
+                "--style=header,numbers,grid",
+                "--decorations=always",
+                "--paging=never",
+            ])
+            .arg(format!("--color={color}"))
+            .args(["--terminal-width=20", "--file-name", "a-long-file-name.txt"])
+            .write_stdin("x\n")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone()
+    };
+    let plain = String::from_utf8(output("never")).unwrap();
+    let colored = String::from_utf8(output("always")).unwrap();
+    assert_eq!(console::strip_ansi_codes(&colored), plain);
+    assert!(colored
+        .lines()
+        .skip(1)
+        .take(2)
+        .all(|line| line.contains('\u{1b}')));
+}
+
+#[test]
 #[cfg(feature = "git")] // Expected output assumes git is enabled
 fn header_default() {
     bat()


### PR DESCRIPTION
Header wrapping counts ANSI escape sequences as printable characters, wrapping colored filenames prematurely and sometimes splitting the escape sequence itself. Counting graphemes alone also gives the wrong width for wide Unicode characters.

Walk escape sequences separately from graphemes, measure terminal display width, and restore active styling after continuation-line indentation. Saturate the available-width calculation and guarantee progress at narrow widths. Regression coverage compares colored and uncolored headers, wide and combining characters, and sidebar alignment.

Fixes #3172.

Validation:
- `cargo test --locked --test integration_tests header_` — 20 passed.
- `cargo clippy --locked --lib --bin bat -- -D warnings` — passed.
- Formatting checked. The [GitHub CI run](https://github.com/sharkdp/bat/actions/runs/34067600847) is blocked by HTTP 504 from Codeberg while checking out the Zig submodule. Completed code checks passed; the failed checkout needs a maintainer retry.

Integration note: #3933 adds OSC 8 links in the same header renderer. A [tested integration reference](https://github.com/Matei02355/bat-contribution/tree/integration-code-batches-20260907) preserves this PR's ANSI/Unicode width calculation, then wraps each completed header fragment with its link. The combined code changes passed 522 tests and all-target/all-feature Clippy locally.