### PR TITLE
Allow silent fallback for unsupported input syntaxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
+- Add `--fail-if-syntax-unsupported` for silent fallback in input preprocessor chains, see #0 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
-- Add `--fail-if-syntax-unsupported` for silent fallback in input preprocessor chains, see #0 (@Matei02355)
+- Add `--fail-if-syntax-unsupported` for silent fallback in input preprocessor chains, see #3942 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -146,6 +146,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--italic-text'           , 'italic-text'           , [CompletionResultType]::ParameterName, 'Use italics in output (always, *never*)')
             [CompletionResult]::new('--decorations'           , 'decorations'           , [CompletionResultType]::ParameterName, 'When to show the decorations (*auto*, never, always).')
             [CompletionResult]::new('--paging'                , 'paging'                , [CompletionResultType]::ParameterName, 'Specify when to use the pager, or use ''-P'' to disable (*auto*, never, always).')
+            [CompletionResult]::new('--fail-if-syntax-unsupported', 'fail-if-syntax-unsupported', [CompletionResultType]::ParameterName, 'Silently reject inputs without a specific syntax.')
             [CompletionResult]::new('--pager'                 , 'pager'                 , [CompletionResultType]::ParameterName, 'Determine which pager to use.')
         #   [CompletionResult]::new('-m'                      , 'm'                     , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
             [CompletionResult]::new('--map-syntax'            , 'map-syntax'            , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -217,6 +217,7 @@ _bat() {
 			--paging
 			--no-paging
 			--pager
+			--fail-if-syntax-unsupported
 			--map-syntax
 			--ignored-suffix
 			--theme

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,5 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -l fail-if-syntax-unsupported -d "Silently reject inputs without a specific syntax" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -44,6 +44,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         '(-f --force-colorization)'--force-colorization'[force colorization and decorations]'
         --paging='[specify when to use the pager]:when:(auto never always)'
         '(-P --no-paging)'--no-paging'[alias for --paging=never]'
+        --fail-if-syntax-unsupported'[silently reject inputs without a specific syntax]'
         --pager='[determine which pager to use]:command:'
         '(-m --map-syntax)'{-m+,--map-syntax=}'[map a glob pattern to an existing syntax name]: :->syntax-maps'
         --ignored-suffix='[ignore extension]:suffix:'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -159,6 +159,15 @@ Example: '\-\-pager "less \fB\-RF\fR"'.
 
 Note: By default, if the pager is set to 'less' (and no command-line options are specified), 'bat' will pass the following command line options to the pager: '-R'/'--RAW-CONTROL-CHARS', '-F'/'--quit-if-one-screen' and '-X'/'--no-init'. The last option ('-X') is only used for 'less' versions older than 530. The '-R' option is needed to interpret ANSI colors correctly. The second option ('-F') instructs less to exit immediately if the output size is smaller than the vertical size of the terminal. This is convenient for small files because you do not have to press 'q' to quit the pager. The third option ('-X') is needed to fix a bug with the '--quit-if-one-screen' feature in old versions of 'less'. Unfortunately, it also breaks mouse-wheel support in 'less'. If you want to enable mouse-wheel scrolling on older versions of 'less', you can pass just '-R' (as in the example above, this will disable the quit-if-one-screen feature). For less 530 or newer, it should work out of the box.
 .HP
+\fB\-\-fail-if-syntax-unsupported\fR
+.IP
+Skip inputs without a specific syntax, producing no output or diagnostic for those
+inputs and exiting with a nonzero status. Other errors are reported normally.
+Plain Text and binary inputs are unsupported; '\-\-binary=as-text' permits binary
+input with a recognized syntax. Explicit languages, mappings, first-line detection,
+'\-\-file-name', and a specific '\-\-fallback-syntax' still apply.
+Disables paging, allowing the next input preprocessor to handle unsupported files.
+.HP
 \fB\-m\fR, \fB\-\-map\-syntax\fR <glob-pattern:syntax-name>...
 .IP
 Map a glob pattern to an existing syntax name. The glob pattern is matched on the full

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -123,6 +123,14 @@ Options:
           the built-in 'minus' pager. To control when the pager is used, see the '--paging' option.
           Example: '--pager "less -RF"'.
 
+      --fail-if-syntax-unsupported
+          Skip inputs without a specific syntax, producing no output or diagnostic for those inputs
+          and exiting with a nonzero status. Plain Text and binary inputs are unsupported;
+          --binary=as-text permits binary input with a recognized syntax. Explicit languages,
+          mappings, first-line detection, and --file-name still apply. A specific --fallback-syntax
+          is accepted. Other errors are reported normally. Disables paging for use in input
+          preprocessor chains.
+
   -m, --map-syntax <glob:syntax>
           Map a glob pattern to an existing syntax name. The glob pattern is matched on the full
           path and the filename. For example, to highlight *.build files with the Python syntax, use

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -479,6 +479,7 @@ impl App {
                     .map(|s| s.as_str()),
                 "--sanitize",
             ),
+            fail_if_syntax_unsupported: self.matches.get_flag("fail-if-syntax-unsupported"),
             quiet_empty: self.matches.get_flag("quiet-empty"),
             unbuffered: self.matches.get_flag("unbuffered"),
             number_nonblank: self.matches.get_flag("number-nonblank")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -397,6 +397,22 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("fail-if-syntax-unsupported")
+                .long("fail-if-syntax-unsupported")
+                .action(ArgAction::SetTrue)
+                .overrides_with("fail-if-syntax-unsupported")
+                .hide_short_help(true)
+                .help("Silently reject inputs without a specific syntax.")
+                .long_help(
+                    "Skip inputs without a specific syntax, producing no output or diagnostic \
+                     for those inputs and exiting with a nonzero status. Plain Text and binary \
+                     inputs are unsupported; --binary=as-text permits binary input with a \
+                     recognized syntax. Explicit languages, mappings, first-line detection, and \
+                     --file-name still apply. A specific --fallback-syntax is accepted. Other \
+                     errors are reported normally. Disables paging for use in input preprocessor chains."
+                ),
+        )
+        .arg(
             Arg::new("map-syntax")
                 .short('m')
                 .long("map-syntax")

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,9 @@ pub struct Config<'a> {
     /// The explicitly configured language, if any
     pub language: Option<&'a str>,
 
+    /// Silently reject inputs without a specific syntax (also disables paging)
+    pub fail_if_syntax_unsupported: bool,
+
     /// The fallback syntax used when auto-detection fails
     pub fallback_syntax: Option<&'a str>,
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -60,7 +60,13 @@ impl Controller<'_> {
             use std::path::Path;
 
             // Do not launch the pager if NONE of the input files exist
-            let mut paging_mode = self.config.paging_mode;
+            // This mode is intended for input preprocessors, where an outer
+            // pager needs an empty stream to try its next fallback.
+            let mut paging_mode = if self.config.fail_if_syntax_unsupported {
+                PagingMode::Never
+            } else {
+                self.config.paging_mode
+            };
             if self.config.paging_mode != PagingMode::Never {
                 let call_pager = inputs.iter().any(|input| {
                     if let InputKind::OrdinaryFile(ref path) = input.kind {
@@ -159,6 +165,32 @@ impl Controller<'_> {
             input.open(stdin, stdout_identifier)?
         };
         opened_input.reader.unbuffered = self.config.unbuffered;
+        if self.config.fail_if_syntax_unsupported {
+            let is_binary = opened_input
+                .reader
+                .content_type
+                .is_some_and(|c| c.is_binary());
+            if is_binary
+                && !self.config.show_nonprintable
+                && self.config.binary != crate::BinaryBehavior::AsText
+            {
+                return Err(Error::SyntaxUnsupported);
+            }
+            match self.assets.get_syntax(
+                self.config.language,
+                self.config.fallback_syntax,
+                &mut opened_input,
+                &self.config.syntax_mapping,
+            ) {
+                Ok(syntax) if syntax.syntax.name == "Plain Text" => {
+                    return Err(Error::SyntaxUnsupported)
+                }
+                Ok(_) => {}
+                Err(Error::UndetectedSyntax(_)) => return Err(Error::SyntaxUnsupported),
+                Err(error) => return Err(error),
+            }
+        }
+
         #[cfg(feature = "git")]
         let line_changes = if self.config.visible_lines.diff_mode()
             || (!self.config.loop_through && self.config.style_components.changes())

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     SerdeYamlError(#[from] ::serde_yaml::Error),
     #[error("unable to detect syntax for {0}")]
     UndetectedSyntax(String),
+    #[error("input has no supported syntax")]
+    SyntaxUnsupported,
     #[error("unknown syntax: '{0}'")]
     UnknownSyntax(String),
     #[error("Unknown style '{0}'")]
@@ -57,6 +59,7 @@ pub fn default_error_handler(error: &Error, output: &mut dyn Write) {
     use nu_ansi_term::Color::Red;
 
     match error {
+        Error::SyntaxUnsupported => {}
         Error::Io(ref io_error) if io_error.kind() == ::std::io::ErrorKind::BrokenPipe => {
             ::std::process::exit(0);
         }

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -133,6 +133,12 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Reject inputs without a specific syntax and disable paging.
+    pub fn fail_if_syntax_unsupported(&mut self, yes: bool) -> &mut Self {
+        self.config.fail_if_syntax_unsupported = yes;
+        self
+    }
+
     /// Whether or not to output 24bit colors (default: true)
     pub fn true_color(&mut self, yes: bool) -> &mut Self {
         self.config.true_color = yes;

--- a/tests/unsupported_syntax.rs
+++ b/tests/unsupported_syntax.rs
@@ -1,0 +1,116 @@
+mod utils;
+use utils::command::bat;
+
+#[test]
+fn unsupported_text_and_binary_are_silent_even_with_headers() {
+    for input in [b"unrecognized input\n".as_slice(), b"PK\x03\x04binary\n"] {
+        bat()
+            .args([
+                "--fail-if-syntax-unsupported",
+                "--decorations=always",
+                "--style=full",
+                "--color=always",
+            ])
+            .write_stdin(input)
+            .assert()
+            .failure()
+            .stdout("")
+            .stderr("");
+    }
+    bat()
+        .args(["--fail-if-syntax-unsupported", "--file-name=plain.txt"])
+        .write_stdin("plain\n")
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr("");
+}
+
+#[test]
+fn explicit_detected_and_fallback_syntaxes_are_accepted_when_piped() {
+    for args in [
+        vec!["-l", "json"],
+        vec!["--file-name=example.json"],
+        vec!["--fallback-syntax=json"],
+        vec!["--file-name=example.custom", "-m", "*.custom:JSON"],
+    ] {
+        bat()
+            .arg("--fail-if-syntax-unsupported")
+            .args(args)
+            .write_stdin("{}\n")
+            .assert()
+            .success()
+            .stdout("{}\n")
+            .stderr("");
+    }
+    bat()
+        .arg("--fail-if-syntax-unsupported")
+        .write_stdin("#!/bin/sh\necho hello\n")
+        .assert()
+        .success()
+        .stdout("#!/bin/sh\necho hello\n")
+        .stderr("");
+}
+
+#[test]
+fn invalid_languages_and_missing_files_still_report_errors() {
+    bat()
+        .args(["--fail-if-syntax-unsupported", "-l", "not-a-language"])
+        .write_stdin("input\n")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("unknown syntax"));
+    bat()
+        .args([
+            "--fail-if-syntax-unsupported",
+            "missing-file-without-syntax.xyz",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("missing-file-without-syntax.xyz"));
+}
+
+#[test]
+fn mixed_inputs_print_supported_files_and_fail_for_unsupported_ones() {
+    let dir = tempfile::tempdir().unwrap();
+    let known = dir.path().join("known.json");
+    let unknown = dir.path().join("unknown.custom");
+    std::fs::write(&known, "{}\n").unwrap();
+    std::fs::write(&unknown, "unknown\n").unwrap();
+    bat()
+        .arg("--fail-if-syntax-unsupported")
+        .arg(unknown)
+        .arg(known)
+        .assert()
+        .failure()
+        .stdout("{}\n")
+        .stderr("");
+}
+
+#[test]
+#[cfg(feature = "paging")]
+fn preprocess_mode_does_not_launch_a_pager() {
+    bat()
+        .args([
+            "--fail-if-syntax-unsupported",
+            "--pager=bat",
+            "--paging=always",
+        ])
+        .write_stdin("unknown\n")
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr("");
+    bat()
+        .args([
+            "--fail-if-syntax-unsupported",
+            "--pager=bat",
+            "--paging=always",
+            "-ljson",
+        ])
+        .write_stdin("{}\n")
+        .assert()
+        .success()
+        .stdout("{}\n")
+        .stderr("");
+}


### PR DESCRIPTION
Input preprocessor chains need bat to return an empty stream and a failure status when another preprocessor would handle an input better.

Add `--fail-if-syntax-unsupported` and the corresponding PrettyPrinter option. Check syntax before headers/content, including when output is piped. Silently reject unidentified syntax, Plain Text, and binary data unless binary-as-text was requested with a recognized syntax. Preserve explicit languages, mappings, filename hints, first-line detection, and specific fallback syntaxes. Other errors remain diagnostic; mixed inputs print supported files and return failure if any input is unsupported. Disable paging in this preprocessor mode.

Fixes #1709.

Validation: five regression tests passed across text/binary input, detection paths, mixed files, genuine errors, and pager suppression. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. Help snapshots, manual, and completions updated. GitHub CI pending.