### PR TITLE
Allow appending literal arguments to the configured pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
+- Add repeatable `--pager-arg` options to extend pager arguments without replacing the configured command, see #0 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
-- Add repeatable `--pager-arg` options to extend pager arguments without replacing the configured command, see #0 (@Matei02355)
+- Add repeatable `--pager-arg` options to extend pager arguments without replacing the configured command, see #3941 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -146,6 +146,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--italic-text'           , 'italic-text'           , [CompletionResultType]::ParameterName, 'Use italics in output (always, *never*)')
             [CompletionResult]::new('--decorations'           , 'decorations'           , [CompletionResultType]::ParameterName, 'When to show the decorations (*auto*, never, always).')
             [CompletionResult]::new('--paging'                , 'paging'                , [CompletionResultType]::ParameterName, 'Specify when to use the pager, or use ''-P'' to disable (*auto*, never, always).')
+            [CompletionResult]::new('--pager-arg='            , 'pager-arg'             , [CompletionResultType]::ParameterName, 'Append a literal argument to the selected pager.')
             [CompletionResult]::new('--pager'                 , 'pager'                 , [CompletionResultType]::ParameterName, 'Determine which pager to use.')
         #   [CompletionResult]::new('-m'                      , 'm'                     , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
             [CompletionResult]::new('--map-syntax'            , 'map-syntax'            , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -148,6 +148,9 @@ _bat() {
 		COMPREPLY=($(compgen -W "always never" -- "$cur"))
 		return 0
 		;;
+	--pager-arg)
+		return 0
+		;;
 	--pager)
 		COMPREPLY=($(compgen -c -- "$cur"))
 		return 0
