### PR TITLE
Add --binary=skip for redirected output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--binary=skip` to omit binary inputs even when output is redirected, see #0 (@Matei02355)
+- Add `--binary=skip` to omit binary inputs even when output is redirected, see #3925 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--binary=skip` to omit binary inputs even when output is redirected, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -10,7 +10,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
     $ArrayWhen       = @('auto', 'never', 'always')
     $ArrayYesNo      = @('never', 'always')
     $ArrayWrap       = @('always', 'never', 'character', 'word')
-    $ArrayBinary     = @('no-printing', 'as-text')
+    $ArrayBinary     = @('no-printing', 'as-text', 'skip')
     $ArrayPrint      = @('unicode', 'caret')
 
     function Get-MyThemes(){
@@ -159,7 +159,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--show-all'              , 'show-all'              , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')
             [CompletionResult]::new('--nonprintable-notation' , 'nonprintable-notation' , [CompletionResultType]::ParameterName, 'Set notation for non-printable characters. (unicode, caret)')
             [CompletionResult]::new('--chop-long-lines'       , 'chop-long-lines'       , [CompletionResultType]::ParameterName, 'Truncate all lines longer than screen width. Alias for ''--wrap=never''.')
-            [CompletionResult]::new('--binary'                , 'binary'                , [CompletionResultType]::ParameterName, 'How to treat binary content. (*no-printing*, as-text)')
+            [CompletionResult]::new('--binary'                , 'binary'                , [CompletionResultType]::ParameterName, 'How to treat binary content. (*no-printing*, as-text, skip)')
             [CompletionResult]::new('--ignored-suffix'        , 'ignored-suffix'        , [CompletionResultType]::ParameterName, 'Ignore extension. For example: ''bat --ignored-suffix ".dev" my_file.json.dev'' will use JSON syntax, and ignore ''.dev''')
             [CompletionResult]::new('--squeeze-blank'         , 'squeeze-blank'         , [CompletionResultType]::ParameterName, 'Squeeze consecutive empty lines into a single empty line.')
             [CompletionResult]::new('--squeeze-limit'         , 'squeeze-limit'         , [CompletionResultType]::ParameterName, 'Set the maximum number of consecutive empty lines to be printed.')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -121,7 +121,7 @@ _bat() {
 		return 0
 		;;
 	--binary)
-		COMPREPLY=($(compgen -W "no-printing as-text" -- "$cur"))
+		COMPREPLY=($(compgen -W "no-printing as-text skip" -- "$cur"))
 		return 0
 		;;
 	--nonprintable-notation)

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -143,7 +143,7 @@ set -l special_themes '
 
 complete -c $bat -l acknowledgements -d "Print acknowledgements" -n __fish_is_first_arg
 
