### PR TITLE
Support periodic line ranges and highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Support periodic line ranges and highlights with `~` increments, see #0 (@Matei02355)
+- Support periodic line ranges and highlights with `~` increments, see #3938 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Features
 
+- Support periodic line ranges and highlights with `~` increments, see #0 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -70,7 +70,11 @@ language names and file extensions.
 .HP
 \fB\-H\fR, \fB\-\-highlight\-line\fR <N:M>...
 .IP
-Highlight the specified line ranges with a different background color. For example:
+Highlight the specified line ranges with a different background color. Append '~N'
+to select every Nth line, starting at the lower bound (at least line 1).
+For example, '30:40~2' selects 30, 32, 34, 36, 38, 40; '30~2' continues to EOF.
+The same increment syntax is available for '\-\-line-range'. N must be positive.
+For example:
 .RS
 .IP "\-\-highlight\-line 40"
 highlights line 40

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -51,6 +51,8 @@ Options:
             '--highlight-line :40' highlights lines 1 to 40
             '--highlight-line 40:' highlights lines 40 to the end of the file
             '--highlight-line 30:+10' highlights lines 30 to 40
+            '--highlight-line 30:40~2' highlights every second line from 30 to 40
+            '--highlight-line 30~2' highlights every second line from 30 onward
 
       --file-name <name>
           Specify the name to display for a file. Useful when piping data to bat from STDIN when bat
@@ -224,6 +226,9 @@ Options:
             '--line-range 30:+10' prints lines 30 to 40
             '--line-range 35::5' prints lines 30 to 40 (line 35 with 5 lines of context)
             '--line-range 30:40:2' prints lines 28 to 42 (range 30-40 with 2 lines of context)
+            '--line-range 30:40~2' prints every second line from 30 to 40
+            '--line-range 30~2' prints every second line from 30 onward. Increments must be positive
+            and start at the range's lower bound (at least line 1).
 
   -L, --list-languages
           Display a list of supported languages for syntax highlighting.

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -147,7 +147,9 @@ pub fn build_app(interactive_output: bool) -> Command {
                      '--highlight-line 30:40' highlights lines 30 to 40\n  \
                      '--highlight-line :40' highlights lines 1 to 40\n  \
                      '--highlight-line 40:' highlights lines 40 to the end of the file\n  \
-                     '--highlight-line 30:+10' highlights lines 30 to 40",
+                     '--highlight-line 30:+10' highlights lines 30 to 40\n  \
+                     '--highlight-line 30:40~2' highlights every second line from 30 to 40\n  \
+                     '--highlight-line 30~2' highlights every second line from 30 onward",
                 ),
         )
         .arg(
@@ -586,7 +588,10 @@ pub fn build_app(interactive_output: bool) -> Command {
                      '--line-range -10:' prints the last 10 lines\n  \
                      '--line-range 30:+10' prints lines 30 to 40\n  \
                      '--line-range 35::5' prints lines 30 to 40 (line 35 with 5 lines of context)\n  \
-                     '--line-range 30:40:2' prints lines 28 to 42 (range 30-40 with 2 lines of context)",
+                     '--line-range 30:40:2' prints lines 28 to 42 (range 30-40 with 2 lines of context)\n  \
+                     '--line-range 30:40~2' prints every second line from 30 to 40\n  \
+                     '--line-range 30~2' prints every second line from 30 onward. \
+                     Increments must be positive and start at the range's lower bound (at least line 1).",
                 ),
         )
         .arg(

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -1,10 +1,12 @@
 use crate::error::*;
 use itertools::{Itertools, MinMaxResult};
+use std::num::NonZeroUsize;
 
 #[derive(Debug, Copy, Clone)]
 pub struct LineRange {
     lower: RangeBound,
     upper: RangeBound,
+    step: NonZeroUsize,
 }
 
 /// Defines a boundary for a range
@@ -21,6 +23,7 @@ impl Default for LineRange {
         LineRange {
             lower: RangeBound::Absolute(usize::MIN),
             upper: RangeBound::Absolute(usize::MAX),
+            step: NonZeroUsize::MIN,
         }
     }
 }
