### PR TITLE
Publish SHA-256 sidecars for release artifacts

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -421,18 +421,34 @@ jobs:
         # build dpkg
         fakeroot dpkg-deb --build "${DPKG_DIR}" "${DPKG_PATH}"
 
+    - name: Generate SHA-256 checksums
+      shell: bash
+      env:
+        ARCHIVE_PATH: ${{ steps.package.outputs.PKG_PATH }}
+        DEBIAN_PATH: ${{ steps.debian-package.outputs.DPKG_PATH }}
+      run: |
+        checksum_inputs=("$ARCHIVE_PATH")
+        if [[ -n "$DEBIAN_PATH" ]]; then
+          checksum_inputs+=("$DEBIAN_PATH")
+        fi
+        python ci/create-checksums.py "${checksum_inputs[@]}"
+
     - name: "Artifact upload: tarball"
       uses: actions/upload-artifact@master
       with:
         name: ${{ steps.package.outputs.PKG_NAME }}
-        path: ${{ steps.package.outputs.PKG_PATH }}
+        path: |
+          ${{ steps.package.outputs.PKG_PATH }}
+          ${{ steps.package.outputs.PKG_PATH }}.sha256
 
     - name: "Artifact upload: Debian package"
       uses: actions/upload-artifact@master
       if: steps.debian-package.outputs.DPKG_NAME
       with:
         name: ${{ steps.debian-package.outputs.DPKG_NAME }}
-        path: ${{ steps.debian-package.outputs.DPKG_PATH }}
+        path: |
+          ${{ steps.debian-package.outputs.DPKG_PATH }}
+          ${{ steps.debian-package.outputs.DPKG_PATH }}.sha256
 
     - name: Check for release
       id: is-release
@@ -447,7 +463,9 @@ jobs:
       with:
         files: |
           ${{ steps.package.outputs.PKG_PATH }}
+          ${{ steps.package.outputs.PKG_PATH }}.sha256
           ${{ steps.debian-package.outputs.DPKG_PATH }}
+          ${{ steps.debian-package.outputs.DPKG_PATH && format('{0}.sha256', steps.debian-package.outputs.DPKG_PATH) || '' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## Other
-- Publish SHA-256 checksum sidecars for release archives and Debian packages, see #0 (@Matei02355)
+- Publish SHA-256 checksum sidecars for release archives and Debian packages, see #3943 (@Matei02355)
 
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## Other
+- Publish SHA-256 checksum sidecars for release archives and Debian packages, see #0 (@Matei02355)
 
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536

--- a/ci/create-checksums.py
+++ b/ci/create-checksums.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Write portable SHA-256 sidecars for release archives and packages."""
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="+", type=Path)
+    args = parser.parse_args()
+    for path in args.files:
+        digest = hashlib.sha256()
+        with path.open("rb") as source:
+            for block in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(block)
+        checksum = path.with_name(path.name + ".sha256")
+        checksum.write_text(f"{digest.hexdigest()}  {path.name}\n", encoding="utf-8", newline="\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -82,3 +82,15 @@
 ```
 
 [auto-merged]: https://github.com/sharkdp/bat/blob/master/.github/workflows/Auto-merge-dependabot-PRs.yml
+
+### Release checksums
+
+Each release archive and Debian package has a matching `.sha256` file. Download
+both files into the same directory and verify the package before installing it:
+
+```sh
+sha256sum --check bat-vVERSION-TARGET.tar.gz.sha256
+```
+
+On macOS, use `shasum -a 256 --check` with the same sidecar. Each checksum contains
+only the asset basename, so verification works after moving the downloads.


### PR DESCRIPTION
Release archives and Debian packages currently have no accompanying checksums for installation scripts to verify.

Generate a `.sha256` sidecar for each final archive and package, and include it in both CI artifacts and tagged-release uploads. Use asset basenames so verification works in any download directory. Each matrix job writes its own sidecars, avoiding races over a shared manifest. Document verification commands.

Fixes #1867.

Validation: workflow YAML parsed; generated sidecars for a multi-megabyte binary archive with spaces in its filename and an empty Debian package both passed `sha256sum --check`; changing the package caused verification to fail. Whitespace checks passed. Tagged-release publication requires a future release run.