### PR TITLE
Detect first-line Vim and Emacs modelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Detect syntax from first-line Vim and Emacs modelines, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Detect syntax from first-line Vim and Emacs modelines, see #0 (@Matei02355)
+- Detect syntax from first-line Vim and Emacs modelines, see #3929 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/README.md
+++ b/README.md
@@ -454,6 +454,15 @@ bat --completion <shell>
 # see --help for supported shells
 ```
 
+### Editor modelines
+
+Bat recognizes a language hint on the first line, such as `# -*- python -*-`,
+`# -*- mode: python; -*-`, or `# vim: set filetype=python:` (also `ft=` and `syntax=`).
+The language uses the names and extensions from `--list-languages`. A recognized
+hint overrides a filename extension; explicit `--language` and syntax mappings
+take precedence. Unknown hints fall back to normal detection. Only the first line
+is examined, including for stdin; editor settings are never executed.
+
 ## Customization
 
 ### Highlighting theme

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -236,6 +236,22 @@ impl HighlightingAssets {
                 .or_else(|| Some(p.to_owned()))
         });
 
+        // An explicit syntax mapping wins over a modeline, just like --language.
+        // Otherwise a valid first-line editor hint takes precedence over file extensions.
+        let has_explicit_mapping = absolute_path.as_ref().is_some_and(|path| {
+            matches!(mapping.get_syntax_for(path), Some(MappingTarget::MapTo(_)))
+        });
+        if !has_explicit_mapping {
+            if let Ok(first_line) = std::str::from_utf8(&input.reader.first_line) {
+                let first_line = first_line.trim_start_matches('\u{feff}');
+                for (_, token) in crate::modeline::syntax_names(first_line) {
+                    if let Some(syntax) = self.find_syntax_by_token(token)? {
+                        return Ok(syntax);
+                    }
+                }
+            }
+        }
+
         let path_syntax = if let Some(ref path) = absolute_path {
             self.get_syntax_for_path(path, mapping).or_else(|e| {
                 // If syntax detection failed on the given path, retry with the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 #![deny(unsafe_code)]
 
 mod macros;
+mod modeline;
 
 pub mod assets;
 pub mod assets_metadata {

--- a/src/modeline.rs
+++ b/src/modeline.rs
@@ -1,0 +1,75 @@
+//! Recognize syntax names in the already-buffered first line. Modelines are data:
+//! no editor options, expressions, or commands are evaluated.
+
+pub(crate) fn syntax_names(line: &str) -> Vec<(usize, &str)> {
+    let mut names = Vec::new();
+    if let Some(start) = line.find("-*-") {
+        let rest = &line[start + 3..];
+        if let Some(end) = rest.find("-*-") {
+            let options = rest[..end].trim();
+            if !options.contains([':', ';']) {
+                if !options.is_empty() {
+                    names.push((start, options));
+                }
+            } else {
+                for option in options.split(';') {
+                    if let Some((key, value)) = option.split_once(':') {
+                        if key.trim().eq_ignore_ascii_case("mode") && !value.trim().is_empty() {
+                            names.push((start, value.trim()));
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for marker in ["vim:", "vi:", "ex:"] {
+        for (start, _) in line.match_indices(marker) {
+            if start > 0 && !line[..start].ends_with(char::is_whitespace) {
+                continue;
+            }
+            let options = &line[start + marker.len()..];
+            for option in options.split(|c: char| c.is_whitespace() || c == ':') {
+                if let Some((key, value)) = option.split_once('=') {
+                    if matches!(key, "ft" | "filetype" | "syntax") && !value.is_empty() {
+                        names.push((start, value));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    names.sort_by_key(|(offset, _)| *offset);
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognize_only_complete_modelines() {
+        for line in [
+            "# -*- python",
+            "# mode: python",
+            "# notvim: ft=python",
+            "vim: setting=python",
+            "# -*- -*-",
+        ] {
+            assert!(syntax_names(line).is_empty(), "{line}");
+        }
+        assert_eq!(
+            syntax_names("# -*- coding: utf-8; Mode: python; -*-"),
+            vec![(2, "python")]
+        );
+        assert_eq!(
+            syntax_names("/* vim: set ts=4 ft=cpp: */"),
+            vec![(3, "cpp")]
+        );
+        assert_eq!(
+            syntax_names("# -*- rust -*- vim: ft=python"),
+            vec![(2, "rust"), (15, "python")]
+        );
+    }
+}

--- a/tests/modelines.rs
+++ b/tests/modelines.rs
@@ -1,0 +1,86 @@
+mod utils;
+
+use utils::command::bat;
+
+fn output(args: &[&str], input: &str) -> Vec<u8> {
+    bat()
+        .args([
+            "--color=always",
+            "--theme=TwoDark",
+            "--style=plain",
+            "--paging=never",
+        ])
+        .args(args)
+        .write_stdin(input)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
+}
+
+#[test]
+fn vim_and_emacs_modelines_select_syntax_without_extensions() {
+    for first in [
+        "# -*- python -*-",
+        "# -*- coding: utf-8; mode: python; -*-",
+        "# vim: set ts=4 filetype=python:",
+        "# vi: ft=python",
+        "# ex: syntax=python",
+        "\u{feff}# -*- python -*-",
+    ] {
+        let text = format!("{first}\nprint('hello')\n");
+        assert_eq!(
+            output(&[], &text),
+            output(&["--language=python"], &text),
+            "{first}"
+        );
+    }
+}
+
+#[test]
+fn modelines_override_extensions_but_not_explicit_language_or_mapping() {
+    let text = "# -*- python -*-\nprint('hello')\n";
+    assert_eq!(
+        output(&["--file-name=unknown.rs"], text),
+        output(&["--language=python"], text)
+    );
+    assert_eq!(
+        output(&["--file-name=unknown.rs", "--language=rust"], text),
+        output(&["--language=rust"], text)
+    );
+    assert_eq!(
+        output(&["--file-name=custom", "--map-syntax=custom:Rust"], text),
+        output(&["--language=rust"], text)
+    );
+}
+
+#[test]
+fn unrecognized_modeline_falls_back_to_filename_and_shebang() {
+    let rust = "// -*- not-a-language -*-\nfn main() {}\n";
+    assert_eq!(
+        output(&["--file-name=example.rs"], rust),
+        output(&["--language=rust"], rust)
+    );
+    let python = "#!/usr/bin/python # -*- not-a-language -*-\nprint('hello')\n";
+    assert_eq!(output(&[], python), output(&["--language=python"], python));
+}
+
+#[test]
+fn first_modeline_wins_and_later_lines_are_not_scanned() {
+    let text = "# -*- python -*- vim: ft=rust\nprint('hello')\n";
+    assert_eq!(output(&[], text), output(&["--language=python"], text));
+    let text = "no modeline here\n# -*- python -*-\nprint('hello')\n";
+    assert_eq!(output(&[], text), output(&["--language=txt"], text));
+}
+
+#[test]
+fn ordinary_text_does_not_become_a_modeline() {
+    for text in [
+        "notvim: ft=python\nprint('hello')\n",
+        "# -*- python\nprint('hello')\n",
+        "# mode: python\nprint('hello')\n",
+    ] {
+        assert_eq!(output(&[], text), output(&["--language=txt"], text));
+    }
+}


### PR DESCRIPTION
Files without useful extensions cannot generically select their language through editor modelines.

Recognize first-line Emacs language/mode hints and Vim/vi/ex `ft`, `filetype`, and `syntax` hints. Resolve language names through the existing syntax set, including custom syntaxes. Valid hints take precedence over extensions; explicit language selections and filename mappings retain priority. Unknown or malformed hints fall back to existing detection. The parser only examines already-buffered first-line text and does not evaluate editor options.

Fixes #1600.

Validation: five CLI integration tests, one parser test, and existing syntax-detection tests passed. Covers both modeline forms, UTF-8 BOM, precedence, unknown hints, ordinary text, multiple hints, and first-line-only behavior. Formatting and whitespace checks passed. [GitHub CI](https://github.com/sharkdp/bat/actions/runs/34075122922) and changelog checks passed.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.