@@ -30,6 +33,7 @@ impl LineRange {
         LineRange {
             lower: RangeBound::Absolute(from),
             upper: RangeBound::Absolute(to),
+            step: NonZeroUsize::MIN,
         }
     }
 
@@ -37,7 +41,28 @@ impl LineRange {
         LineRange::parse_range(range_raw)
     }
 
+    /// Select every `step`th line, starting at the lower bound (at least line 1).
+    pub fn with_step(mut self, step: usize) -> Result<Self> {
+        self.step = NonZeroUsize::new(step).ok_or("Line increment must be greater than zero")?;
+        Ok(self)
+    }
+
     fn parse_range(range_raw: &str) -> Result<LineRange> {
+        if let Some((bounds, step)) = range_raw.split_once('~') {
+            let step = step
+                .parse()
+                .map_err(|_| "Invalid line increment after '~'")?;
+            let bounds = if bounds.contains(':') {
+                bounds.to_owned()
+            } else {
+                format!("{bounds}:")
+            };
+            return Self::parse_bounds(&bounds)?.with_step(step);
+        }
+        Self::parse_bounds(range_raw)
+    }
+
+    fn parse_bounds(range_raw: &str) -> Result<LineRange> {
         let mut new_range = LineRange::default();
         let mut raw_range_iter = range_raw.bytes();
         let first_byte = raw_range_iter.next().ok_or("Empty line range")?;
@@ -138,7 +163,7 @@ impl LineRange {
         line: usize,
         max_buffered_line_number: MaxBufferedLineNumber,
     ) -> bool {
-        match (self.lower, self.upper, max_buffered_line_number) {
+        let inside = match (self.lower, self.upper, max_buffered_line_number) {
             (RangeBound::Absolute(lower), RangeBound::Absolute(upper), _) => {
                 lower <= line && line <= upper
             }
@@ -187,8 +212,59 @@ impl LineRange {
                 // too far away from the having reached the lower end of the range
                 false
             }
+        };
+        if !inside || self.step == NonZeroUsize::MIN {
+            return inside;
         }
+        let anchor = match (self.lower, max_buffered_line_number) {
+            (RangeBound::Absolute(lower), _) => lower.max(1),
+            (RangeBound::OffsetFromEnd(offset), MaxBufferedLineNumber::Final(last)) => {
+                // The CLI's -N: form displays the last N lines.
+                last.saturating_sub(offset.saturating_sub(1)).max(1)
+            }
+            (RangeBound::OffsetFromEnd(_), MaxBufferedLineNumber::Tentative(_)) => return false,
+        };
+        line >= anchor && (line - anchor).is_multiple_of(self.step.get())
     }
+}
+
+#[test]
+fn increments_preserve_bounds_and_context_syntax() {
+    for (raw, expected) in [
+        ("2:8~3", vec![2, 5, 8]),
+        ("2~3", vec![2, 5, 8, 11]),
+        (":8~3", vec![1, 4, 7]),
+        ("0:8~3", vec![1, 4, 7]),
+        ("5::2~2", vec![3, 5, 7]),
+        ("5:7:2~2", vec![3, 5, 7, 9]),
+        ("-4:~2", vec![9, 11]),
+        (":-2~3", vec![1, 4, 7, 10]),
+        ("2:-2~3", vec![1]),
+    ] {
+        let range = LineRange::from(raw).unwrap();
+        let actual: Vec<_> = (1..=12)
+            .filter(|line| range.is_inside(*line, MaxBufferedLineNumber::Final(12)))
+            .collect();
+        assert_eq!(actual, expected, "{raw}");
+    }
+    assert!(LineRange::from("5:7:2")
+        .unwrap()
+        .is_inside(4, MaxBufferedLineNumber::Final(12)));
+}
+
+#[test]
+fn invalid_increments_are_rejected() {
+    for raw in ["2~0", "2~", "~2", "2~x", "2~-1", "2~2~3"] {
+        assert!(LineRange::from(raw).is_err(), "{raw}");
+    }
+    assert!(LineRange::new(1, 10).with_step(0).is_err());
+}
+
+#[test]
+fn large_increments_do_not_overflow() {
+    let range = LineRange::new(2, usize::MAX).with_step(usize::MAX).unwrap();
+    assert!(range.is_inside(2, MaxBufferedLineNumber::Tentative(2)));
+    assert!(!range.is_inside(usize::MAX, MaxBufferedLineNumber::Final(usize::MAX)));
 }
 
 #[test]
@@ -438,6 +514,16 @@ impl LineRanges {
             .any(|r| r.is_inside(line, max_buffered_line_number))
         {
             RangeCheckResult::InRange
+        } else if self.ranges.iter().any(|range| {
+            // Skipping a line between increments does not mean the range ended.
+            range.step != NonZeroUsize::MIN
+                && LineRange {
+                    step: NonZeroUsize::MIN,
+                    ..*range
+                }
+                .is_inside(line, max_buffered_line_number)
+        }) {
+            RangeCheckResult::BeforeOrBetweenRanges
         } else if matches!(max_buffered_line_number, MaxBufferedLineNumber::Final(final_line_number) if line > final_line_number.saturating_sub(self.smallest_offset_from_end))
         {
             RangeCheckResult::AfterLastRange

--- a/tests/line_increments.rs
+++ b/tests/line_increments.rs
@@ -1,0 +1,76 @@
+mod utils;
+
+use utils::command::bat;
+
+#[test]
+fn display_periodic_lines_with_original_numbers() {
+    bat()
+        .args([
+            "--line-range=2:8~3",
+            "--style=numbers",
+            "--decorations=always",
+            "--color=never",
+        ])
+        .write_stdin("one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\n")
+        .assert()
+        .success()
+        .stdout("   2 two\n   5 five\n   8 eight\n");
+}
+
+#[test]
+fn open_and_tail_relative_increments_work() {
+    for (range, expected) in [("2~2", "two\nfour\n"), ("-3:~2", "three\nfive\n")] {
+        bat()
+            .arg(format!("--line-range={range}"))
+            .write_stdin("one\ntwo\nthree\nfour\nfive\n")
+            .assert()
+            .success()
+            .stdout(expected);
+    }
+}
+
+#[test]
+fn periodic_highlighting_matches_explicit_lines() {
+    let input = "one\ntwo\nthree\nfour\nfive\n";
+    let output = |highlights: &[&str]| {
+        bat()
+            .args([
+                "--color=always",
+                "--theme=ansi",
+                "--style=plain",
+                "--paging=never",
+            ])
+            .args(highlights)
+            .write_stdin(input)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone()
+    };
+    assert_eq!(
+        output(&["--highlight-line=2~2"]),
+        output(&["-H", "2", "-H", "4"])
+    );
+}
+
+#[test]
+fn ranges_union_without_duplicate_lines() {
+    bat()
+        .args(["--line-range=1~2", "--line-range=3:4"])
+        .write_stdin("one\ntwo\nthree\nfour\nfive\n")
+        .assert()
+        .success()
+        .stdout("one\nthree\nfour\nfive\n");
+}
+
+#[test]
+fn zero_stride_fails_without_output() {
+    for flag in ["--line-range", "--highlight-line"] {
+        bat()
+            .args([flag, "1~0", "test.txt"])
+            .assert()
+            .failure()
+            .stdout("");
+    }
+}


### PR DESCRIPTION
Selecting alternating or periodic lines currently requires listing every individual line range.

Support `N:M~S` and `N~S` for both `--line-range` and `--highlight-line`. Increments start at the resolved lower bound, including ranges relative to the end of input. The `~` separator preserves the existing colon-based context syntax. Reject zero, negative, and malformed increments, and keep gaps inside a stepped range from terminating input early. Expose `LineRange::with_step()` for library callers.

Fixes #1611.

Validation: all 31 line-range unit tests and five CLI regression tests passed, including context ranges, tail-relative ranges, range unions, highlighting, invalid input, and overflow boundaries. Clippy with all targets/features and warnings denied passed. Formatting, whitespace checks, manual, and help snapshots updated. GitHub CI pending.