### PR TITLE
Add text indicators for highlighted lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
-- Add a `highlight-indicator` style component for text markers beside highlighted lines, see #0 (@Matei02355)
+- Add a `highlight-indicator` style component for text markers beside highlighted lines, see #3940 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
+- Add a `highlight-indicator` style component for text markers beside highlighted lines, see #0 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -5,7 +5,7 @@ using namespace System.Management.Automation.Language
 Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
-    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
+    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'highlight-indicator', 'grid', 'rule', 'numbers', 'snip')
     $ArrayCompletion = @('bash', 'fish', 'zsh', 'ps1')
     $ArrayWhen       = @('auto', 'never', 'always')
     $ArrayYesNo      = @('never', 'always')
@@ -152,7 +152,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
-            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, highlight-indicator, grid, rule, numbers, snip).')
         #   [CompletionResult]::new('-r'                      , 'r'                     , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
         #   [CompletionResult]::new('-A'                      , 'A'                     , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -176,6 +176,7 @@ _bat() {
 			header
 			header-filename
 			header-filesize
+			highlight-indicator
 			grid
 			rule
 			numbers

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -83,6 +83,7 @@ function __bat_style_opts
         "header-filename,filename above content" \
         "header-filesize,filesize above content" \
         "grid,lines b/w sidebar/header/content" \
+        "highlight-indicator,text markers for highlighted lines" \
         "numbers,line numbers in sidebar" \
         "rule,separate files" \
         "snip,separate ranges"

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -56,7 +56,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
-            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+            default auto full plain changes header header-filename header-filesize highlight-indicator grid rule numbers snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
         '(* -)'{-L,--list-languages}'[display all supported languages]'
         '(-u --unbuffered)'--unbuffered'[enable unbuffered input reading for streaming use cases]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -242,8 +242,10 @@ replacing them.
 By default, the following components are enabled:
 changes, grid, header\-filename, numbers, snip
 .IP
-Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
-rule, numbers, snip.
+Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, highlight-indicator, grid,
+rule, numbers, snip. The highlight-indicator component marks highlighted lines with
+'>' in the sidebar, including wrapped continuations, and remains visible without colors.
+It is included in full style and only shown when highlight ranges are configured.
 .HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...
 .IP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -208,6 +208,8 @@ Options:
             * header: alias for 'header-filename'.
             * header-filename: show filenames before the content.
             * header-filesize: show file sizes before the content.
+            * highlight-indicator: mark highlighted lines with '>'.
+                    Shown only when highlight ranges are configured.
             * grid: vertical/horizontal lines to separate side bar
                     and the header from the content.
             * rule: horizontal lines to delimit files.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -57,7 +57,7 @@ Options:
           Squeeze consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
