### PR TITLE
Add sidebar style alias for numbers and Git changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add the `sidebar` style alias for line numbers and Git modification markers, see #0 (@Matei02355)
+- Add the `sidebar` style alias for line numbers and Git modification markers, see #3937 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Features
 
+- Add the `sidebar` style alias for line numbers and Git modification markers, see #0 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -5,7 +5,7 @@ using namespace System.Management.Automation.Language
 Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
-    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
+    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'sidebar', 'snip')
     $ArrayCompletion = @('bash', 'fish', 'zsh', 'ps1')
     $ArrayWhen       = @('auto', 'never', 'always')
     $ArrayYesNo      = @('never', 'always')
@@ -152,7 +152,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
-            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, sidebar, snip).')
         #   [CompletionResult]::new('-r'                      , 'r'                     , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
         #   [CompletionResult]::new('-A'                      , 'A'                     , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -179,6 +179,7 @@ _bat() {
 			grid
 			rule
 			numbers
+			sidebar
 			snip
 		)
 		# shellcheck disable=SC2016

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -84,6 +84,7 @@ function __bat_style_opts
         "header-filesize,filesize above content" \
         "grid,lines b/w sidebar/header/content" \
         "numbers,line numbers in sidebar" \
+        "sidebar,line numbers and Git changes" \
         "rule,separate files" \
         "snip,separate ranges"
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -56,7 +56,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
-            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+            default auto full plain changes header header-filename header-filesize grid rule numbers sidebar snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
         '(* -)'{-L,--list-languages}'[display all supported languages]'
         '(-u --unbuffered)'--unbuffered'[enable unbuffered input reading for streaming use cases]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -243,7 +243,8 @@ By default, the following components are enabled:
 changes, grid, header\-filename, numbers, snip
 .IP
 Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
-rule, numbers, snip.
+rule, numbers, sidebar, snip. The sidebar alias combines numbers and changes;
+use 'full,-sidebar' to remove both while retaining headers and borders.
 .HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...
 .IP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -212,6 +212,7 @@ Options:
                     and the header from the content.
             * rule: horizontal lines to delimit files.
             * numbers: show line numbers in the side bar.
+            * sidebar: show line numbers and Git modification markers.
             * snip: draw separation lines between distinct line ranges.
 
   -r, --line-range <N:M>

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -57,7 +57,7 @@ Options:
           Squeeze consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
-          header, header-filename, header-filesize, grid, rule, numbers, snip).
+          header, header-filename, header-filesize, grid, rule, numbers, sidebar, snip).
   -r, --line-range <N:M>
           Only print the lines from N to M.
   -L, --list-languages

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -534,7 +534,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).",
+                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, sidebar, snip).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -565,6 +565,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                        and the header from the content.\n  \
                      * rule: horizontal lines to delimit files.\n  \
                      * numbers: show line numbers in the side bar.\n  \
+                     * sidebar: show line numbers and Git modification markers.\n  \
                      * snip: draw separation lines between distinct line ranges.",
                 ),
         )

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -151,6 +151,16 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Enable or disable line numbers and Git modification markers together.
+    pub fn sidebar(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.line_numbers = yes;
+        #[cfg(feature = "git")]
+        {
+            self.active_style_components.vcs_modification_markers = yes;
+        }
+        self
+    }
+
     /// Whether to paint a grid, separating line numbers, git changes and the code
     pub fn grid(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.grid = yes;

--- a/src/style.rs
+++ b/src/style.rs
@@ -15,6 +15,7 @@ pub enum StyleComponent {
     HeaderFilename,
     HeaderFilesize,
     LineNumbers,
+    Sidebar,
     Snip,
     Full,
     Default,
@@ -39,6 +40,11 @@ impl StyleComponent {
             StyleComponent::HeaderFilename => &[StyleComponent::HeaderFilename],
             StyleComponent::HeaderFilesize => &[StyleComponent::HeaderFilesize],
             StyleComponent::LineNumbers => &[StyleComponent::LineNumbers],
+            StyleComponent::Sidebar => &[
+                #[cfg(feature = "git")]
+                StyleComponent::Changes,
+                StyleComponent::LineNumbers,
+            ],
             StyleComponent::Snip => &[StyleComponent::Snip],
             StyleComponent::Full => &[
                 #[cfg(feature = "git")]
@@ -76,6 +82,7 @@ impl FromStr for StyleComponent {
             "header-filename" => Ok(StyleComponent::HeaderFilename),
             "header-filesize" => Ok(StyleComponent::HeaderFilesize),
             "numbers" => Ok(StyleComponent::LineNumbers),
+            "sidebar" => Ok(StyleComponent::Sidebar),
             "snip" => Ok(StyleComponent::Snip),
             "full" => Ok(StyleComponent::Full),
             "default" => Ok(StyleComponent::Default),

--- a/tests/sidebar_style.rs
+++ b/tests/sidebar_style.rs
@@ -1,0 +1,49 @@
+mod utils;
+
+use utils::command::bat;
+
+fn output(style: &str) -> Vec<u8> {
+    bat()
+        .args([
+            "--decorations=always",
+            "--color=never",
+            "--paging=never",
+            "--terminal-width=30",
+        ])
+        .arg(format!("--style={style}"))
+        .write_stdin("first\nsecond\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
+}
+
+#[test]
+fn sidebar_expands_to_numbers_and_changes() {
+    #[cfg(feature = "git")]
+    let explicit = "numbers,changes";
+    #[cfg(not(feature = "git"))]
+    let explicit = "numbers";
+    assert_eq!(output("sidebar"), output(explicit));
+    assert_eq!(output("plain,+sidebar"), output(explicit));
+}
+
+#[test]
+fn removing_sidebar_keeps_headers_and_borders() {
+    #[cfg(feature = "git")]
+    let explicit = "full,-numbers,-changes";
+    #[cfg(not(feature = "git"))]
+    let explicit = "full,-numbers";
+    assert_eq!(output("full,-sidebar"), output(explicit));
+    assert_eq!(output("sidebar,-sidebar"), output("plain"));
+}
+
+#[test]
+fn components_can_override_the_sidebar_alias() {
+    assert_eq!(
+        output("plain,+sidebar,-sidebar,+numbers"),
+        output("numbers")
+    );
+    assert_eq!(output("full,-sidebar,+sidebar"), output("full"));
+}


### PR DESCRIPTION
Removing the entire sidebar currently requires knowing that both `numbers` and `changes` contribute to it.

Add a `sidebar` style alias that expands to both components, including the existing +/- style modifiers. `--style=full,-sidebar` keeps headers and borders while removing the sidebar, and later components can override the alias normally. Builds without Git support expand it to line numbers only. Add `PrettyPrinter::sidebar()` for library callers.

Fixes #3454.

Validation: three CLI regression tests passed, covering expansion, addition/removal, existing decorations, and component ordering. Formatting and whitespace checks passed. Help snapshots, manual, and four shell completions updated. GitHub CI pending.