### PR TITLE
Allow ignoring the system configuration with --no-system-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--no-system-config` to ignore machine-wide settings while retaining user configuration, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--no-system-config` to ignore machine-wide settings while retaining user configuration, see #0 (@Matei02355)
+- Add `--no-system-config` to ignore machine-wide settings while retaining user configuration, see #3926 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/README.md
+++ b/README.md
@@ -768,6 +768,7 @@ bat --generate-config-file
 There is also now a systemwide configuration file, which is located under `/etc/bat/config` on
 Linux and Mac OS and `C:\ProgramData\bat\config` on windows. If the system wide configuration
 file is present, the content of the user configuration will simply be appended to it.
+Pass `--no-system-config` on the command line to load only the user configuration.
 
 ### Format
 

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -181,6 +181,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-u'                      , 'u'                     , [CompletionResultType]::ParameterName, 'u')
             [CompletionResult]::new('--unbuffered'            , 'unbuffered'            , [CompletionResultType]::ParameterName, 'Enable unbuffered input reading for streaming use cases')
             [CompletionResult]::new('--completion'            , 'completion'            , [CompletionResultType]::ParameterName, 'Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]')
+            [CompletionResult]::new('--no-system-config'             , 'no-system-config'             , [CompletionResultType]::ParameterName, 'Ignore the system-wide configuration file')
             [CompletionResult]::new('--no-config'             , 'no-config'             , [CompletionResultType]::ParameterName, 'Do not use the configuration file')
             [CompletionResult]::new('--no-custom-assets'      , 'no-custom-assets'      , [CompletionResultType]::ParameterName, 'Do not load custom assets')
             [CompletionResult]::new('--lessopen'              , 'lessopen'              , [CompletionResultType]::ParameterName, 'Enable the $LESSOPEN preprocessor')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -242,6 +242,7 @@ _bat() {
 			--config-dir
 			--config-file
 			--generate-config-file
+			--no-system-config
 			--no-config
 			--no-custom-assets
 			--no-lessopen

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -194,6 +194,7 @@ complete -c $bat -l list-themes -f -d "List syntax highlighting themes" -n __fis
 
 complete -c $bat -s m -l map-syntax -x -a "(__bat_complete_map_syntax)" -d "Map <glob pattern>:<language syntax>" -n __bat_no_excl_args
 
+complete -c $bat -l no-system-config -d "Ignore the system-wide configuration file"
 complete -c $bat -l no-config -d "Do not use the configuration file"
 
 complete -c $bat -l no-custom-assets -d "Do not load custom assets"

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -65,6 +65,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --diagnostic'[show diagnostic information for bug reports]'
         --quiet-empty'[do not produce any output when the input is empty]'
         -P'[disable paging]'
+        "--no-system-config[ignore the system-wide configuration file]"
         "--no-config[don't use the configuration file]"
         "--no-custom-assets[don't load custom assets]"
         '(--no-lessopen)'--lessopen'[enable the $LESSOPEN preprocessor]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -305,6 +305,14 @@ Print this help message.
 \fB\-V\fR, \fB\-\-version\fR
 .IP
 Show version information.
+
+.HP
+\fB\-\-no-system-config\fR
+.IP
+Ignore the system-wide configuration file. The user configuration, including
+BAT_CONFIG_PATH, and environment options still apply. Pass this option on the
+command line; putting it in a configuration file has no effect.
+
 .SH "POSITIONAL ARGUMENTS"
 .HP
 \fB<FILE>...\fR

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -235,6 +235,11 @@ Options:
           automatically disabled in unbuffered mode, and syntax highlighting may be imperfect on
           partial lines.
 
+      --no-system-config
+          Ignore the system-wide configuration file while still loading the user configuration
+          (including BAT_CONFIG_PATH) and environment options. This option must be passed on the
+          command line.
+
       --completion <SHELL>
           Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]
 

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -64,6 +64,8 @@ Options:
           Display all supported languages.
   -u, --unbuffered
           Enable unbuffered input reading for streaming use cases.