-          header, header-filename, header-filesize, grid, rule, numbers, snip).
+          header, header-filename, header-filesize, highlight-indicator, grid, rule, numbers, snip).
   -r, --line-range <N:M>
           Only print the lines from N to M.
   -L, --list-languages

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -534,7 +534,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).",
+                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, highlight-indicator, grid, rule, numbers, snip).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -561,6 +561,8 @@ pub fn build_app(interactive_output: bool) -> Command {
                      * header: alias for 'header-filename'.\n  \
                      * header-filename: show filenames before the content.\n  \
                      * header-filesize: show file sizes before the content.\n  \
+                     * highlight-indicator: mark highlighted lines with '>'.\n          \
+                       Shown only when highlight ranges are configured.\n  \
                      * grid: vertical/horizontal lines to separate side bar\n          \
                        and the header from the content.\n  \
                      * rule: horizontal lines to delimit files.\n  \

--- a/src/decorations.rs
+++ b/src/decorations.rs
@@ -19,6 +19,32 @@ pub(crate) trait Decoration {
     fn width(&self) -> usize;
 }
 
+/// A text marker keeps selected lines identifiable without terminal colors.
+pub(crate) struct HighlightIndicatorDecoration;
+
+impl Decoration for HighlightIndicatorDecoration {
+    fn generate(
+        &self,
+        _line_number: usize,
+        _continuation: bool,
+        printer: &InteractivePrinter,
+    ) -> DecorationText {
+        DecorationText {
+            text: if printer.highlight_this_line {
+                ">"
+            } else {
+                " "
+            }
+            .to_owned(),
+            width: 1,
+        }
+    }
+
+    fn width(&self) -> usize {
+        1
+    }
+}
+
 pub(crate) struct LineNumberDecoration {
     color: Style,
     cached_wrap: DecorationText,

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -448,6 +448,10 @@ impl LineRanges {
         }
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+
     pub(crate) fn largest_offset_from_end(&self) -> usize {
         self.largest_offset_from_end
     }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -26,6 +26,7 @@ struct ActiveStyleComponents {
     grid: bool,
     rule: bool,
     line_numbers: bool,
+    highlight_indicator: bool,
     snip: bool,
 }
 
@@ -148,6 +149,13 @@ impl<'a> PrettyPrinter<'a> {
     /// Whether to show line numbers
     pub fn line_numbers(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.line_numbers = yes;
+        self
+    }
+
+    /// Whether to mark highlighted lines with `>` in the sidebar.
+    /// The column is omitted when no highlight ranges are configured.
+    pub fn highlight_indicator(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.highlight_indicator = yes;
         self
     }
 
@@ -313,6 +321,11 @@ impl<'a> PrettyPrinter<'a> {
             self.config
                 .style_components
                 .insert(StyleComponent::HeaderFilename);
+        }
+        if self.active_style_components.highlight_indicator {
+            self.config
+                .style_components
+                .insert(StyleComponent::HighlightIndicator);
         }
         if self.active_style_components.line_numbers {
             self.config

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -22,7 +22,9 @@ use crate::assets::{HighlightingAssets, SyntaxReferenceInSet};
 use crate::config::Config;
 #[cfg(feature = "git")]
 use crate::decorations::LineChangesDecoration;
-use crate::decorations::{Decoration, GridBorderDecoration, LineNumberDecoration};
+use crate::decorations::{
+    Decoration, GridBorderDecoration, HighlightIndicatorDecoration, LineNumberDecoration,
+};
 #[cfg(feature = "git")]
 use crate::diff::LineChanges;
 use crate::error::*;
@@ -209,6 +211,7 @@ pub(crate) struct InteractivePrinter<'a> {
     pub line_changes: &'a Option<LineChanges>,
     highlighter_from_set: Option<HighlighterFromSet<'a>>,
     background_color_highlight: Option<Color>,
+    pub(crate) highlight_this_line: bool,
     consecutive_empty_lines: usize,
     strip_ansi: bool,
     sanitize: bool,
@@ -234,6 +237,10 @@ impl<'a> InteractivePrinter<'a> {
 
         // Create decorations.
         let mut decorations: Vec<Box<dyn Decoration>> = Vec::new();
+
+        if config.style_components.highlight_indicator() && !config.highlighted_lines.0.is_empty() {
+            decorations.push(Box::new(HighlightIndicatorDecoration));
+        }
 
         if config.style_components.numbers() {
             decorations.push(Box::new(LineNumberDecoration::new(&colors)));
@@ -342,6 +349,7 @@ impl<'a> InteractivePrinter<'a> {
             line_changes,
             highlighter_from_set,
             background_color_highlight,
+            highlight_this_line: false,
             consecutive_empty_lines: 0,
             strip_ansi,
             sanitize,
@@ -728,13 +736,15 @@ impl Printer for InteractivePrinter<'_> {
             .check(line_number, max_buffered_line_number)
             == RangeCheckResult::InRange;
 
-        if highlight_this_line && self.config.theme == "ansi" {
+        self.highlight_this_line = highlight_this_line;
+
+        if highlight_this_line && self.config.colored_output && self.config.theme == "ansi" {
             self.ansi_style.update(ANSI_UNDERLINE_ENABLE);
         }
 
         let background_color = self
             .background_color_highlight
-            .filter(|_| highlight_this_line);
+            .filter(|_| highlight_this_line && self.config.colored_output);
 
         // Line decorations.
         if self.panel_width > 0 {
@@ -971,7 +981,7 @@ impl Printer for InteractivePrinter<'_> {
             writeln!(handle)?;
         }
 
-        if highlight_this_line && self.config.theme == "ansi" {
+        if highlight_this_line && self.config.colored_output && self.config.theme == "ansi" {
             write!(handle, "{}", ANSI_UNDERLINE_DISABLE.raw())?;
             self.ansi_style.update(ANSI_UNDERLINE_DISABLE);
         }

--- a/src/style.rs
+++ b/src/style.rs
@@ -14,6 +14,7 @@ pub enum StyleComponent {
     Header,
     HeaderFilename,
     HeaderFilesize,
+    HighlightIndicator,
     LineNumbers,
     Snip,
     Full,
@@ -38,6 +39,7 @@ impl StyleComponent {
             StyleComponent::Header => &[StyleComponent::HeaderFilename],
             StyleComponent::HeaderFilename => &[StyleComponent::HeaderFilename],
             StyleComponent::HeaderFilesize => &[StyleComponent::HeaderFilesize],
+            StyleComponent::HighlightIndicator => &[StyleComponent::HighlightIndicator],
             StyleComponent::LineNumbers => &[StyleComponent::LineNumbers],
             StyleComponent::Snip => &[StyleComponent::Snip],
             StyleComponent::Full => &[
@@ -46,6 +48,7 @@ impl StyleComponent {
                 StyleComponent::Grid,
                 StyleComponent::HeaderFilename,
                 StyleComponent::HeaderFilesize,
+                StyleComponent::HighlightIndicator,
                 StyleComponent::LineNumbers,
                 StyleComponent::Snip,
             ],
@@ -75,6 +78,7 @@ impl FromStr for StyleComponent {
             "header" => Ok(StyleComponent::Header),
             "header-filename" => Ok(StyleComponent::HeaderFilename),
             "header-filesize" => Ok(StyleComponent::HeaderFilesize),
+            "highlight-indicator" => Ok(StyleComponent::HighlightIndicator),
             "numbers" => Ok(StyleComponent::LineNumbers),
             "snip" => Ok(StyleComponent::Snip),
             "full" => Ok(StyleComponent::Full),
@@ -116,6 +120,10 @@ impl StyleComponents {
 
     pub fn header_filesize(&self) -> bool {
         self.0.contains(&StyleComponent::HeaderFilesize)
+    }
+
+    pub fn highlight_indicator(&self) -> bool {
+        self.0.contains(&StyleComponent::HighlightIndicator)
     }
 
     pub fn numbers(&self) -> bool {

--- a/tests/highlight_indicator.rs
+++ b/tests/highlight_indicator.rs
@@ -1,0 +1,113 @@
+mod utils;
+
+use utils::command::bat;
+
+fn render(args: &[&str], input: &str) -> String {
+    let output = bat()
+        .args([
+            "--decorations=always",
+            "--color=never",
+            "--paging=never",
+            "--terminal-width=30",
+        ])
+        .args(args)
+        .write_stdin(input)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(output).unwrap()
+}
+
+#[test]
+fn text_indicators_work_without_colors() {
+    assert_eq!(
+        render(
+            &["--style=highlight-indicator", "-H2:3"],
+            "one\ntwo\nthree\nfour\n"
+        ),
+        "  one\n> two\n> three\n  four\n"
+    );
+    assert_eq!(
+        render(
+            &["--style=highlight-indicator,numbers", "-H2"],
+            "one\ntwo\n"
+        ),
+        "     1 one\n>    2 two\n"
+    );
+}
+
+#[test]
+fn indicators_continue_across_wrapped_lines() {
+    assert_eq!(
+        render(
+            &[
+                "--style=highlight-indicator",
+                "-H2",
+                "--terminal-width=8",
+                "--wrap=character"
+            ],
+            "one\n123456789\nthree\n"
+        ),
+        "  one\n> 123456\n> 789\n  three\n"
+    );
+}
+
+#[test]
+fn indicators_respect_ranges_and_numbering_overrides() {
+    assert_eq!(
+        render(
+            &["--style=highlight-indicator", "-H2:4", "-r2:3"],
+            "one\n\nthree\nfour\n"
+        ),
+        "> \n> three\n"
+    );
+    assert_eq!(
+        render(
+            &[
+                "--number-nonblank",
+                "--style=highlight-indicator,numbers",
+                "-H2"
+            ],
+            "one\n\nthree\n"
+        ),
+        "   1 one\n     \n   2 three\n"
+    );
+}
+
+#[test]
+fn unused_or_disabled_indicators_do_not_change_output() {
+    let input = "one\ntwo\n";
+    assert_eq!(
+        render(&["--style=numbers,+highlight-indicator"], input),
+        render(&["--style=numbers"], input)
+    );
+    assert_eq!(
+        render(
+            &["--style=full", "-H2", "--style=-highlight-indicator"],
+            input
+        ),
+        render(&["--style=full,-highlight-indicator", "-H2"], input)
+    );
+    assert_eq!(
+        render(
+            &["--style=highlight-indicator", "-H2", "--terminal-width=3"],
+            input
+        ),
+        input
+    );
+}
+
+#[test]
+fn library_callers_can_enable_indicators() {
+    let mut output = String::new();
+    bat::PrettyPrinter::new()
+        .input_from_bytes(b"one\ntwo\n")
+        .colored_output(false)
+        .highlight(2)
+        .highlight_indicator(true)
+        .print_with_writer(Some(&mut output))
+        .unwrap();
+    assert_eq!(output, "  one\n> two\n");
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3247,7 +3247,7 @@ fn grid_for_file_without_newline() {
 fn ansi_highlight_underline() {
     bat()
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3476,7 +3476,7 @@ fn theme_arg_overrides_env() {
     bat()
         .env("BAT_THEME", "TwoDark")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3496,7 +3496,7 @@ fn theme_arg_overrides_env_withconfig() {
         .env("BAT_CONFIG_PATH", "bat-theme.conf")
         .env("BAT_THEME", "TwoDark")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3517,7 +3517,7 @@ fn theme_light_env_var_is_respected() {
         .env("COLORTERM", "truecolor")
         .arg("--theme=light")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3526,7 +3526,7 @@ fn theme_light_env_var_is_respected() {
         .write_stdin("Lorem Ipsum")
         .assert()
         .success()
-        .stdout("\x1B[48;2;208;218;231mLorem Ipsum\x1B[0m")
+        .stdout("\x1B[48;2;208;218;231;38;2;17;27;39mLorem Ipsum\x1B[0m")
         .stderr("");
 }
 
@@ -3537,7 +3537,7 @@ fn theme_dark_env_var_is_respected() {
         .env("COLORTERM", "truecolor")
         .arg("--theme=dark")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3546,7 +3546,7 @@ fn theme_dark_env_var_is_respected() {
         .write_stdin("Lorem Ipsum")
         .assert()
         .success()
-        .stdout("\x1B[48;2;33;48;67mLorem Ipsum\x1B[0m")
+        .stdout("\x1B[48;2;33;48;67;38;2;227;234;242mLorem Ipsum\x1B[0m")
         .stderr("");
 }
 
@@ -3556,7 +3556,7 @@ fn theme_env_overrides_config() {
         .env("BAT_CONFIG_PATH", "bat-theme.conf")
         .env("BAT_THEME", "ansi")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")


### PR DESCRIPTION
Highlighted lines currently rely on terminal styling and are difficult to identify in colorless output.

Add `highlight-indicator` as a style component and `PrettyPrinter::highlight_indicator()`. A `>` marks selected lines and their wrapped continuations. The component is included in `full`, and its column is omitted when no highlight ranges are configured. It composes with line numbers, grid borders, style modifiers, and narrow-terminal handling.

Also honor `--color=never` for highlight backgrounds and ANSI-theme underline sequences; the text indicator remains visible. Update theme-selection tests to request colors explicitly.

Fixes #1324.

Validation: five new CLI/library regression tests passed. Existing CLI integration coverage passed after updating the two color-enabled theme expectations; all five theme-selection tests passed on rerun. All-target/all-feature Clippy with warnings denied passed. Formatting, whitespace checks, help snapshots, manual, and four completions updated. GitHub CI pending.