### PR TITLE
Support separate styles for single files, stdin, and multiple inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Allow separate styles for a single file, stdin, and multiple inputs, see #0 (@Matei02355)
+- Allow separate styles for a single file, stdin, and multiple inputs, see #3931 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Allow separate styles for a single file, stdin, and multiple inputs, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -454,6 +454,15 @@ bat --completion <shell>
 # see --help for supported shells
 ```
 
+### Styles for different inputs
+
+Use `--style-single-file`, `--style-stdin`, and `--style-multiple-files` to select
+styles by input type. For example, configure `--style-single-file=plain` and
+`--style-stdin=plain` with `--style-multiple-files=header,rule` to show filenames
+only when concatenating several inputs. A mixture of files and stdin uses the
+multiple-file style throughout. Each context supports the same `+`/`-` modifiers
+as `--style`; explicit plain and numbering flags still take precedence.
+
 ## Customization
 
 ### Highlighting theme

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -65,7 +65,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
             break
         }
-        '*;--style' {
+        {$_ -like '*;--style' -or $_ -like '*;--style-single-file' -or $_ -like '*;--style-stdin' -or $_ -like '*;--style-multiple-files'} {
             $ArrayStyle |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
             break
@@ -152,6 +152,9 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
+            [CompletionResult]::new('--style-single-file'                 , 'style-single-file'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+            [CompletionResult]::new('--style-stdin'                 , 'style-stdin'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+            [CompletionResult]::new('--style-multiple-files'                 , 'style-multiple-files'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
             [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
         #   [CompletionResult]::new('-r'                      , 'r'                     , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -165,7 +165,7 @@ _bat() {
 		__bat_escape_completions
 		return 0
 		;;
-	--style)
+	--style | --style-single-file | --style-stdin | --style-multiple-files)
 		# shellcheck disable=SC2034
 		local -a styles=(
 			default
@@ -228,6 +228,9 @@ _bat() {
 			--sanitize
 			--strip-ansi
 			--style
+			--style-single-file
+			--style-stdin
+			--style-multiple-files
 			--line-range
 			--list-languages
 			--lessopen

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -229,6 +229,9 @@ complete -c $bat -o pp -d "Disable decorations and paging" -n __bat_no_excl_args
 
 complete -c $bat -s P -d "Disable paging" -n __bat_no_excl_args
 
+complete -c $bat -l style-single-file -x -k -a "(__fish_complete_list , __bat_style_opts)" -d "Specify which non-content elements to display" -n __bat_no_excl_args
+complete -c $bat -l style-stdin -x -k -a "(__fish_complete_list , __bat_style_opts)" -d "Specify which non-content elements to display" -n __bat_no_excl_args
+complete -c $bat -l style-multiple-files -x -k -a "(__fish_complete_list , __bat_style_opts)" -d "Specify which non-content elements to display" -n __bat_no_excl_args
 complete -c $bat -l style -x -k -a "(__fish_complete_list , __bat_style_opts)" -d "Specify which non-content elements to display" -n __bat_no_excl_args
 
 complete -c $bat -l tabs -x -a "$tabs_opts" -d "Set tab width" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -55,6 +55,12 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --squeeze-limit='[set the maximum number of consecutive empty lines]:limit:'
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
+        --style-single-file='[comma-separated list of style elements to display]: : _values "style [default]"
+            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+        --style-stdin='[comma-separated list of style elements to display]: : _values "style [default]"
+            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+        --style-multiple-files='[comma-separated list of style elements to display]: : _values "style [default]"
+            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
             default auto full plain changes header header-filename header-filesize grid rule numbers snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -305,6 +305,18 @@ Print this help message.
 \fB\-V\fR, \fB\-\-version\fR
 .IP
 Show version information.
+.HP
+\fB\-\-style-single-file\fR <components>
+.HP
+\fB\-\-style-stdin\fR <components>
+.HP
+\fB\-\-style-multiple-files\fR <components>
+.IP
+Select styles for a single file, stdin alone, or multiple inputs respectively.
+A mixture of files and '-' uses the multiple-input style for every input.
+Uses the same components and +/- modifiers as '\-\-style', applied after
+the general style. Explicit plain/numbering flags and disabled decorations
+still take precedence. These options can be set in the configuration file.
 .SH "POSITIONAL ARGUMENTS"
 .HP
 \fB<FILE>...\fR

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -57,6 +57,24 @@ Options:
           does not otherwise know the filename. Note that the provided file name is also used for
           syntax detection.
 
+      --style-single-file <components>
+          Override the style when displaying one file. Uses the same components and +/- modifiers as
+          '--style'. Applied after the general style. Multiple inputs include any combination of
+          files and '-'. Explicit '--plain', numbering flags, and '--decorations=never' still take
+          precedence.
+
+      --style-stdin <components>
+          Override the style when displaying only standard input. Uses the same components and +/-
+          modifiers as '--style'. Applied after the general style. Multiple inputs include any
+          combination of files and '-'. Explicit '--plain', numbering flags, and
+          '--decorations=never' still take precedence.
+
+      --style-multiple-files <components>
+          Override the style when displaying multiple inputs. Uses the same components and +/-
+          modifiers as '--style'. Applied after the general style. Multiple inputs include any
+          combination of files and '-'. Explicit '--plain', numbering flags, and
+          '--decorations=never' still take precedence.
+
   -d, --diff
           Only show lines that have been added/removed/modified with respect to the Git index. Use
           --diff-context=N to control how much context you want to see.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -23,6 +23,12 @@ Options:
           Highlight lines N through M.
       --file-name <name>
           Specify the name to display for a file.
+      --style-single-file <components>
+          Override the style when displaying one file.
+      --style-stdin <components>
+          Override the style when displaying only standard input.
+      --style-multiple-files <components>
+          Override the style when displaying multiple inputs.
   -d, --diff
           Only show lines that have been added/removed/modified.
       --tabs <T>

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -267,7 +267,7 @@ impl App {
     }
 
     pub fn config(&self, inputs: &[Input]) -> Result<Config<'_>> {
-        let style_components = self.style_components()?;
+        let style_components = self.style_components(inputs)?;
 
         let extra_plain = self.matches.get_count("plain") > 1;
         let plain_last_index = self
@@ -627,16 +627,25 @@ impl App {
         None
     }
 
-    fn style_components(&self) -> Result<StyleComponents> {
+    fn style_components(&self, inputs: &[Input]) -> Result<StyleComponents> {
         let matches = &self.matches;
+        let context = if inputs.len() > 1 {
+            "style-multiple-files"
+        } else if inputs.first().is_some_and(Input::is_stdin) {
+            "style-stdin"
+        } else {
+            "style-single-file"
+        };
         let mut styled_components = match self.forced_style_components() {
             Some(forced_components) => forced_components,
 
             // Parse the `--style` arguments and merge them.
-            None if matches.contains_id("style") => {
+            None if matches.contains_id("style") || matches.contains_id(context) => {
                 let lists = matches
                     .get_many::<String>("style")
-                    .expect("styles present")
+                    .into_iter()
+                    .flatten()
+                    .chain(matches.get_many::<String>(context).into_iter().flatten())
                     .map(|v| StyleComponentList::from_str(v))
                     .collect::<Result<Vec<StyleComponentList>>>()?;
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -165,6 +165,40 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         );
 
+    for (name, description) in [
+        (
+            "style-single-file",
+            "Override the style when displaying one file.",
+        ),
+        (
+            "style-stdin",
+            "Override the style when displaying only standard input.",
+        ),
+        (
+            "style-multiple-files",
+            "Override the style when displaying multiple inputs.",
+        ),
+    ] {
+        app = app.arg(
+            Arg::new(name)
+                .long(name)
+                .value_name("components")
+                .action(ArgAction::Append)
+                .value_parser(|s: &str| {
+                    StyleComponentList::from_str(s)
+                        .map(|_| s.to_owned())
+                        .map_err(|e| e.to_string())
+                })
+                .help(description)
+                .long_help(format!(
+                    "{description} Uses the same components and +/- modifiers as '--style'. \
+                     Applied after the general style. Multiple inputs include any combination of \
+                     files and '-'. Explicit '--plain', numbering flags, and '--decorations=never' \
+                     still take precedence."
+                )),
+        );
+    }
+
     #[cfg(feature = "git")]
     {
         app = app

--- a/tests/context_styles.rs
+++ b/tests/context_styles.rs
@@ -1,0 +1,101 @@
+mod utils;
+
+use utils::command::bat;
+
+fn output(args: &[&str], input: &str) -> Vec<u8> {
+    bat()
+        .args(["--decorations=always", "--color=never", "--paging=never"])
+        .args(args)
+        .write_stdin(input)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
+}
+
+const CONTEXTS: [&str; 3] = [
+    "--style-single-file=numbers",
+    "--style-stdin=plain",
+    "--style-multiple-files=header",
+];
+
+#[test]
+fn single_file_and_stdin_use_distinct_styles() {
+    let mut args = CONTEXTS.to_vec();
+    args.push("test.txt");
+    assert_eq!(
+        output(&args, ""),
+        output(&["--style=numbers", "test.txt"], "")
+    );
+    assert_eq!(output(&CONTEXTS, "text\n"), b"text\n");
+    assert_eq!(
+        output(&[CONTEXTS[0], CONTEXTS[1], CONTEXTS[2], "-"], "text\n"),
+        b"text\n"
+    );
+}
+
+#[test]
+fn mixed_inputs_all_use_multiple_file_style() {
+    for inputs in [
+        vec!["test.txt", "test.txt"],
+        vec!["-", "test.txt"],
+        vec!["test.txt", "-"],
+    ] {
+        let mut args = CONTEXTS.to_vec();
+        args.extend(&inputs);
+        let mut expected = vec!["--style=header"];
+        expected.extend(&inputs);
+        assert_eq!(output(&args, "stdin\n"), output(&expected, "stdin\n"));
+    }
+}
+
+#[test]
+fn context_modifiers_build_on_general_style() {
+    assert_eq!(
+        output(
+            &[
+                "--style=numbers,header",
+                "--style-single-file=-header",
+                "test.txt"
+            ],
+            ""
+        ),
+        output(&["--style=numbers", "test.txt"], "")
+    );
+    assert_eq!(
+        output(
+            &[
+                "--style=numbers",
+                "--style-multiple-files=plain",
+                "test.txt"
+            ],
+            ""
+        ),
+        output(&["--style=numbers", "test.txt"], "")
+    );
+}
+
+#[test]
+fn plain_numbering_and_disabled_decorations_take_precedence() {
+    for flag in [
+        "--plain",
+        "--number",
+        "--number-nonblank",
+        "--decorations=never",
+    ] {
+        assert_eq!(
+            output(&["--style-stdin=header", flag], "one\n\ntwo\n"),
+            output(&[flag], "one\n\ntwo\n")
+        );
+    }
+}
+
+#[test]
+fn invalid_context_style_is_rejected() {
+    bat()
+        .args(["--style-single-file=invalid", "test.txt"])
+        .assert()
+        .failure()
+        .stdout("");
+}


### PR DESCRIPTION
A single style cannot keep one-file/stdin output compact while showing filenames when concatenating several inputs.

Add `--style-single-file`, `--style-stdin`, and `--style-multiple-files`, usable in the config file. Select one context for the entire invocation, treating mixtures of files and stdin as multiple inputs. Apply context styles after general styles with the existing +/- modifier semantics, while retaining explicit plain/numbering/decoration overrides.

Fixes #3425.

Validation: five new integration tests passed, covering input selection, mixed ordering, general-style modifiers, inactive context settings, forced styles, and invalid values. Formatting and whitespace checks passed. [GitHub CI](https://github.com/sharkdp/bat/actions/runs/34075902468) and changelog checks passed.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.