### PR TITLE
Add an opt-in warning for a missing trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add an opt-in warning for a missing trailing newline without changing redirected file contents. Closes #975, see #0 (@Matei02355)
+- Add an opt-in warning for a missing trailing newline without changing redirected file contents. Closes #975, see #3934 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Features
 
+- Add an opt-in warning for a missing trailing newline without changing redirected file contents. Closes #975, see #0 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -60,6 +60,11 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterName, $_)}
             break
         }
+        '*;--warning' {
+            @('none', 'missing-trailing-newline') |
+            ForEach-Object {[CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
         '*;--binary' {
             $ArrayBinary |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
@@ -159,6 +164,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--show-all'              , 'show-all'              , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')
             [CompletionResult]::new('--nonprintable-notation' , 'nonprintable-notation' , [CompletionResultType]::ParameterName, 'Set notation for non-printable characters. (unicode, caret)')
             [CompletionResult]::new('--chop-long-lines'       , 'chop-long-lines'       , [CompletionResultType]::ParameterName, 'Truncate all lines longer than screen width. Alias for ''--wrap=never''.')
+            [CompletionResult]::new('--warning'                , 'warning'                , [CompletionResultType]::ParameterName, 'Enable optional input warnings')
             [CompletionResult]::new('--binary'                , 'binary'                , [CompletionResultType]::ParameterName, 'How to treat binary content. (*no-printing*, as-text)')
             [CompletionResult]::new('--ignored-suffix'        , 'ignored-suffix'        , [CompletionResultType]::ParameterName, 'Ignore extension. For example: ''bat --ignored-suffix ".dev" my_file.json.dev'' will use JSON syntax, and ignore ''.dev''')
             [CompletionResult]::new('--squeeze-blank'         , 'squeeze-blank'         , [CompletionResultType]::ParameterName, 'Squeeze consecutive empty lines into a single empty line.')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -120,6 +120,10 @@ _bat() {
 		COMPREPLY=($(compgen -W "auto never character word" -- "$cur"))
 		return 0
 		;;
+	--warning)
+		COMPREPLY=($(compgen -W "none missing-trailing-newline" -- "$cur"))
+		return 0
+		;;
 	--binary)
 		COMPREPLY=($(compgen -W "no-printing as-text" -- "$cur"))
 		return 0
@@ -199,6 +203,7 @@ _bat() {
 			--show-all
 			--nonprintable-notation
 			--binary
+			--warning
 			--plain
 			--language
 			--highlight-line

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,5 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -l warning -x -a "none missing-trailing-newline" -d "Enable optional input warnings" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -26,6 +26,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
     args=(
         '(-A --show-all)'{-A,--show-all}'[show non-printable characters (space, tab, newline, ..)]'
         --nonprintable-notation='[specify how to display non-printable characters when using --show-all]:notation:(caret unicode)'
+        --warning='[enable optional input warnings]:kind:(none missing-trailing-newline)'
         --binary='[specify how to treat binary content]:behavior:(no-printing as-text)'
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -305,6 +305,13 @@ Print this help message.
 \fB\-V\fR, \fB\-\-version\fR
 .IP
 Show version information.
+.HP
+\fB\-\-warning\fR <kind>
+.IP
+Enable optional warnings: 'none' (default) or 'missing-trailing-newline'.
+The warning appears below formatted output, or on standard error when output is
+passed through unchanged. Empty inputs, binary inputs, and excluded final lines
+do not trigger the warning.
 .SH "POSITIONAL ARGUMENTS"
 .HP
 \fB<FILE>...\fR

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -241,6 +241,12 @@ Options:
       --diagnostic
           Show diagnostic information for bug reports.
 
+      --warning <kind>
+          Enable optional input warnings: 'none' (default) or 'missing-trailing-newline'. A missing
+          final newline is reported below formatted output, or on standard error in plain redirected
+          output. Empty files and final lines excluded by '--line-range' do not produce this
+          warning.
+
   -E, --quiet-empty
           When this flag is set, bat will produce no output at all when the input is empty. This is
           useful when piping commands that may produce empty output, like 'git diff'.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -66,6 +66,8 @@ Options:
           Enable unbuffered input reading for streaming use cases.
       --completion <SHELL>
           Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]
+      --warning <kind>
+          Enable optional input warnings.
   -E, --quiet-empty
           Produce no output when the input is empty.
   -h, --help

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -480,6 +480,11 @@ impl App {
                 "--sanitize",
             ),
             quiet_empty: self.matches.get_flag("quiet-empty"),
+            warn_missing_newline: self
+                .matches
+                .get_one::<String>("warning")
+                .map(String::as_str)
+                == Some("missing-trailing-newline"),
             unbuffered: self.matches.get_flag("unbuffered"),
             number_nonblank: self.matches.get_flag("number-nonblank")
                 || self.number_nonblank_from_cli,

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -702,6 +702,22 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .help("Show diagnostic information for bug reports."),
         )
         .arg(
+            Arg::new("warning")
+                .long("warning")
+                .overrides_with("warning")
+                .value_name("kind")
+                .value_parser(["none", "missing-trailing-newline"])
+                .default_value("none")
+                .hide_default_value(true)
+                .help("Enable optional input warnings.")
+                .long_help(
+                    "Enable optional input warnings: 'none' (default) or 'missing-trailing-newline'. \
+                     A missing final newline is reported below formatted output, or on standard \
+                     error in plain redirected output. Empty files and final lines excluded by \
+                     '--line-range' do not produce this warning.",
+                ),
+        )
+        .arg(
             Arg::new("quiet-empty")
                 .long("quiet-empty")
                 .short('E')

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,9 @@ pub struct Config<'a> {
     /// Whether or not to produce no output when input is empty
     pub quiet_empty: bool,
 
+    /// Report a missing final newline after reading the input to EOF.
+    pub warn_missing_newline: bool,
+
     /// Whether or not to use unbuffered input reading for streaming use cases
     pub unbuffered: bool,
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -242,7 +242,24 @@ impl Controller<'_> {
                 }
             };
 
-            self.print_file_ranges(printer, writer, &mut input.reader, &line_ranges)?;
+            let missing_newline =
+                self.print_file_ranges(printer, writer, &mut input.reader, &line_ranges)?;
+            if self.config.warn_missing_newline
+                && missing_newline
+                && input
+                    .reader
+                    .content_type
+                    .is_some_and(|content| content.is_text())
+            {
+                if self.config.loop_through {
+                    eprintln!(
+                        "[bat warning]: {}: No newline at end of file",
+                        crate::sanitize_for_terminal(&input.description.summary())
+                    );
+                } else {
+                    printer.print_missing_newline_warning(writer)?;
+                }
+            }
         }
         printer.print_footer(writer, input)?;
 