-complete -c $bat -l binary -x -a "no-printing as-text" -d "How to treat binary content" -n __bat_no_excl_args
+complete -c $bat -l binary -x -a "no-printing as-text skip" -d "How to treat binary content" -n __bat_no_excl_args
 
 complete -c $bat -l cache-dir -f -d "Show bat's cache directory" -n __fish_is_first_arg
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -26,7 +26,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
     args=(
         '(-A --show-all)'{-A,--show-all}'[show non-printable characters (space, tab, newline, ..)]'
         --nonprintable-notation='[specify how to display non-printable characters when using --show-all]:notation:(caret unicode)'
-        --binary='[specify how to treat binary content]:behavior:(no-printing as-text)'
+        --binary='[specify how to treat binary content]:behavior:(no-printing as-text skip)'
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
         \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -48,6 +48,9 @@ Possible values:
 Do not print any binary content (default)
 .IP "as\-text"
 Treat binary content as normal text
+.IP "skip"
+Omit binary inputs entirely, including their headers and decorations. This also
+applies when output is redirected and takes precedence over '\-\-show-all'.
 .RE
 .HP
 \fB\-\-completion\fR <SHELL>

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -26,6 +26,8 @@ Options:
           Possible values:
             * no-printing: do not print any binary content
             * as-text: treat binary content as normal text
+            * skip: omit binary inputs entirely, even when output is redirected or '--show-all' is
+            used
 
   -p, --plain...
           Only show plain style, no decorations. This is an alias for '--style=plain'. When '-p' is

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -395,6 +395,7 @@ impl App {
             binary: match self.matches.get_one::<String>("binary").map(|s| s.as_str()) {
                 Some("as-text") => BinaryBehavior::AsText,
                 Some("no-printing") => BinaryBehavior::NoPrinting,
+                Some("skip") => BinaryBehavior::Skip,
                 _ => unreachable!("other values for --binary are not allowed"),
             },
             wrapping_mode: {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -83,7 +83,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long("binary")
                 .action(ArgAction::Set)
                 .default_value("no-printing")
-                .value_parser(["no-printing", "as-text"])
+                .value_parser(["no-printing", "as-text", "skip"])
                 .value_name("behavior")
                 .hide_default_value(true)
                 .help("How to treat binary content. (default: no-printing)")
@@ -91,7 +91,9 @@ pub fn build_app(interactive_output: bool) -> Command {
                     "How to treat binary content. (default: no-printing)\n\n\
                     Possible values:\n  \
                     * no-printing: do not print any binary content\n  \
-                    * as-text: treat binary content as normal text",
+                    * as-text: treat binary content as normal text\n  \
+                    * skip: omit binary inputs entirely, even when output is redirected or \
+                    '--show-all' is used",
                 ),
         )
         .arg(

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -109,15 +109,18 @@ impl Controller<'_> {
         let mut no_errors: bool = true;
         let stderr = io::stderr();
 
-        for (index, input) in inputs.into_iter().enumerate() {
+        let mut is_first = true;
+        for input in inputs {
             let identifier = stdout_identifier.as_ref();
-            let is_first = index == 0;
             let result = if input.is_stdin() {
                 self.print_input(input, &mut writer, io::stdin().lock(), identifier, is_first)
             } else {
                 // Use dummy stdin since stdin is actually not used (#1902)
                 self.print_input(input, &mut writer, io::empty(), identifier, is_first)
             };
+            if matches!(result, Ok(true)) {
+                is_first = false;
+            }
             if let Err(error) = result {
                 match writer {
                     // It doesn't make much sense to send errors straight to stderr if the user
@@ -145,7 +148,7 @@ impl Controller<'_> {
         stdin: R,
         stdout_identifier: Option<&Identifier>,
         is_first: bool,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let mut opened_input = {
             #[cfg(feature = "lessopen")]
             match self.preprocessor {
@@ -159,6 +162,14 @@ impl Controller<'_> {
             input.open(stdin, stdout_identifier)?
         };
         opened_input.reader.unbuffered = self.config.unbuffered;
+        if self.config.binary == crate::BinaryBehavior::Skip
+            && opened_input
+                .reader
+                .content_type
+                .is_some_and(|c| c.is_binary())
+        {
+            return Ok(false);
+        }
         #[cfg(feature = "git")]
         let line_changes = if self.config.visible_lines.diff_mode()
             || (!self.config.loop_through && self.config.style_components.changes())
@@ -174,14 +185,14 @@ impl Controller<'_> {
                             .map(|changes| changes.is_empty())
                             .unwrap_or(false)
                     {
-                        return Ok(());
+                        return Ok(false);
                     }
 
                     diff
                 }
                 _ if self.config.visible_lines.diff_mode() => {
                     // Skip non-file inputs in diff mode
-                    return Ok(());
+                    return Ok(false);
                 }
                 _ => None,
             }
@@ -208,7 +219,8 @@ impl Controller<'_> {
             !is_first,
             #[cfg(feature = "git")]
             &line_changes,
-        )
+        )?;
+        Ok(true)
     }
 
     fn print_file(

--- a/src/nonprintable_notation.rs
+++ b/src/nonprintable_notation.rs
@@ -21,4 +21,7 @@ pub enum BinaryBehavior {
 
     /// Treat binary content as normal text
     AsText,
+
+    /// Skip binary inputs entirely, including when output is redirected.
+    Skip,
 }

--- a/tests/binary_skip.rs
+++ b/tests/binary_skip.rs
@@ -1,0 +1,83 @@
+mod utils;
+
+use utils::command::bat;
+
+#[test]
+fn skip_binary_inputs_when_redirected() {
+    bat()
+        .args(["--binary=skip", "test.txt", "test.binary", "test.txt"])
+        .assert()
+        .success()
+        .stdout("hello world\nhello world\n")
+        .stderr("");
+}
+
+#[test]
+fn skip_binary_stdin_even_with_show_all() {
+    for args in [vec!["--binary=skip"], vec!["--binary=skip", "--show-all"]] {
+        bat()
+            .args(args)
+            .write_stdin(b"text\n\0binary\n" as &[u8])
+            .assert()
+            .success()
+            .stdout("")
+            .stderr("");
+    }
+}
+
+#[test]
+fn skipped_inputs_do_not_add_headers_or_padding() {
+    let expected = bat()
+        .args(["--decorations=always", "--style=header", "test.txt"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    bat()
+        .args([
+            "--binary=skip",
+            "--decorations=always",
+            "--style=header",
+            "test.binary",
+            "test.txt",
+            "test.binary",
+        ])
+        .assert()
+        .success()
+        .stdout(expected)
+        .stderr("");
+}
+
+#[test]
+fn skip_preserves_utf16_and_unterminated_text_when_redirected() {
+    for file in [
+        "test_UTF-16LE.txt",
+        "test_UTF-16BE.txt",
+        "single-line.txt",
+        "empty.txt",
+    ] {
+        let expected = bat()
+            .arg(file)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        bat()
+            .args(["--binary=skip", file])
+            .assert()
+            .success()
+            .stdout(expected);
+    }
+}
+
+#[test]
+fn default_binary_output_is_unchanged() {
+    let input = b"text\n\0binary\n";
+    bat()
+        .write_stdin(input as &[u8])
+        .assert()
+        .success()
+        .stdout(input as &[u8]);
+}


### PR DESCRIPTION
Redirecting bat currently writes binary content even when users are collecting only text files. Add `--binary=skip` to omit binary inputs entirely, including headers, while preserving normal redirected output by default.

Skipping happens after existing content detection and before syntax matching or Git diff work. It works with files, stdin, and `--show-all`; UTF-16 text remains text. Skipped files do not introduce header padding.

Fixes #2927.

Validation: five new integration tests passed; the existing library, binary, and integration suites passed after updating the help snapshot (423 tests total). Formatting and whitespace checks passed. [GitHub CI](https://github.com/sharkdp/bat/actions/runs/34074201325) and changelog checks passed.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.