### PR TITLE
Document BAT_OPTS, BAT_TABS and BAT_CACHE_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,13 @@ syntax:
    bat cache --clear
    ```
 
+   The cache is written to the directory reported by `bat --cache-dir`. Set `BAT_CACHE_PATH` to put
+   it somewhere else:
+
+   ```bash
+   export BAT_CACHE_PATH="/path/to/bat/cache"
+   ```
+
 4. If you think that a specific syntax should be included in `bat` by default, please
    consider opening a "syntax request" ticket after reading the policies and
    instructions [here](doc/assets.md): [Open Syntax Request](https://github.com/sharkdp/bat/issues/new?labels=syntax-request&template=syntax_request.md).
@@ -699,7 +706,8 @@ to truncate any lines larger than the terminal width.
 ### Indentation
 
 `bat` expands tabs to 4 spaces by itself, not relying on the pager. To change this, simply add the
-`--tabs` argument with the number of spaces you want to be displayed.
+`--tabs` argument with the number of spaces you want to be displayed, or export the `BAT_TABS`
+environment variable (e.g. `export BAT_TABS=2`).
 
 **Note**: Defining tab stops for the pager (via the `--pager` argument by `bat`, or via the `LESS`
 environment variable for `less`) won't be taken into account because the pager will already get
@@ -764,6 +772,14 @@ A default configuration file can be created with the `--generate-config-file` op
 ```bash
 bat --generate-config-file
 ```
+
+The `BAT_OPTS` environment variable holds command-line options in the same format, and is read
+*instead of* the configuration file, not in addition to it:
+```bash
+export BAT_OPTS="--theme='TwoDark' --style=numbers"
+```
+Setting it means the configuration file is not read at all, so anything you rely on there has to be
+repeated in `BAT_OPTS`.
 
 There is also now a systemwide configuration file, which is located under `/etc/bat/config` on
 Linux and Mac OS and `C:\ProgramData\bat\config` on windows. If the system wide configuration


### PR DESCRIPTION
`--diagnostic` lists eleven `BAT_*` variables as things that affect bat. Three of them are documented nowhere a user would look:

| | README | man page | `--help` |
|---|---|---|---|
| `BAT_OPTS` | — | — | — |
| `BAT_TABS` | — | — | — |
| `BAT_CACHE_PATH` | — | — | — |
| `BAT_WIDTH` | — | — | yes |

`BAT_TABS`' only appearance in the repository is inside a docker alias in `doc/README-ja.md`.

All three work. Checked against a build of `master`:

```console
$ printf 'a\tb\n' > t.txt

$ BAT_TABS=2 bat --style=plain --decorations=always t.txt
a b

$ BAT_OPTS="--style=numbers" bat --decorations=always t.txt
   1 a   b

$ BAT_CACHE_PATH=/tmp/mycache bat cache --build --blank --source=/dev/null
Writing syntax set to /tmp/mycache/syntaxes.bin ... okay
```

`BAT_OPTS` is the one worth spelling out, because the behaviour is easy to get wrong:

```rust
let config_args = match get_args_from_env_opts_var() {
    Some(r) => r,
    None => get_args_from_config_file(),
};
```

It is read *instead of* the config file, not in addition to it. Setting it for one unrelated option throws away everything else you have configured:

```console
$ cat ~/.config/bat/config
--tabs=8

$ bat --style=plain --decorations=always t.txt
a       b

$ BAT_OPTS="--squeeze-blank" bat --style=plain --decorations=always t.txt
a	b        # tabs back to 4 — the config file was not read
```

So the README now says that, next to the config file it replaces.

Placed each one where someone would go looking rather than adding a separate list: `BAT_TABS` next to `--tabs` under Indentation, `BAT_CACHE_PATH` next to `bat cache --build`, `BAT_OPTS` in the configuration file section.

No changelog entry — documentation is on CONTRIBUTING.md's list of changes that do not need one.
