### PR TITLE
Add --highlight-pattern for matching lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--highlight-pattern` to highlight lines matching regular expressions, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--highlight-pattern` to highlight lines matching regular expressions, see #0 (@Matei02355)
+- Add `--highlight-pattern` to highlight lines matching regular expressions, see #3928 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ minimal-application = [
 git = ["gix"] # Support indicating git modifications
 paging = [ "shell-words", "grep-cli", "minus"] # Support applying a pager on the output
 lessopen = ["execute"] # Support $LESSOPEN preprocessor
-build-assets = ["syntect/yaml-load", "syntect/plist-load", "regex", "walkdir"]
+build-assets = ["syntect/yaml-load", "syntect/plist-load", "walkdir"]
 
 # You need to use one of these if you depend on bat as a library:
 regex-onig = ["syntect/regex-onig"] # Use the "oniguruma" regex engine
@@ -66,7 +66,7 @@ clircle = { version = "0.6.1", default-features = false }
 bugreport = { version = "0.6.0", optional = true }
 etcetera = { version = "0.11.0", optional = true }
 grep-cli = { version = "0.1.12", optional = true }
-regex = { version = "1.12.3", optional = true }
+regex = "1.12.3"
 walkdir = { version = "2.5", optional = true }
 bytesize = { version = "2.3.1" }
 encoding_rs = "0.8.35"

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -136,6 +136,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-l'                      , 'l'                     , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
             [CompletionResult]::new('--language'              , 'language'              , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
         #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+            [CompletionResult]::new('--highlight-pattern'        , 'highlight-pattern'        , [CompletionResultType]::ParameterName, 'Highlight lines matching a regular expression.')
             [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
             [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
             [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -87,7 +87,7 @@ _bat() {
 		__bat_escape_completions
 		return 0
 		;;
-	-H | --highlight-line | \
+	-H | --highlight-line | --highlight-pattern | \
 	--diff-context | \
 	--tabs | \
 	--terminal-width | \
@@ -202,6 +202,7 @@ _bat() {
 			--plain
 			--language
 			--highlight-line
+			--highlight-pattern
 			--file-name
 			--diff
 			--diff-context

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -176,6 +176,7 @@ complete -c $bat -s h -d "Print a concise overview" -n __fish_is_first_arg
 
 complete -c $bat -l help -f -d "Print all help information" -n __fish_is_first_arg
 
+complete -c $bat -l highlight-pattern -x -d "Highlight lines matching a regular expression" -n __bat_no_excl_args
 complete -c $bat -s H -l highlight-line -x -d "Highlight line(s) N[:M]" -n __bat_no_excl_args
 
 complete -c $bat -l ignored-suffix -x -d "Ignore extension" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -29,6 +29,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --binary='[specify how to treat binary content]:behavior:(no-printing as-text)'
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
+        \*--highlight-pattern='[highlight lines matching a regular expression]:regex'
         \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
         \*--file-name='[specify the name to display for a file]:name:_files'
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -305,6 +305,15 @@ Print this help message.
 \fB\-V\fR, \fB\-\-version\fR
 .IP
 Show version information.
+
+.HP
+\fB\-\-highlight-pattern\fR <regex>
+.IP
+Highlight lines matching a regular expression, using the style of
+'\-\-highlight-line'. Line endings are excluded from the match; wrapping does
+not change which lines match. Repeat the option to match any of several patterns,
+or combine it with explicit line ranges. Use '(?i)' for case-insensitive matching.
+
 .SH "POSITIONAL ARGUMENTS"
 .HP
 \fB<FILE>...\fR

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -44,6 +44,12 @@ Options:
           
           [aliases: --fallback-language]
 
+      --highlight-pattern <regex>
+          Highlight lines matching a regular expression, using the same style as '--highlight-line'.
+          Matches exclude the line ending and are evaluated before wrapping. Repeat the option to
+          match any of several patterns; it can also be combined with '--highlight-line'. Use '(?i)'
+          for case-insensitive matching.
+
   -H, --highlight-line <N:M>
           Highlight the specified line ranges with a different background color For example:
             '--highlight-line 40' highlights line 40

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -19,6 +19,8 @@ Options:
           Set the language for syntax highlighting.
       --fallback-syntax <fallback-syntax>
           Set a fallback language for undetected syntaxes. [aliases: --fallback-language]
+      --highlight-pattern <regex>
+          Highlight lines matching a regular expression.
   -H, --highlight-line <N:M>
           Highlight lines N through M.
       --file-name <name>

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -520,6 +520,11 @@ impl App {
                 .map(LineRanges::from)
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
+            highlighted_patterns: self
+                .matches
+                .get_many::<regex::Regex>("highlight-pattern")
+                .map(|patterns| patterns.cloned().collect())
+                .unwrap_or_default(),
             use_custom_assets: !self.matches.get_flag("no-custom-assets"),
             #[cfg(feature = "lessopen")]
             use_lessopen: self.matches.get_flag("lessopen"),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -134,6 +134,20 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("highlight-pattern")
+                .long("highlight-pattern")
+                .action(ArgAction::Append)
+                .value_name("regex")
+                .value_parser(regex::Regex::new)
+                .help("Highlight lines matching a regular expression.")
+                .long_help(
+                    "Highlight lines matching a regular expression, using the same style as \
+                     '--highlight-line'. Matches exclude the line ending and are evaluated before \
+                     wrapping. Repeat the option to match any of several patterns; it can also be \
+                     combined with '--highlight-line'. Use '(?i)' for case-insensitive matching.",
+                ),
+        )
+        .arg(
             Arg::new("highlight-line")
                 .long("highlight-line")
                 .short('H')

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,9 @@ pub struct Config<'a> {
     /// Ranges of lines which should be highlighted with a special background color
     pub highlighted_lines: HighlightedLineRanges,
 
+    /// Regular expressions selecting additional lines to highlight.
+    pub highlighted_patterns: Vec<regex::Regex>,
+
     /// Whether or not to allow custom assets. If this is false or if custom assets (a.k.a.
     /// cached assets) are not available, assets from the binary will be used instead.
     pub use_custom_assets: bool,

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -249,6 +249,16 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Highlight lines matching a regular expression, in addition to explicit ranges.
+    /// Repeat this method to match any of several patterns.
+    pub fn highlight_pattern(&mut self, pattern: &str) -> Result<&mut Self> {
+        self.config.highlighted_patterns.push(
+            regex::Regex::new(pattern)
+                .map_err(|error| format!("Invalid highlight pattern: {error}"))?,
+        );
+        Ok(self)
+    }
+
     /// Specify the maximum number of consecutive empty lines to print.
     pub fn squeeze_empty_lines(&mut self, maximum: Option<usize>) -> &mut Self {
         self.config.squeeze_lines = maximum;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -726,7 +726,12 @@ impl Printer for InteractivePrinter<'_> {
             .highlighted_lines
             .0
             .check(line_number, max_buffered_line_number)
-            == RangeCheckResult::InRange;
+            == RangeCheckResult::InRange
+            || self
+                .config
+                .highlighted_patterns
+                .iter()
+                .any(|pattern| pattern.is_match(line.trim_end_matches(['\r', '\n'])));
 
         if highlight_this_line && self.config.theme == "ansi" {
             self.ansi_style.update(ANSI_UNDERLINE_ENABLE);

--- a/tests/highlight_pattern.rs
+++ b/tests/highlight_pattern.rs
@@ -1,0 +1,103 @@
+mod utils;
+
+use utils::command::bat;
+
+fn output(args: &[&str], input: &[u8]) -> Vec<u8> {
+    bat()
+        .args([
+            "--color=always",
+            "--theme=TwoDark",
+            "--style=plain",
+            "--paging=never",
+        ])
+        .args(args)
+        .write_stdin(input)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
+}
+
+#[test]
+fn patterns_match_whole_lines_and_union_with_ranges() {
+    let input = b"ok\nERROR: first\nwarn: second\ntail\n";
+    assert_eq!(
+        output(
+            &[
+                "--highlight-pattern",
+                "^ERROR:",
+                "--highlight-pattern",
+                "(?i)^WARN:",
+                "-H",
+                "4"
+            ],
+            input
+        ),
+        output(&["-H", "2:4"], input),
+    );
+}
+
+#[test]
+fn pattern_anchors_ignore_crlf_and_work_without_final_newline() {
+    let input = "ok\r\n警告\r\n警告".as_bytes();
+    assert_eq!(
+        output(&["--highlight-pattern", "^警告$"], input),
+        output(&["-H", "2:3"], input)
+    );
+}
+
+#[test]
+fn pattern_highlights_all_wrapped_fragments() {
+    let input = b"long enough for several lines\n";
+    assert_eq!(
+        output(
+            &[
+                "--highlight-pattern",
+                "several lines$",
+                "--wrap=character",
+                "--terminal-width=10"
+            ],
+            input
+        ),
+        output(
+            &["-H", "1", "--wrap=character", "--terminal-width=10"],
+            input
+        ),
+    );
+}
+
+#[test]
+fn patterns_work_with_ansi_theme_and_visible_ranges() {
+    let input = b"first\nmatch\nlast\n";
+    assert_eq!(
+        output(
+            &[
+                "--theme=ansi",
+                "--highlight-pattern",
+                "match",
+                "--line-range=2:3"
+            ],
+            input
+        ),
+        output(&["--theme=ansi", "-H", "2", "--line-range=2:3"], input),
+    );
+}
+
+#[test]
+fn invalid_pattern_fails_before_printing() {
+    bat()
+        .args(["--highlight-pattern", "[", "test.txt"])
+        .assert()
+        .failure()
+        .stdout("");
+}
+
+#[test]
+fn pattern_does_not_force_colors_when_redirected() {
+    bat()
+        .args(["--highlight-pattern", ".", "test.txt"])
+        .assert()
+        .success()
+        .stdout("hello world\n");
+}


### PR DESCRIPTION
Selecting log or document lines to emphasize currently requires knowing their line numbers.

Add repeatable `--highlight-pattern <regex>` and `PrettyPrinter::highlight_pattern()`. Matching lines use the existing `--highlight-line` rendering, and patterns can be combined with numeric ranges. Patterns are compiled once, ignore line terminators, and match before wrapping. Invalid patterns fail before reading input; the option does not force colors in redirected output.

Fixes #2487.

Validation: six new integration tests passed, covering multiple patterns, range unions, Unicode, CRLF, unterminated final lines, wrapping, ANSI theme, visible ranges, invalid patterns, and redirected output. Formatting and whitespace checks passed. [GitHub CI](https://github.com/sharkdp/bat/actions/runs/34074696352) and changelog checks passed.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.