+      --no-system-config
+          Ignore the system-wide configuration file.
       --completion <SHELL>
           Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]
   -E, --quiet-empty

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -79,7 +79,7 @@ impl App {
         let number_from_cli = cli_matches.get_flag("number");
         let number_nonblank_from_cli = cli_matches.get_flag("number-nonblank");
 
-        let matches = Self::matches(interactive_output)?;
+        let matches = Self::matches(interactive_output, cli_matches.get_flag("no-system-config"))?;
 
         if matches.get_flag("help") {
             let help_type = if wild::args_os().any(|arg| arg == "--help") {
@@ -195,7 +195,7 @@ impl App {
         clap_app::build_app(interactive_output).get_matches_from(wild::args_os())
     }
 
-    fn matches(interactive_output: bool) -> Result<ArgMatches> {
+    fn matches(interactive_output: bool, skip_system_config: bool) -> Result<ArgMatches> {
         // Check if we should skip config file processing for special arguments
         // that don't require full application setup (version, diagnostic)
         let should_skip_config = wild::args_os().any(|arg| {
@@ -229,7 +229,7 @@ impl App {
         // Read arguments from bats config file
         let config_args = match get_args_from_env_opts_var() {
             Some(result) => result,
-            None => get_args_from_config_file(),
+            None => get_args_from_config_file(skip_system_config),
         };
 
         // For help, ignore config file parse errors (use empty config instead)

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -615,6 +615,18 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("no-system-config")
+                .long("no-system-config")
+                .action(ArgAction::SetTrue)
+                .overrides_with("no-system-config")
+                .help("Ignore the system-wide configuration file.")
+                .long_help(
+                    "Ignore the system-wide configuration file while still loading the user \
+                     configuration (including BAT_CONFIG_PATH) and environment options. \
+                     This option must be passed on the command line.",
+                ),
+        )
+        .arg(
             Arg::new("no-config")
                 .long("no-config")
                 .action(ArgAction::SetTrue)

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -101,21 +101,31 @@ pub fn generate_config_file() -> bat::error::Result<()> {
     Ok(())
 }
 
-pub fn get_args_from_config_file() -> Result<Vec<OsString>, shell_words::ParseError> {
-    let mut config = String::new();
-
+pub fn get_args_from_config_file(
+    skip_system: bool,
+) -> Result<Vec<OsString>, shell_words::ParseError> {
     let system_config = system_config_file();
     let user_config = config_file();
+    get_args_from_config_files(&system_config, &user_config, skip_system)
+}
 
-    if let Ok(c) = fs::read_to_string(&system_config) {
-        config.push_str(&c);
-        config.push('\n');
+fn get_args_from_config_files(
+    system_config: &Path,
+    user_config: &Path,
+    skip_system: bool,
+) -> Result<Vec<OsString>, shell_words::ParseError> {
+    let mut config = String::new();
+    if !skip_system {
+        if let Ok(c) = fs::read_to_string(system_config) {
+            config.push_str(&c);
+            config.push('\n');
+        }
     }
 
     // Skip the user config if it resolves to the same file as the system config,
     // which can happen when BAT_CONFIG_DIR is set to e.g. "/etc/bat". See #3589.
-    if !same_file(&system_config, &user_config) {
-        if let Ok(c) = fs::read_to_string(&user_config) {
+    if skip_system || !same_file(system_config, user_config) {
+        if let Ok(c) = fs::read_to_string(user_config) {
             config.push_str(&c);
         }
     }
@@ -265,4 +275,40 @@ fn same_file_via_symlink() {
     fs::write(&original, "").unwrap();
     std::os::unix::fs::symlink(&original, &link).unwrap();
     assert!(same_file(&original, &link));
+}
+
+#[test]
+fn skip_system_config_preserves_user_arguments() {
+    let dir = tempfile::tempdir().unwrap();
+    let system = dir.path().join("system");
+    let user = dir.path().join("user");
+    fs::write(&system, "--tabs=2\n--style=numbers").unwrap();
+    fs::write(&user, "--tabs=8").unwrap();
+    assert_eq!(
+        get_args_from_config_files(&system, &user, false).unwrap(),
+        vec!["--tabs=2", "--style=numbers", "--tabs=8"]
+    );
+    assert_eq!(
+        get_args_from_config_files(&system, &user, true).unwrap(),
+        vec!["--tabs=8"]
+    );
+    fs::write(&system, "\"unterminated").unwrap();
+    assert!(get_args_from_config_files(&system, &user, false).is_err());
+    assert_eq!(
+        get_args_from_config_files(&system, &user, true).unwrap(),
+        vec!["--tabs=8"]
+    );
+}
+
+#[test]
+fn explicitly_selected_user_config_is_loaded_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config");
+    fs::write(&config, "--plain").unwrap();
+    for skip_system in [false, true] {
+        assert_eq!(
+            get_args_from_config_files(&config, &config, skip_system).unwrap(),
+            vec!["--plain"]
+        );
+    }
 }

--- a/tests/system_config.rs
+++ b/tests/system_config.rs
@@ -1,0 +1,26 @@
+mod utils;
+
+use utils::command::bat_with_config;
+
+#[test]
+fn no_system_config_keeps_user_config_and_cli_overrides() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config");
+    std::fs::write(
+        &config,
+        "--color=never\n--style=numbers\n--decorations=always",
+    )
+    .unwrap();
+    bat_with_config()
+        .env("BAT_CONFIG_PATH", &config)
+        .args(["--no-system-config", "test.txt"])
+        .assert()
+        .success()
+        .stdout("   1 hello world\n");
+    bat_with_config()
+        .env("BAT_CONFIG_PATH", &config)
+        .args(["--no-system-config", "--style=plain", "test.txt"])
+        .assert()
+        .success()
+        .stdout("hello world\n");
+}


### PR DESCRIPTION
Portable launchers can select a user config with `BAT_CONFIG_PATH`, but cannot avoid settings from the machine's system config.

Add an explicit command-line `--no-system-config` switch. User configuration and existing environment precedence are retained. Parse the switch from the original CLI before reading configuration; identical system/user paths still load the explicitly selected user file once.

Fixes #2993.

Validation: 12 configuration unit tests and one CLI integration test passed, covering malformed system configuration, file deduplication, retained user settings, and CLI overrides. Formatting and whitespace checks passed. [GitHub CI](https://github.com/sharkdp/bat/actions/runs/34074323811) and changelog checks passed.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.