### PR TITLE
Add grid-vertical style without horizontal borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add the `grid-vertical` style for a sidebar separator without horizontal borders, see #0 (@Matei02355)
+- Add the `grid-vertical` style for a sidebar separator without horizontal borders, see #3927 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add the `grid-vertical` style for a sidebar separator without horizontal borders, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -5,7 +5,7 @@ using namespace System.Management.Automation.Language
 Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
-    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
+    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'grid-vertical', 'rule', 'numbers', 'snip')
     $ArrayCompletion = @('bash', 'fish', 'zsh', 'ps1')
     $ArrayWhen       = @('auto', 'never', 'always')
     $ArrayYesNo      = @('never', 'always')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -177,6 +177,7 @@ _bat() {
 			header-filename
 			header-filesize
 			grid
+			grid-vertical
 			rule
 			numbers
 			snip

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -83,6 +83,7 @@ function __bat_style_opts
         "header-filename,filename above content" \
         "header-filesize,filesize above content" \
         "grid,lines b/w sidebar/header/content" \
+        "grid-vertical,vertical sidebar separator" \
         "numbers,line numbers in sidebar" \
         "rule,separate files" \
         "snip,separate ranges"

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -56,7 +56,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
-            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+            default auto full plain changes header header-filename header-filesize grid grid-vertical rule numbers snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
         '(* -)'{-L,--list-languages}'[display all supported languages]'
         '(-u --unbuffered)'--unbuffered'[enable unbuffered input reading for streaming use cases]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -242,8 +242,13 @@ replacing them.
 By default, the following components are enabled:
 changes, grid, header\-filename, numbers, snip
 .IP
-Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
+Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid, grid-vertical,
 rule, numbers, snip.
+
+.PP
+The 'grid-vertical' style draws only the sidebar separator, without top or bottom
+borders. Combine it with 'numbers' and optionally 'rule' for separators between files.
+
 .HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...
 .IP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -210,6 +210,7 @@ Options:
             * header-filesize: show file sizes before the content.
             * grid: vertical/horizontal lines to separate side bar
                     and the header from the content.
+            * grid-vertical: only the vertical line separating the side bar.
             * rule: horizontal lines to delimit files.
             * numbers: show line numbers in the side bar.
             * snip: draw separation lines between distinct line ranges.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -57,7 +57,7 @@ Options:
           Squeeze consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
-          header, header-filename, header-filesize, grid, rule, numbers, snip).
+          header, header-filename, header-filesize, grid, grid-vertical, rule, numbers, snip).
   -r, --line-range <N:M>
           Only print the lines from N to M.
   -L, --list-languages

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -534,7 +534,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).",
+                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, grid-vertical, rule, numbers, snip).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -563,6 +563,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                      * header-filesize: show file sizes before the content.\n  \
                      * grid: vertical/horizontal lines to separate side bar\n          \
                        and the header from the content.\n  \
