### PR TITLE
Add syntax delimiters for independent snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--syntax-delimiter` to reset highlighting between independent text sections, see #0 (@Matei02355)
+- Add `--syntax-delimiter` to reset highlighting between independent text sections, see #3930 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--syntax-delimiter` to reset highlighting between independent text sections, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ minimal-application = [
 git = ["gix"] # Support indicating git modifications
 paging = [ "shell-words", "grep-cli", "minus"] # Support applying a pager on the output
 lessopen = ["execute"] # Support $LESSOPEN preprocessor
-build-assets = ["syntect/yaml-load", "syntect/plist-load", "regex", "walkdir"]
+build-assets = ["syntect/yaml-load", "syntect/plist-load", "walkdir"]
 
 # You need to use one of these if you depend on bat as a library:
 regex-onig = ["syntect/regex-onig"] # Use the "oniguruma" regex engine
@@ -66,7 +66,7 @@ clircle = { version = "0.6.1", default-features = false }
 bugreport = { version = "0.6.0", optional = true }
 etcetera = { version = "0.11.0", optional = true }
 grep-cli = { version = "0.1.12", optional = true }
-regex = { version = "1.12.3", optional = true }
+regex = "1.12.3"
 walkdir = { version = "2.5", optional = true }
 bytesize = { version = "2.3.1" }
 encoding_rs = "0.8.35"

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -136,6 +136,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-l'                      , 'l'                     , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
             [CompletionResult]::new('--language'              , 'language'              , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
         #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+            [CompletionResult]::new('--syntax-delimiter'        , 'syntax-delimiter'        , [CompletionResultType]::ParameterName, 'Reset highlighting before matching lines.')
             [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
             [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
             [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -87,7 +87,7 @@ _bat() {
 		__bat_escape_completions
 		return 0
 		;;
-	-H | --highlight-line | \
+	-H | --highlight-line | --syntax-delimiter | \
 	--diff-context | \
 	--tabs | \
 	--terminal-width | \
@@ -202,6 +202,7 @@ _bat() {
 			--plain
 			--language
 			--highlight-line
+			--syntax-delimiter
 			--file-name
 			--diff
 			--diff-context

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -176,6 +176,7 @@ complete -c $bat -s h -d "Print a concise overview" -n __fish_is_first_arg
 
 complete -c $bat -l help -f -d "Print all help information" -n __fish_is_first_arg
 
+complete -c $bat -l syntax-delimiter -x -d "Reset highlighting before matching lines" -n __bat_no_excl_args
 complete -c $bat -s H -l highlight-line -x -d "Highlight line(s) N[:M]" -n __bat_no_excl_args
 
 complete -c $bat -l ignored-suffix -x -d "Ignore extension" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -29,6 +29,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --binary='[specify how to treat binary content]:behavior:(no-printing as-text)'
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
+        --syntax-delimiter='[reset highlighting before matching lines]:regex'
         \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
         \*--file-name='[specify the name to display for a file]:name:_files'
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -305,6 +305,14 @@ Print this help message.
 \fB\-V\fR, \fB\-\-version\fR
 .IP
 Show version information.
+.HP
+\fB\-\-syntax-delimiter\fR <regex>
+.IP
+Reset syntax highlighting before each line matching a regular expression.
+Delimiter lines are still displayed. Matches exclude line endings and are
+evaluated before wrapping, including lines hidden by '\-\-line-range'.
+For example, '\-\-syntax-delimiter=^---$' separates independent snippets at
+lines containing exactly '---'.
 .SH "POSITIONAL ARGUMENTS"
 .HP
 \fB<FILE>...\fR

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -37,6 +37,12 @@ Options:
           name (like 'C++' or 'LaTeX') or possible file extension (like 'cpp', 'hpp' or 'md'). Use
           '--list-languages' to show all supported language names and file extensions.
 
+      --syntax-delimiter <regex>
+          Reset syntax highlighting state before each line matching a regular expression. Useful for
+          independent snippets or shell history entries with unmatched quotes. Delimiter lines are
+          still printed and highlighted. Matches exclude line endings and are evaluated before
+          wrapping. For example, '--syntax-delimiter=^---$' starts a new section at each '---' line.
+
       --fallback-syntax <fallback-syntax>
           Set a fallback language for syntax highlighting when auto-detection fails. Unlike
           '--language', this is only used when no syntax could be detected from filename, custom

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -17,6 +17,8 @@ Options:
           Show plain style (alias for '--style=plain').
   -l, --language <language>
           Set the language for syntax highlighting.
+      --syntax-delimiter <regex>
+          Reset highlighting before lines matching a regular expression.
       --fallback-syntax <fallback-syntax>
           Set a fallback language for undetected syntaxes. [aliases: --fallback-language]
   -H, --highlight-line <N:M>

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -382,6 +382,10 @@ impl App {
                 .matches
                 .get_one::<String>("fallback-syntax")
                 .map(|s| s.as_str()),
+            syntax_delimiter: self
+                .matches
+                .get_one::<regex::Regex>("syntax-delimiter")
+                .cloned(),
             show_nonprintable: self.matches.get_flag("show-all"),
             nonprintable_notation: match self
                 .matches

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -123,6 +123,21 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("syntax-delimiter")
+                .long("syntax-delimiter")
+                .overrides_with("syntax-delimiter")
+                .value_name("regex")
+                .value_parser(regex::Regex::new)
+                .help("Reset highlighting before lines matching a regular expression.")
+                .long_help(
+                    "Reset syntax highlighting state before each line matching a regular \
+                     expression. Useful for independent snippets or shell history entries with \
+                     unmatched quotes. Delimiter lines are still printed and highlighted. \
+                     Matches exclude line endings and are evaluated before wrapping. \
+                     For example, '--syntax-delimiter=^---$' starts a new section at each '---' line.",
+                ),
+        )
+        .arg(
             Arg::new("fallback-syntax")
                 .long("fallback-syntax")
                 .visible_alias("fallback-language")

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,9 @@ pub struct Config<'a> {
     /// The fallback syntax used when auto-detection fails
     pub fallback_syntax: Option<&'a str>,
 
+    /// Reset syntax highlighting before lines matching this regular expression.
+    pub syntax_delimiter: Option<regex::Regex>,
+
     /// Whether or not to show/replace non-printable characters like space, tab and newline.
     pub show_nonprintable: bool,
 

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -115,6 +115,15 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Reset highlighting before lines matching the given regular expression.
+    pub fn syntax_delimiter(&mut self, pattern: &str) -> Result<&mut Self> {
+        self.config.syntax_delimiter = Some(
+            regex::Regex::new(pattern)
+                .map_err(|error| format!("Invalid syntax delimiter: {error}"))?,
+        );
+        Ok(self)
+    }
+
     /// The character width of the terminal (default: autodetect)
     pub fn term_width(&mut self, width: usize) -> &mut Self {
         self.term_width = Some(width);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -187,6 +187,8 @@ impl Printer for SimplePrinter<'_> {
 struct HighlighterFromSet<'a> {
     highlighter: HighlightLines<'a>,
     syntax_set: &'a SyntaxSet,
+    syntax: &'a syntect::parsing::SyntaxReference,
+    theme: &'a Theme,
 }
 
 impl<'a> HighlighterFromSet<'a> {
@@ -194,6 +196,8 @@ impl<'a> HighlighterFromSet<'a> {
         Self {
             highlighter: HighlightLines::new(syntax_in_set.syntax, theme),
             syntax_set: syntax_in_set.syntax_set,
+            syntax: syntax_in_set.syntax,
+            theme,
         }
     }
 }
@@ -450,6 +454,16 @@ impl<'a> InteractivePrinter<'a> {
             Some(ref mut highlighter_from_set) => highlighter_from_set,
             _ => return Ok(vec![(EMPTY_SYNTECT_STYLE, line)]),
         };
+
+        if self
+            .config
+            .syntax_delimiter
+            .as_ref()
+            .is_some_and(|delimiter| delimiter.is_match(line.trim_end_matches(['\r', '\n'])))
+        {
+            highlighter_from_set.highlighter =
+                HighlightLines::new(highlighter_from_set.syntax, highlighter_from_set.theme);
+        }
 
         // skip syntax highlighting on long lines
         let too_long = line.len() > 1024 * 16;

--- a/tests/syntax_delimiter.rs
+++ b/tests/syntax_delimiter.rs
@@ -1,0 +1,69 @@
+mod utils;
+
+use utils::command::bat;
+
+fn output(args: &[&str], input: &str) -> Vec<u8> {
+    bat()
+        .args([
+            "--color=always",
+            "--theme=TwoDark",
+            "--language=rust",
+            "--style=plain",
+            "--paging=never",
+        ])
+        .args(args)
+        .write_stdin(input)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
+}
+
+#[test]
+fn delimiter_resets_unterminated_comments_and_strings() {
+    for first in ["/* unmatched\n", "let text = \"unmatched\n"] {
+        let second = "---\nfn main() {}\n";
+        let input = format!("{first}{second}");
+        let expected = [output(&[], first), output(&[], second)].concat();
+        assert_eq!(output(&["--syntax-delimiter=^---$"], &input), expected);
+        assert_ne!(output(&[], &input), expected);
+    }
+}
+
+#[test]
+fn delimiter_in_hidden_lines_still_resets_state() {
+    let input = "/* unmatched\n---\nfn main() {}\n";
+    assert_eq!(
+        output(&["--syntax-delimiter=^---$", "--line-range=3:"], input),
+        output(&[], "fn main() {}\n")
+    );
+}
+
+#[test]
+fn delimiter_matching_excludes_crlf() {
+    let first = "/* unmatched\r\n";
+    let second = "---\r\nfn main() {}\r\n";
+    assert_eq!(
+        output(&["--syntax-delimiter=^---$"], &format!("{first}{second}")),
+        [output(&[], first), output(&[], second)].concat()
+    );
+}
+
+#[test]
+fn unmatched_delimiter_keeps_multiline_highlighting() {
+    let input = "/* a\nmultiline comment */\nfn main() {}\n";
+    assert_eq!(
+        output(&["--syntax-delimiter=^---$"], input),
+        output(&[], input)
+    );
+}
+
+#[test]
+fn invalid_syntax_delimiter_fails_before_printing() {
+    bat()
+        .args(["--syntax-delimiter=[", "test.txt"])
+        .assert()
+        .failure()
+        .stdout("");
+}


### PR DESCRIPTION
An unmatched quote or comment in one shell-history entry or snippet can leave all subsequent entries highlighted in the wrong state.

Add `--syntax-delimiter <regex>` and `PrettyPrinter::syntax_delimiter()`. Before a matching line, recreate the syntax parser/highlighter with the same syntax and theme. Delimiters stay visible, matching excludes line endings, and hidden lines still update/reset state. Patterns compile once during configuration.

Fixes #3811.

Validation: five new integration tests passed, covering unmatched comments/strings, visible ranges, CRLF, unchanged multiline highlighting when there is no delimiter, and malformed patterns. Formatting and whitespace checks passed. GitHub code quality, documentation, MSRV, and platform jobs passed. The [CI run](https://github.com/sharkdp/bat/actions/runs/34075569826) needs a maintainer retry: syntax/theme and license jobs failed during checkout because Codeberg returned HTTP 504 for the Zig submodule, before either check ran.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.