### PR TITLE
Allow library printers to load custom highlighting assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Allow library callers to construct `PrettyPrinter` with cached or custom highlighting assets, see #0 (@Matei02355)
+- Allow library callers to construct `PrettyPrinter` with cached or custom highlighting assets, see #3939 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Features
 
+- Allow library callers to construct `PrettyPrinter` with cached or custom highlighting assets, see #0 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -906,6 +906,13 @@ features as a library, check out the [API documentation](https://docs.rs/bat/).
 Note that you have to use either `regex-onig` or `regex-fancy` as a feature
 when you depend on `bat` as a library.
 
+`PrettyPrinter::new()` uses embedded syntaxes and themes. To use a custom cache
+built with `bat cache --build`, construct the printer with
+`PrettyPrinter::from_cache(cache_directory)?`. Callers managing their own
+`HighlightingAssets` can use `PrettyPrinter::with_assets(assets)?` instead. Both
+constructors validate cached syntaxes before returning; they do not read CLI
+configuration or select a cache directory from the environment.
+
 ## Contributing
 
 Take a look at the [`CONTRIBUTING.md`](CONTRIBUTING.md) guide.

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -64,6 +64,27 @@ impl<'a> PrettyPrinter<'a> {
         }
     }
 
+    /// Create a printer using an existing asset cache, such as one built by
+    /// `bat cache --build`. The directory is explicit: this does not read user
+    /// configuration or environment variables.
+    ///
+    /// Invalid or missing caches return an error during construction.
+    pub fn from_cache(cache_path: impl AsRef<Path>) -> Result<Self> {
+        Self::with_assets(HighlightingAssets::from_cache(cache_path.as_ref())?)
+    }
+
+    /// Create a printer with custom syntax and theme assets.
+    ///
+    /// Syntaxes are loaded immediately so malformed caches return an error
+    /// before this printer is used or its syntaxes are enumerated.
+    pub fn with_assets(assets: HighlightingAssets) -> Result<Self> {
+        assets.get_syntaxes()?;
+        Ok(Self {
+            assets,
+            ..Self::new()
+        })
+    }
+
     /// Add an input which should be pretty-printed
     pub fn input(&mut self, input: Input<'a>) -> &mut Self {
         self.inputs.push(input);
@@ -274,8 +295,8 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     pub fn syntaxes(&self) -> impl Iterator<Item = Syntax> + '_ {
-        // We always use assets from the binary, which are guaranteed to always
-        // be valid, so get_syntaxes() can never fail here
+        // Embedded assets are valid; custom assets were loaded and validated
+        // by with_assets(), so get_syntaxes() cannot fail here.
         self.assets
             .get_syntaxes()
             .unwrap()

--- a/tests/library_assets.rs
+++ b/tests/library_assets.rs
@@ -1,0 +1,72 @@
+use bat::{assets::HighlightingAssets, PrettyPrinter};
+
+#[test]
+fn explicit_embedded_assets_preserve_default_behavior() {
+    let printer = PrettyPrinter::with_assets(HighlightingAssets::from_binary()).unwrap();
+    assert_eq!(
+        printer.syntaxes().map(|s| s.name).collect::<Vec<_>>(),
+        PrettyPrinter::new()
+            .syntaxes()
+            .map(|s| s.name)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn missing_cache_fails_during_construction() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(PrettyPrinter::from_cache(dir.path()).is_err());
+}
+
+#[test]
+#[cfg(feature = "build-assets")]
+fn custom_cache_is_listed_and_used_for_highlighting() {
+    let source = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+    let syntaxes = source.path().join("syntaxes");
+    std::fs::create_dir(&syntaxes).unwrap();
+    std::fs::write(
+        syntaxes.join("Example.sublime-syntax"),
+        r#"%YAML 1.2
+---
+name: Local Library Example
+file_extensions: [local-library-example]
+scope: source.local-library-example
+contexts:
+  main:
+    - match: '\bhello\b'
+      scope: keyword.control
+"#,
+    )
+    .unwrap();
+    bat::assets::build(
+        source.path(),
+        true,
+        false,
+        cache.path(),
+        env!("CARGO_PKG_VERSION"),
+    )
+    .unwrap();
+    let mut printer = PrettyPrinter::from_cache(cache.path()).unwrap();
+    assert!(printer
+        .syntaxes()
+        .any(|s| s.name == "Local Library Example"));
+    assert!(!PrettyPrinter::new()
+        .syntaxes()
+        .any(|s| s.name == "Local Library Example"));
+    let mut output = String::new();
+    printer
+        .language("Local Library Example")
+        .theme("ansi")
+        .input_from_bytes(b"hello world\n")
+        .print_with_writer(Some(&mut output))
+        .unwrap();
+    assert_eq!(console::strip_ansi_codes(&output), "hello world\n");
+    assert!(output.contains("\x1b["));
+
+    // A cache can load its themes successfully but fail later when syntaxes
+    // are deserialized. The constructor must surface that error, not panic
+    // when the caller subsequently enumerates syntaxes.
+    std::fs::write(cache.path().join("syntaxes.bin"), b"invalid cache").unwrap();
+    assert!(PrettyPrinter::from_cache(cache.path()).is_err());
+}


### PR DESCRIPTION
`PrettyPrinter` currently always uses embedded assets, so library applications cannot enumerate or use the custom syntaxes and themes available to the CLI.

Add `PrettyPrinter::from_cache(path)` and `PrettyPrinter::with_assets(assets)` as explicit constructors. Validate cached syntax data during construction so malformed caches return an error before syntax enumeration or printing. Keep the existing default constructor and document the opt-in APIs.

Fixes #2441.

Validation: three integration tests passed, including building and loading a custom syntax, enumerating it, rendering highlighted output, preserving default assets, and rejecting missing/corrupt caches. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. GitHub CI pending.