+                     * grid-vertical: only the vertical line separating the side bar.\n  \
                      * rule: horizontal lines to delimit files.\n  \
                      * numbers: show line numbers in the side bar.\n  \
                      * snip: draw separation lines between distinct line ranges.",

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -24,6 +24,7 @@ struct ActiveStyleComponents {
     #[cfg(feature = "git")]
     vcs_modification_markers: bool,
     grid: bool,
+    grid_vertical: bool,
     rule: bool,
     line_numbers: bool,
     snip: bool,
@@ -154,6 +155,12 @@ impl<'a> PrettyPrinter<'a> {
     /// Whether to paint a grid, separating line numbers, git changes and the code
     pub fn grid(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.grid = yes;
+        self
+    }
+
+    /// Whether to separate the sidebar from the contents without horizontal borders.
+    pub fn grid_vertical(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.grid_vertical = yes;
         self
     }
 
@@ -305,6 +312,11 @@ impl<'a> PrettyPrinter<'a> {
         self.config.style_components.clear();
         if self.active_style_components.grid {
             self.config.style_components.insert(StyleComponent::Grid);
+        }
+        if self.active_style_components.grid_vertical {
+            self.config
+                .style_components
+                .insert(StyleComponent::GridVertical);
         }
         if self.active_style_components.rule {
             self.config.style_components.insert(StyleComponent::Rule);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -254,7 +254,7 @@ impl<'a> InteractivePrinter<'a> {
         // The grid border decoration isn't added until after the panel_width calculation, since the
         // print_horizontal_line, print_header, and print_footer functions all assume the panel
         // width is without the grid border.
-        if config.style_components.grid() && !decorations.is_empty() {
+        if config.style_components.grid_vertical() && !decorations.is_empty() {
             decorations.push(Box::new(GridBorderDecoration::new(&colors)));
         }
 
@@ -384,7 +384,7 @@ impl<'a> InteractivePrinter<'a> {
             "{text_truncated}{}",
             " ".repeat(self.panel_width - 1 - text_truncated.len())
         );
-        if self.config.style_components.grid() {
+        if self.config.style_components.grid_vertical() {
             format!("{text_filled} │ ")
         } else {
             text_filled
@@ -392,7 +392,7 @@ impl<'a> InteractivePrinter<'a> {
     }
 
     fn get_header_component_indent_length(&self) -> usize {
-        if self.config.style_components.grid() && self.panel_width > 0 {
+        if self.config.style_components.grid_vertical() && self.panel_width > 0 {
             self.panel_width + 2
         } else {
             self.panel_width
@@ -400,7 +400,7 @@ impl<'a> InteractivePrinter<'a> {
     }
 
     fn print_header_component_indent(&mut self, handle: &mut OutputHandle) -> Result<()> {
-        if self.config.style_components.grid() {
+        if self.config.style_components.grid_vertical() {
             write!(
                 handle,
                 "{}{}",
@@ -490,7 +490,12 @@ impl Printer for InteractivePrinter<'_> {
         }
 
         if add_header_padding && self.config.style_components.rule() {
-            self.print_horizontal_line_term(handle, self.colors.rule)?;
+            if self.config.style_components.grid_vertical() && !self.config.style_components.grid()
+            {
+                self.print_horizontal_line(handle, '┼')?;
+            } else {
+                self.print_horizontal_line_term(handle, self.colors.rule)?;
+            }
         }
 
         if !self.config.style_components.header() {

--- a/src/style.rs
+++ b/src/style.rs
@@ -10,6 +10,7 @@ pub enum StyleComponent {
     #[cfg(feature = "git")]
     Changes,
     Grid,
+    GridVertical,
     Rule,
     Header,
     HeaderFilename,
@@ -34,6 +35,7 @@ impl StyleComponent {
             #[cfg(feature = "git")]
             StyleComponent::Changes => &[StyleComponent::Changes],
             StyleComponent::Grid => &[StyleComponent::Grid],
+            StyleComponent::GridVertical => &[StyleComponent::GridVertical],
             StyleComponent::Rule => &[StyleComponent::Rule],
             StyleComponent::Header => &[StyleComponent::HeaderFilename],
             StyleComponent::HeaderFilename => &[StyleComponent::HeaderFilename],
@@ -71,6 +73,7 @@ impl FromStr for StyleComponent {
             #[cfg(feature = "git")]
             "changes" => Ok(StyleComponent::Changes),
             "grid" => Ok(StyleComponent::Grid),
+            "grid-vertical" => Ok(StyleComponent::GridVertical),
             "rule" => Ok(StyleComponent::Rule),
             "header" => Ok(StyleComponent::Header),
             "header-filename" => Ok(StyleComponent::HeaderFilename),
@@ -104,6 +107,11 @@ impl StyleComponents {
 
     pub fn rule(&self) -> bool {
         self.0.contains(&StyleComponent::Rule)
+    }
+
+    /// Whether the sidebar has a vertical separator, with or without horizontal borders.
+    pub fn grid_vertical(&self) -> bool {
+        self.grid() || self.0.contains(&StyleComponent::GridVertical)
     }
 
     pub fn header(&self) -> bool {

--- a/tests/vertical_grid.rs
+++ b/tests/vertical_grid.rs
@@ -1,0 +1,82 @@
+mod utils;
+
+use utils::command::bat;
+
+#[test]
+fn vertical_grid_has_no_horizontal_borders() {
+    bat()
+        .args([
+            "--style=numbers,grid-vertical",
+            "--decorations=always",
+            "--color=never",
+        ])
+        .write_stdin("one\ntwo\n")
+        .assert()
+        .success()
+        .stdout("   1 │ one\n   2 │ two\n");
+}
+
+#[test]
+fn vertical_grid_connects_rules_between_files() {
+    bat()
+        .args([
+            "--style=numbers,grid-vertical,rule",
+            "--decorations=always",
+            "--color=never",
+            "--terminal-width=20",
+            "test.txt",
+            "test.txt",
+        ])
+        .assert()
+        .success()
+        .stdout("   1 │ hello world\n─────┼──────────────\n   1 │ hello world\n");
+}
+
+#[test]
+fn vertical_grid_aligns_wrapped_lines_and_headers() {
+    bat()
+        .args([
+            "--style=numbers,grid-vertical,header",
+            "--decorations=always",
+            "--color=never",
+            "--terminal-width=12",
+            "--wrap=character",
+        ])
+        .write_stdin("abcdefgh\n")
+        .assert()
+        .success()
+        .stdout("     │ STDIN\n   1 │ abcde\n     │ fgh\n");
+}
+
+#[test]
+fn vertical_grid_respects_small_terminals_and_missing_sidebar() {
+    for style in ["numbers,grid-vertical", "grid-vertical"] {
+        bat()
+            .args([
+                "--style",
+                style,
+                "--decorations=always",
+                "--color=never",
+                "--terminal-width=5",
+            ])
+            .write_stdin("abc\n")
+            .assert()
+            .success()
+            .stdout("abc\n");
+    }
+}
+
+#[test]
+fn removing_grid_keeps_explicit_vertical_separator() {
+    bat()
+        .args([
+            "--style=numbers,grid,grid-vertical",
+            "--style=-grid",
+            "--decorations=always",
+            "--color=never",
+        ])
+        .write_stdin("one\n")
+        .assert()
+        .success()
+        .stdout("   1 │ one\n");
+}


### PR DESCRIPTION
The existing `grid` style adds top and bottom borders even when users only need a separator between line numbers and content.

Add `--style=grid-vertical` and `PrettyPrinter::grid_vertical()`. Headers, wrapped continuations, and snips keep the sidebar alignment. Combining it with `rule` draws connected separators between files without outer borders. Existing `grid` and default styles retain their behavior.

Fixes #2028.

Validation: five new integration tests passed, covering borders, multiple files, header/wrap alignment, narrow terminals, absent sidebars, and style subtraction. Formatting and whitespace checks passed. [GitHub CI](https://github.com/sharkdp/bat/actions/runs/34074518921) and changelog checks passed.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.