@@ -255,7 +272,7 @@ impl Controller<'_> {
         writer: &mut OutputHandle,
         reader: &mut InputReader,
         line_ranges: &LineRanges,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let mut current_line_buffer: Vec<u8> = Vec::new();
         let mut current_line_number: usize = 1;
         // Buffer needs to be 1 greater than the offset to have a look-ahead line for EOF
@@ -264,6 +281,7 @@ impl Controller<'_> {
         let mut buffered_lines: VecDeque<(Vec<u8>, usize)> = VecDeque::with_capacity(buffer_size);
 
         let mut reached_eof: bool = false;
+        let mut missing_newline = false;
         let mut first_range: bool = true;
         let mut mid_range: bool = false;
 
@@ -305,6 +323,7 @@ impl Controller<'_> {
             let Some((line, line_nr)) = buffered_lines.pop_front() else {
                 break;
             };
+            missing_newline = false;
 
             // Determine if the last line number in the buffer is the last line of the file or
             // just a line somewhere in the file
@@ -328,6 +347,15 @@ impl Controller<'_> {
                 }
 
                 RangeCheckResult::InRange => {
+                    missing_newline = match reader.content_type {
+                        Some(content_inspector::ContentType::UTF_16LE) => {
+                            !line.ends_with(&[b'\n', 0])
+                        }
+                        Some(content_inspector::ContentType::UTF_16BE) => {
+                            !line.ends_with(&[0, b'\n'])
+                        }
+                        _ => !line.ends_with(b"\n"),
+                    };
                     if style_snip {
                         if first_range {
                             first_range = false;
@@ -348,6 +376,6 @@ impl Controller<'_> {
                 }
             }
         }
-        Ok(())
+        Ok(reached_eof && missing_newline)
     }
 }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -177,6 +177,12 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Report a missing final newline after the last visible line.