@@ -217,6 +220,7 @@ _bat() {
 			--paging
 			--no-paging
 			--pager
+			--pager-arg=
 			--map-syntax
 			--ignored-suffix
 			--theme

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,5 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -l pager-arg -r -f -d "Append a literal argument to the selected pager" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -45,6 +45,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --paging='[specify when to use the pager]:when:(auto never always)'
         '(-P --no-paging)'--no-paging'[alias for --paging=never]'
         --pager='[determine which pager to use]:command:'
+        '*--pager-arg=[append an argument to the selected pager]:argument:'
         '(-m --map-syntax)'{-m+,--map-syntax=}'[map a glob pattern to an existing syntax name]: :->syntax-maps'
         --ignored-suffix='[ignore extension]:suffix:'
         '(--theme)'--theme='[set the color theme for syntax highlighting]:theme:->theme_preferences'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -159,6 +159,14 @@ Example: '\-\-pager "less \fB\-RF\fR"'.
 
 Note: By default, if the pager is set to 'less' (and no command-line options are specified), 'bat' will pass the following command line options to the pager: '-R'/'--RAW-CONTROL-CHARS', '-F'/'--quit-if-one-screen' and '-X'/'--no-init'. The last option ('-X') is only used for 'less' versions older than 530. The '-R' option is needed to interpret ANSI colors correctly. The second option ('-F') instructs less to exit immediately if the output size is smaller than the vertical size of the terminal. This is convenient for small files because you do not have to press 'q' to quit the pager. The third option ('-X') is needed to fix a bug with the '--quit-if-one-screen' feature in old versions of 'less'. Unfortunately, it also breaks mouse-wheel support in 'less'. If you want to enable mouse-wheel scrolling on older versions of 'less', you can pass just '-R' (as in the example above, this will disable the quit-if-one-screen feature). For less 530 or newer, it should work out of the box.
 .HP
+\fB\-\-pager\-arg\fR=<arg>...
+.IP
+Append a literal argument after the selected external pager's existing arguments,
+including the default options supplied to less. Repeat for multiple arguments.
+No shell expansion is performed. For example, '\-\-pager\-arg=+100' opens less
+at line 100 without replacing BAT_PAGER or '\-\-pager'. The built-in pager does
+not accept additional arguments. This option has no effect when paging is disabled.
+.HP
 \fB\-m\fR, \fB\-\-map\-syntax\fR <glob-pattern:syntax-name>...
 .IP
 Map a glob pattern to an existing syntax name. The glob pattern is matched on the full

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -123,6 +123,13 @@ Options:
           the built-in 'minus' pager. To control when the pager is used, see the '--paging' option.
           Example: '--pager "less -RF"'.
 
+      --pager-arg=<arg>
+          Append a literal argument after the selected pager's existing arguments, including the
+          default options supplied to less. Repeat this option for multiple arguments. Arguments are
+          passed directly, without shell expansion. For example, --pager-arg=+100 opens less at line
+          100 without replacing BAT_PAGER or --pager. Use --pager-arg='-Pmy prompt' for an argument
+          containing spaces. The built-in pager does not accept additional arguments.
+
   -m, --map-syntax <glob:syntax>
           Map a glob pattern to an existing syntax name. The glob pattern is matched on the full
           path and the filename. For example, to highlight *.build files with the Python syntax, use

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -88,27 +88,13 @@ impl App {
                 HelpType::Short
             };
 
-            let use_pager = match matches.get_one::<String>("paging").map(|s| s.as_str()) {
-                Some("never") => false,
-                _ => !matches.get_flag("no-paging"),
-            };
-
-            let use_color = match matches.get_one::<String>("color").map(|s| s.as_str()) {
-                Some("always") => true,
-                Some("never") => false,
-                _ => interactive_output, // auto: use color if interactive
-            };
-
-            let pager = matches.get_one::<String>("pager").map(|s| s.as_str());
             let theme_options = Self::theme_options_from_matches(&matches);
             let use_custom_assets = !matches.get_flag("no-custom-assets");
 
             Self::display_help(
                 interactive_output,
                 help_type,
-                use_pager,
-                use_color,
-                pager,
+                &matches,
                 theme_options,
                 use_custom_assets,
             )?;
@@ -126,9 +112,7 @@ impl App {
     fn display_help(
         interactive_output: bool,
         help_type: HelpType,
-        use_pager: bool,
-        use_color: bool,
-        pager: Option<&str>,
+        matches: &ArgMatches,
         theme_options: ThemeOptions,
         use_custom_assets: bool,
     ) -> Result<()> {
@@ -142,6 +126,21 @@ impl App {
             theme::theme,
             PagingMode,
         };
+
+        let use_pager = match matches.get_one::<String>("paging").map(|s| s.as_str()) {
+            Some("never") => false,
+            _ => !matches.get_flag("no-paging"),
+        };
+        let use_color = match matches.get_one::<String>("color").map(|s| s.as_str()) {
+            Some("always") => true,
+            Some("never") => false,
+            _ => interactive_output,
+        };
+        let pager = matches.get_one::<String>("pager").map(|s| s.as_str());
+        let pager_args = matches
+            .get_many::<String>("pager-arg")
+            .map(|args| args.cloned().collect())
+            .unwrap_or_default();
 
         let mut cmd = clap_app::build_app(interactive_output);
         let help_text = match help_type {
@@ -161,6 +160,7 @@ impl App {
             style_components: StyleComponents::new(StyleComponent::Plain.components(false)),
             paging_mode,
             pager,
+            pager_args,
             colored_output: use_color,
             true_color: use_color,
             language: if use_color { Some("help") } else { None },
@@ -507,6 +507,11 @@ impl App {
             style_components,
             syntax_mapping,
             pager: self.matches.get_one::<String>("pager").map(|s| s.as_str()),
+            pager_args: self
+                .matches
+                .get_many::<String>("pager-arg")
+                .map(|args| args.cloned().collect())
+                .unwrap_or_default(),
             use_italic_text: self
                 .matches
                 .get_one::<String>("italic-text")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -397,6 +397,24 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("pager-arg")
+                .long("pager-arg")
+                .action(ArgAction::Append)
+                .value_name("arg")
+                .require_equals(true)
+                .allow_hyphen_values(true)
+                .hide_short_help(true)
+                .help("Append a literal argument to the selected external pager.")
+                .long_help(
+                    "Append a literal argument after the selected pager's existing arguments, \
+                     including the default options supplied to less. Repeat this option for \
+                     multiple arguments. Arguments are passed directly, without shell expansion. \
+                     For example, --pager-arg=+100 opens less at line 100 without replacing \
+                     BAT_PAGER or --pager. Use --pager-arg='-Pmy prompt' for an argument \
+                     containing spaces. The built-in pager does not accept additional arguments."
+                ),
+        )
+        .arg(
             Arg::new("map-syntax")
                 .short('m')
                 .long("map-syntax")

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -254,8 +254,12 @@ pub fn list_themes(
         ))?;
     }
 
-    let mut output_type =
-        OutputType::from_mode(config.paging_mode, config.wrapping_mode, config.pager)?;
+    let mut output_type = OutputType::from_mode_with_args(
+        config.paging_mode,
+        config.wrapping_mode,
+        config.pager,
+        &config.pager_args,
+    )?;
     let mut writer = output_type.handle()?;
     writer.write_fmt(format_args!("{buf}"))?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,9 @@ pub struct Config<'a> {
     /// Command to start the pager
     pub pager: Option<&'a str>,
 
+    /// Literal arguments appended after the selected pager's existing arguments
+    pub pager_args: Vec<String>,
+
     /// Whether or not to use ANSI italics
     pub use_italic_text: bool,
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -76,10 +76,11 @@ impl Controller<'_> {
 
             let wrapping_mode = self.config.wrapping_mode;
 
-            output_type_opt = Some(OutputType::from_mode(
+            output_type_opt = Some(OutputType::from_mode_with_args(
                 paging_mode,
                 wrapping_mode,
                 self.config.pager,
+                &self.config.pager_args,
             )?);
         }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -78,11 +78,27 @@ impl OutputType {
         wrapping_mode: WrappingMode,
         pager: Option<&str>,
     ) -> Result<Self> {
+        Self::from_mode_with_args(paging_mode, wrapping_mode, pager, &[])
+    }
+
+    /// Select output and append literal arguments to an external pager.
+    #[cfg(feature = "paging")]
+    pub fn from_mode_with_args(
+        paging_mode: PagingMode,
+        wrapping_mode: WrappingMode,
+        pager: Option<&str>,
+        pager_args: &[String],
+    ) -> Result<Self> {
         use self::PagingMode::*;
         Ok(match paging_mode {
-            Always => OutputType::try_pager(SingleScreenAction::Nothing, wrapping_mode, pager)?,
+            Always => OutputType::try_pager(
+                SingleScreenAction::Nothing,
+                wrapping_mode,
+                pager,
+                pager_args,
+            )?,
             QuitIfOneScreen => {
-                OutputType::try_pager(SingleScreenAction::Quit, wrapping_mode, pager)?
+                OutputType::try_pager(SingleScreenAction::Quit, wrapping_mode, pager, pager_args)?
             }
             _ => OutputType::stdout(),
         })
@@ -94,6 +110,7 @@ impl OutputType {
         single_screen_action: SingleScreenAction,
         wrapping_mode: WrappingMode,
         pager_from_config: Option<&str>,
+        pager_args: &[String],
     ) -> Result<Self> {
         use crate::pager::{self, PagerKind, PagerSource};
         use std::process::{Command, Stdio};
@@ -111,6 +128,9 @@ impl OutputType {
         }
 
         if pager.kind == PagerKind::Builtin {
+            if !pager_args.is_empty() {
+                return Err("The built-in pager does not accept additional arguments".into());
+            }
             return Ok(OutputType::BuiltinPager(BuiltinPager::new()));
         }
 
@@ -186,6 +206,8 @@ impl OutputType {
         } else {
             p.args(args);
         };
+
+        p.args(pager_args);
 
         Ok(p.stdin(Stdio::piped())
             .spawn()

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -227,6 +227,14 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Append a literal argument to the selected external pager.
+    /// Can be called repeatedly. The built-in pager does not accept arguments.
+    #[cfg(feature = "paging")]
+    pub fn pager_arg(&mut self, arg: impl Into<String>) -> &mut Self {
+        self.config.pager_args.push(arg.into());
+        self
+    }
+
     /// Specify the lines that should be printed (default: all)
     pub fn line_ranges(&mut self, ranges: LineRanges) -> &mut Self {
         self.config.visible_lines = VisibleLines::Ranges(ranges);

--- a/tests/pager_arguments.rs
+++ b/tests/pager_arguments.rs
@@ -1,0 +1,104 @@
+#![cfg(all(unix, feature = "paging"))]
+
+mod utils;
+
+use std::os::unix::fs::PermissionsExt;
+use utils::command::bat;
+
+fn mock_pager(name: &str) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(name);
+    std::fs::write(&path, "#!/bin/sh\nif [ \"$1\" = --version ]; then echo 'less 590'; else printf '[%s]\\n' \"$@\"; cat >/dev/null; fi\n").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    (dir, path.to_string_lossy().into_owned())
+}
+
+#[test]
+fn append_literal_arguments_to_configured_pager() {
+    let (_dir, pager) = mock_pager("pager");
+    let output = bat()
+        .env("BAT_PAGER", format!("{pager} existing"))
+        .args([
+            "--paging=always",
+            "--pager-arg=+10",
+            "--pager-arg=two words",
+            "--pager-arg=$(literal)",
+        ])
+        .write_stdin("input\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(
+        String::from_utf8(output).unwrap(),
+        "[existing]\n[+10]\n[two words]\n[$(literal)]\n"
+    );
+}
+
+#[test]
+fn less_retains_automatic_options_before_extra_arguments() {
+    let (_dir, pager) = mock_pager("less");
+    let output = bat()
+        .arg(format!("--pager={pager}"))
+        .args(["--paging=always", "--wrap=never", "--pager-arg=+42"])
+        .write_stdin("input\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.starts_with("[-R]\n[-S]\n[-K]\n"), "{output}");
+    assert!(output.ends_with("[+42]\n"), "{output}");
+}
+
+#[test]
+fn explicit_less_arguments_are_not_replaced() {
+    let (_dir, pager) = mock_pager("less");
+    let output = bat()
+        .arg(format!("--pager={pager} -RF"))
+        .args(["--paging=always", "--pager-arg=-S"])
+        .write_stdin("input\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.starts_with("[-RF]\n"), "{output}");
+    assert!(output.ends_with("[-S]\n"), "{output}");
+    assert!(!output.contains("[-R]\n"), "{output}");
+}
+
+#[test]
+fn builtin_pager_rejects_extra_arguments_but_disabled_paging_ignores_them() {
+    bat()
+        .args(["--pager=builtin", "--paging=always", "--pager-arg=+1"])
+        .write_stdin("input\n")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("built-in pager does not accept"));
+    bat()
+        .args([
+            "--pager=builtin",
+            "--paging=never",
+            "--pager-arg=+1",
+            "--style=plain",
+        ])
+        .write_stdin("input\n")
+        .assert()
+        .success()
+        .stdout("input\n");
+}
+
+#[test]
+fn help_passes_extra_arguments_to_the_pager() {
+    let (_dir, pager) = mock_pager("pager");
+    bat()
+        .arg(format!("--pager={pager} existing"))
+        .args(["--help", "--paging=always", "--pager-arg=extra"])
+        .assert()
+        .success()
+        .stdout("[existing]\n[extra]\n");
+}


### PR DESCRIPTION
Per-invocation pager options currently require replacing the entire pager command, including arguments configured in BAT_PAGER or the config file.

Add repeatable `--pager-arg=<arg>` options and `PrettyPrinter::pager_arg()`. Append each value literally after existing pager arguments and bat's automatically supplied less options. Preserve spaces and shell metacharacters without expanding them. Help and theme-list paging use the same arguments. Reject extra arguments for the built-in pager when paging is active, and preserve the existing `OutputType::from_mode()` API.

Fixes #2837.

Validation: five new pager tests and 25 existing pager regression tests passed, including default/custom less options, literal values, help output, and disabled paging. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. Manual, completions, and help snapshots updated. GitHub CI pending.