### PR TITLE
Highlight only inserted escape markers with --show-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Only highlight inserted nonprintable placeholders with `--show-all`, preserving literal escape spellings, see #0 (@Matei02355)
+- Only highlight inserted nonprintable placeholders with `--show-all`, preserving literal escape spellings, see #3932 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Only highlight inserted nonprintable placeholders with `--show-all`, preserving literal escape spellings, see #0 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -61,6 +61,31 @@ pub fn replace_nonprintable(
     tab_width: usize,
     nonprintable_notation: NonprintableNotation,
 ) -> String {
+    replace_nonprintable_impl(input, tab_width, nonprintable_notation, |_| {})
+}
+
+pub(crate) fn replace_nonprintable_with_ranges(
+    input: &[u8],
+    tab_width: usize,
+    notation: NonprintableNotation,
+) -> (String, Vec<std::ops::Range<usize>>) {
+    let mut ranges: Vec<std::ops::Range<usize>> = Vec::new();
+    let text = replace_nonprintable_impl(input, tab_width, notation, |range| {
+        if let Some(last) = ranges.last_mut().filter(|last| last.end == range.start) {
+            last.end = range.end;
+        } else {
+            ranges.push(range);
+        }
+    });
+    (text, ranges)
+}
+
+fn replace_nonprintable_impl(
+    input: &[u8],
+    tab_width: usize,
+    nonprintable_notation: NonprintableNotation,
+    mut replacement: impl FnMut(std::ops::Range<usize>),
+) -> String {
     let mut output = String::new();
 
     let tab_width = if tab_width == 0 { 4 } else { tab_width };
@@ -69,6 +94,8 @@ pub fn replace_nonprintable(
     let mut line_idx = 0;
     let len = input.len();
     while idx < len {
+        let start = output.len();
+        let mut replaced = true;
         if let Some((chr, skip_ahead)) = try_parse_utf8_char(&input[idx..]) {
             idx += skip_ahead;
             line_idx += 1;
@@ -122,6 +149,7 @@ pub fn replace_nonprintable(
                     || c.is_ascii_punctuation()
                     || c.is_ascii_graphic() =>
                 {
+                    replaced = false;
                     output.push(c)
                 }
                 // everything else
@@ -130,6 +158,9 @@ pub fn replace_nonprintable(
         } else {
             write!(output, "\\x{:02X}", input[idx]).ok();
             idx += 1;
+        }
+        if replaced {
+            replacement(start..output.len());
         }
     }
 
@@ -528,4 +559,27 @@ fn test_sanitize_for_terminal_idempotent_on_sanitized() {
     assert_eq!(sanitize_for_terminal(&clean), clean);
     assert!(!clean.contains('\x1b'));
     assert!(!clean.contains('\x07'));
+}
+
+#[test]
+fn nonprintable_ranges_distinguish_literal_escape_spellings() {
+    let (text, ranges) =
+        replace_nonprintable_with_ranges(b"\x86_64 != \\x86_64", 4, NonprintableNotation::Unicode);
+    assert_eq!(text, "\\x86_64\u{b7}!=\u{b7}\\x86_64");
+    let placeholders: Vec<_> = ranges.iter().map(|range| &text[range.clone()]).collect();
+    assert_eq!(placeholders, vec!["\\x86", "\u{b7}", "\u{b7}"]);
+}
+
+#[test]
+fn nonprintable_ranges_track_unicode_tabs_and_caret_controls() {
+    for notation in [NonprintableNotation::Unicode, NonprintableNotation::Caret] {
+        let input = "a\t界\0z\n".as_bytes();
+        let (text, ranges) = replace_nonprintable_with_ranges(input, 4, notation);
+        assert_eq!(text, replace_nonprintable(input, 4, notation));
+        assert!(ranges
+            .iter()
+            .all(|range| text.is_char_boundary(range.start) && text.is_char_boundary(range.end)));
+        assert_eq!(&text[..ranges[0].start], "a");
+        assert_eq!(&text[ranges[0].end..ranges[1].start], "z");
+    }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -30,8 +30,8 @@ use crate::input::OpenedInput;
 use crate::line_range::{MaxBufferedLineNumber, RangeCheckResult};
 use crate::output::OutputHandle;
 use crate::preprocessor::{
-    expand_tabs, replace_nonprintable, sanitize, sanitize_for_terminal, strip_ansi,
-    strip_overstrike,
+    expand_tabs, replace_nonprintable, replace_nonprintable_with_ranges, sanitize,
+    sanitize_for_terminal, strip_ansi, strip_overstrike,
 };
 use crate::style::StyleComponent;
 use crate::terminal::{as_terminal_escaped, to_ansi_color};
@@ -213,6 +213,7 @@ pub(crate) struct InteractivePrinter<'a> {
     strip_ansi: bool,
     sanitize: bool,
     strip_overstrike: bool,
+    plain_style: syntect::highlighting::Style,
 }
 
 impl<'a> InteractivePrinter<'a> {
@@ -332,6 +333,7 @@ impl<'a> InteractivePrinter<'a> {
         };
 
         Ok(InteractivePrinter {
+            plain_style: syntect::highlighting::Highlighter::new(theme).get_default(),
             panel_width,
             colors,
             config,
@@ -653,13 +655,15 @@ impl Printer for InteractivePrinter<'_> {
         line_buffer: &[u8],
         max_buffered_line_number: MaxBufferedLineNumber,
     ) -> Result<()> {
+        let mut replacement_ranges = Vec::new();
         let line = if self.config.show_nonprintable {
-            replace_nonprintable(
+            let (text, ranges) = replace_nonprintable_with_ranges(
                 line_buffer,
                 self.config.tab_width,
                 self.config.nonprintable_notation,
-            )
-            .into()
+            );
+            replacement_ranges = ranges;
+            text.into()
         } else {
             let mut line = match self.content_type {
                 Some(ContentType::BINARY) | None
@@ -698,7 +702,20 @@ impl Printer for InteractivePrinter<'_> {
             line
         };
 
-        let regions = self.highlight_regions_for_line(&line)?;
+        let mut regions = self.highlight_regions_for_line(&line)?;
+        if self.config.show_nonprintable
+            && self
+                .config
+                .language
+                .is_some_and(|language| language.eq_ignore_ascii_case("show-nonprintable"))
+        {
+            regions = mask_nonprintable_highlighting(
+                &line,
+                regions,
+                &replacement_ranges,
+                self.plain_style,
+            );
+        }
         if out_of_range {
             return Ok(());
         }
@@ -1022,4 +1039,36 @@ impl Colors {
             line_number: gutter_style,
         }
     }
+}
+
+/// Keep highlighting only on placeholders inserted by the nonprintable preprocessor.
+/// Literal escape spellings in the source retain the theme's normal text style.
+fn mask_nonprintable_highlighting<'a>(
+    line: &'a str,
+    regions: Vec<(syntect::highlighting::Style, &'a str)>,
+    replacements: &[std::ops::Range<usize>],
+    plain: syntect::highlighting::Style,
+) -> Vec<(syntect::highlighting::Style, &'a str)> {
+    let mut result = Vec::new();
+    let mut replacements = replacements.iter().peekable();
+    let mut offset = 0;
+    for (style, region) in regions {
+        let end = offset + region.len();
+        while offset < end {
+            while replacements.peek().is_some_and(|range| range.end <= offset) {
+                replacements.next();
+            }
+            let (boundary, is_replacement) = match replacements.peek() {
+                Some(range) if range.start <= offset => (end.min(range.end), true),
+                Some(range) => (end.min(range.start), false),
+                None => (end, false),
+            };
+            result.push((
+                if is_replacement { style } else { plain },
+                &line[offset..boundary],
+            ));
+            offset = boundary;
+        }
+    }
+    result
 }

--- a/tests/nonprintable_highlighting.rs
+++ b/tests/nonprintable_highlighting.rs
@@ -1,0 +1,70 @@
+mod utils;
+
+use utils::command::bat;
+
+fn output(args: &[&str], input: &[u8]) -> String {
+    String::from_utf8(
+        bat()
+            .args([
+                "--color=always",
+                "--theme=TwoDark",
+                "--style=plain",
+                "--paging=never",
+            ])
+            .args(args)
+            .write_stdin(input)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap()
+}
+
+// Read the SGR style active at an ASCII substring, without depending on theme RGB values.
+fn style_at(text: &str, position: usize) -> &str {
+    let prefix = &text[..position];
+    prefix
+        .rfind("\x1b[")
+        .map(|start| &prefix[start..start + prefix[start..].find('m').unwrap() + 1])
+        .unwrap_or("")
+}
+
+#[test]
+fn literal_hex_escapes_keep_plain_text_color() {
+    let colored = output(&["--show-all"], b"\x86_64 != \\x86_64");
+    let positions: Vec<_> = colored.match_indices("\\x86").map(|(i, _)| i).collect();
+    assert_eq!(positions.len(), 2);
+    let plain = output(&["--language=txt"], b"\\x86");
+    assert_eq!(
+        style_at(&colored, positions[1]),
+        style_at(&plain, plain.find("\\x86").unwrap())
+    );
+    assert_ne!(
+        style_at(&colored, positions[0]),
+        style_at(&colored, positions[1])
+    );
+}
+
+#[test]
+fn literal_caret_notation_keeps_plain_color() {
+    let colored = output(&["--show-all", "--nonprintable-notation=caret"], b"\x07^G");
+    let positions: Vec<_> = colored.match_indices("^G").map(|(i, _)| i).collect();
+    assert_eq!(positions.len(), 2);
+    let plain = output(&["--language=txt"], b"^G");
+    assert_eq!(
+        style_at(&colored, positions[1]),
+        style_at(&plain, plain.find("^G").unwrap())
+    );
+}
+
+#[test]
+fn explicit_nonprintable_syntax_still_highlights_literal_escapes() {
+    let colored = output(&["--language=show-nonprintable"], b"\\x86");
+    let plain = output(&["--language=txt"], b"\\x86");
+    assert_ne!(
+        style_at(&colored, colored.find("\\x86").unwrap()),
+        style_at(&plain, plain.find("\\x86").unwrap())
+    );
+}


### PR DESCRIPTION
`--show-all` highlights literal escape spellings such as `\\x86` as if they were placeholders generated for nonprintable input, making the two indistinguishable.

Record byte ranges for generated placeholders during preprocessing, then restrict the automatic show-nonprintable syntax colors to those ranges. Original text keeps the theme's normal text style. The existing preprocessing entrypoint and uncolored output are unchanged; explicitly selecting the show-nonprintable syntax without replacement still highlights escape spellings.

Fixes #2405.

Validation: two range tests and three CLI regression tests passed, covering invalid bytes, literal hex escapes, caret notation, Unicode, tabs, code-point boundaries, and explicit syntax selection. Formatting and whitespace checks passed. [GitHub CI](https://github.com/sharkdp/bat/actions/runs/34076005306) and changelog checks passed.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.