+    pub fn warn_missing_newline(&mut self, yes: bool) -> &mut Self {
+        self.config.warn_missing_newline = yes;
+        self
+    }
+
     /// Whether to show "snip" markers between visible line ranges (default: no)
     pub fn snip(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.snip = yes;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -89,6 +89,10 @@ pub(crate) trait Printer {
     ) -> Result<()>;
     fn print_footer(&mut self, handle: &mut OutputHandle, input: &OpenedInput) -> Result<()>;
 
+    fn print_missing_newline_warning(&mut self, _handle: &mut OutputHandle) -> Result<()> {
+        Ok(())
+    }
+
     fn print_snip(&mut self, handle: &mut OutputHandle) -> Result<()>;
 
     fn print_line(
@@ -478,6 +482,10 @@ impl<'a> InteractivePrinter<'a> {
 }
 
 impl Printer for InteractivePrinter<'_> {
+    fn print_missing_newline_warning(&mut self, handle: &mut OutputHandle) -> Result<()> {
+        self.print_header_multiline_component(handle, "[No newline at end of file]")
+    }
+
     fn print_header(
         &mut self,
         handle: &mut OutputHandle,

--- a/tests/newline_warning.rs
+++ b/tests/newline_warning.rs
@@ -1,0 +1,99 @@
+mod utils;
+
+use predicates::prelude::*;
+use utils::command::bat;
+
+const WARNING: &str = "--warning=missing-trailing-newline";
+
+#[test]
+fn warning_does_not_change_redirected_bytes() {
+    bat()
+        .arg(WARNING)
+        .write_stdin("text")
+        .assert()
+        .success()
+        .stdout("text")
+        .stderr(predicate::str::contains("No newline at end of file"));
+}
+
+#[test]
+fn formatted_warning_appears_before_bottom_border() {
+    bat().args([WARNING, "--decorations=always", "--style=numbers,grid", "--color=never", "--terminal-width=40"])
+        .write_stdin("text").assert().success()
+        .stdout("─────┬──────────────────────────────────\n   1 │ text\n     │ [No newline at end of file]\n─────┴──────────────────────────────────\n")
+        .stderr("");
+}
+
+#[test]
+fn complete_empty_and_excluded_final_lines_do_not_warn() {
+    for input in ["", "text\n", "text\r\n"] {
+        bat()
+            .arg(WARNING)
+            .write_stdin(input)
+            .assert()
+            .success()
+            .stdout(input)
+            .stderr("");
+    }
+    bat()
+        .args([WARNING, "--line-range=1:1"])
+        .write_stdin("first\nlast")
+        .assert()
+        .success()
+        .stdout("first\n")
+        .stderr("");
+}
+
+#[test]
+fn utf16_endings_are_checked_as_code_units() {
+    for (bom, little) in [([0xff, 0xfe], true), ([0xfe, 0xff], false)] {
+        for (text, should_warn) in [("hello\n", false), ("hello", true)] {
+            let mut input = bom.to_vec();
+            for unit in text.encode_utf16() {
+                input.extend(if little {
+                    unit.to_le_bytes()
+                } else {
+                    unit.to_be_bytes()
+                });
+            }
+            let result = bat()
+                .arg(WARNING)
+                .write_stdin(input.clone())
+                .assert()
+                .success()
+                .stdout(input);
+            if should_warn {
+                result.stderr(predicate::str::contains("No newline at end of file"));
+            } else {
+                result.stderr("");
+            }
+        }
+    }
+}
+
+#[test]
+fn warnings_can_be_disabled_and_binary_inputs_do_not_warn() {
+    bat()
+        .args([WARNING, "--warning=none"])
+        .write_stdin("text")
+        .assert()
+        .success()
+        .stdout("text")
+        .stderr("");
+    bat()
+        .args([WARNING, "test.binary"])
+        .assert()
+        .success()
+        .stderr("");
+}
+
+#[test]
+fn unbuffered_complete_input_does_not_report_partial_chunks() {
+    bat()
+        .args([WARNING, "--unbuffered"])
+        .write_stdin("first\nsecond\n")
+        .assert()
+        .success()
+        .stdout("first\nsecond\n")
+        .stderr("");
+}


### PR DESCRIPTION
A missing final newline is currently invisible in ordinary output.

Add `--warning=missing-trailing-newline` and the corresponding `PrettyPrinter` setting. Formatted output shows a marker before the footer; redirected output keeps the original bytes and sends the warning to stderr. `--warning=none` disables it, which is also the default.

Only warn after reaching EOF when the final line was displayed. Empty files, binary inputs, complete line endings, and excluded final lines do not warn. UTF-16 endings are checked as code units, and unbuffered reading tracks the final chunk rather than reporting intermediate partial lines.

Closes #975.

Validation: six CLI regression tests passed, covering raw byte preservation, formatted placement, empty and complete input, line ranges, both UTF-16 byte orders, binary files, explicit disabling, and unbuffered complete input. Formatting and whitespace checks passed. Help snapshots, manual, and shell completions updated. [GitHub CI](https://github.com/sharkdp/bat/actions/runs/34076626059) is still completing platform tests; changelog checks passed.

Integration validation: a local checkout combining #3925–#3934 passed 508 tests, including four interaction tests, plus all-target/all-feature Clippy. A [reference branch](https://github.com/Matei02355/bat-contribution/tree/integration-code-batches-20260907) also combines the first batch's code changes; it passed 522 tests and all-target/all-feature Clippy. Five existing tests remained ignored by their normal configuration.