### PR TITLE
Highlight entire lines with Git modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
-- Add `changes-highlight` style for whole-line highlighting of Git changes, see #0 (@Matei02355)
+- Add `changes-highlight` style for whole-line highlighting of Git changes, see #3946 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
+- Add `changes-highlight` style for whole-line highlighting of Git changes, see #0 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -5,7 +5,7 @@ using namespace System.Management.Automation.Language
 Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
-    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
+    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'changes-highlight', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
     $ArrayCompletion = @('bash', 'fish', 'zsh', 'ps1')
     $ArrayWhen       = @('auto', 'never', 'always')
     $ArrayYesNo      = @('never', 'always')
@@ -152,7 +152,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
-            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, changes-highlight, header, header-filename, header-filesize, grid, rule, numbers, snip).')
         #   [CompletionResult]::new('-r'                      , 'r'                     , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
         #   [CompletionResult]::new('-A'                      , 'A'                     , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -173,6 +173,7 @@ _bat() {
 			auto
 			plain
 			changes
+			changes-highlight
 			header
 			header-filename
 			header-filesize

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -79,6 +79,7 @@ function __bat_style_opts
         "full,all components" \
         "plain,no components" \
         "changes,Git change markers" \
+        "changes-highlight,highlight lines with Git changes" \
         "header,alias for header-filename" \
         "header-filename,filename above content" \
         "header-filesize,filesize above content" \

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -56,7 +56,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
-            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+            default auto full plain changes changes-highlight header header-filename header-filesize grid rule numbers snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
         '(* -)'{-L,--list-languages}'[display all supported languages]'
         '(-u --unbuffered)'--unbuffered'[enable unbuffered input reading for streaming use cases]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -242,8 +242,11 @@ replacing them.
 By default, the following components are enabled:
 changes, grid, header\-filename, numbers, snip
 .IP
-Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
-rule, numbers, snip.
+Possible values: *default*, full, auto, plain, changes, changes-highlight, header, header-filename, header-filesize, grid,
+rule, numbers, snip. The changes-highlight component uses the theme's line
+highlight for lines with Git change markers, including the surviving line adjacent
+to a deletion. It can be used independently of sidebar markers, is included in full
+style, and respects '\-\-color=never'. Requires Git support.
 .HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...
 .IP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -205,6 +205,7 @@ Options:
             * auto: same as 'default', unless the output is piped.
             * plain: disables all available components.
             * changes: show Git modification markers.
+            * changes-highlight: highlight lines with Git change markers.
             * header: alias for 'header-filename'.
             * header-filename: show filenames before the content.
             * header-filesize: show file sizes before the content.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -57,7 +57,7 @@ Options:
           Squeeze consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
-          header, header-filename, header-filesize, grid, rule, numbers, snip).
+          changes-highlight, header, header-filename, header-filesize, grid, rule, numbers, snip).
   -r, --line-range <N:M>
           Only print the lines from N to M.
   -L, --list-languages

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -534,7 +534,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).",
+                     (*default*, auto, full, plain, changes, changes-highlight, header, header-filename, header-filesize, grid, rule, numbers, snip).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -558,6 +558,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                      * auto: same as 'default', unless the output is piped.\n  \
                      * plain: disables all available components.\n  \
                      * changes: show Git modification markers.\n  \
+                     * changes-highlight: highlight lines with Git change markers.\n  \
                      * header: alias for 'header-filename'.\n  \
                      * header-filename: show filenames before the content.\n  \
                      * header-filesize: show file sizes before the content.\n  \

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -161,7 +161,9 @@ impl Controller<'_> {
         opened_input.reader.unbuffered = self.config.unbuffered;
         #[cfg(feature = "git")]
         let line_changes = if self.config.visible_lines.diff_mode()
-            || (!self.config.loop_through && self.config.style_components.changes())
+            || (!self.config.loop_through
+                && (self.config.style_components.changes()
+                    || self.config.style_components.changes_highlight()))
         {
             match opened_input.kind {
                 crate::input::OpenedInputKind::OrdinaryFile(ref path) => {

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -23,6 +23,8 @@ struct ActiveStyleComponents {
     header_filename: bool,
     #[cfg(feature = "git")]
     vcs_modification_markers: bool,
+    #[cfg(feature = "git")]
+    vcs_modification_highlighting: bool,
     grid: bool,
     rule: bool,
     line_numbers: bool,
@@ -168,6 +170,14 @@ impl<'a> PrettyPrinter<'a> {
     #[cfg(feature = "git")]
     pub fn vcs_modification_markers(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.vcs_modification_markers = yes;
+        self
+    }
+
+    /// Highlight lines with Git change markers using the theme's line highlight.
+    /// This can be enabled independently of the sidebar modification markers.
+    #[cfg(feature = "git")]
+    pub fn vcs_modification_highlighting(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.vcs_modification_highlighting = yes;
         self
     }
 
@@ -321,6 +331,12 @@ impl<'a> PrettyPrinter<'a> {
         }
         if self.active_style_components.snip {
             self.config.style_components.insert(StyleComponent::Snip);
+        }
+        #[cfg(feature = "git")]
+        if self.active_style_components.vcs_modification_highlighting {
+            self.config
+                .style_components
+                .insert(StyleComponent::ChangesHighlight);
         }
         #[cfg(feature = "git")]
         if self.active_style_components.vcs_modification_markers {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -728,6 +728,16 @@ impl Printer for InteractivePrinter<'_> {
             .check(line_number, max_buffered_line_number)
             == RangeCheckResult::InRange;
 
+        #[cfg(feature = "git")]
+        let highlight_this_line = highlight_this_line
+            || (self.config.colored_output
+                && self.config.style_components.changes_highlight()
+                && u32::try_from(line_number).ok().is_some_and(|line| {
+                    self.line_changes
+                        .as_ref()
+                        .is_some_and(|changes| changes.contains_key(&line))
+                }));
+
         if highlight_this_line && self.config.theme == "ansi" {
             self.ansi_style.update(ANSI_UNDERLINE_ENABLE);
         }

--- a/src/style.rs
+++ b/src/style.rs
@@ -9,6 +9,8 @@ pub enum StyleComponent {
     Auto,
     #[cfg(feature = "git")]
     Changes,
+    #[cfg(feature = "git")]
+    ChangesHighlight,
     Grid,
     Rule,
     Header,
@@ -33,6 +35,8 @@ impl StyleComponent {
             }
             #[cfg(feature = "git")]
             StyleComponent::Changes => &[StyleComponent::Changes],
+            #[cfg(feature = "git")]
+            StyleComponent::ChangesHighlight => &[StyleComponent::ChangesHighlight],
             StyleComponent::Grid => &[StyleComponent::Grid],
             StyleComponent::Rule => &[StyleComponent::Rule],
             StyleComponent::Header => &[StyleComponent::HeaderFilename],
@@ -43,6 +47,8 @@ impl StyleComponent {
             StyleComponent::Full => &[
                 #[cfg(feature = "git")]
                 StyleComponent::Changes,
+                #[cfg(feature = "git")]
+                StyleComponent::ChangesHighlight,
                 StyleComponent::Grid,
                 StyleComponent::HeaderFilename,
                 StyleComponent::HeaderFilesize,
@@ -70,6 +76,8 @@ impl FromStr for StyleComponent {
             "auto" => Ok(StyleComponent::Auto),
             #[cfg(feature = "git")]
             "changes" => Ok(StyleComponent::Changes),
+            #[cfg(feature = "git")]
+            "changes-highlight" => Ok(StyleComponent::ChangesHighlight),
             "grid" => Ok(StyleComponent::Grid),
             "rule" => Ok(StyleComponent::Rule),
             "header" => Ok(StyleComponent::Header),
@@ -96,6 +104,11 @@ impl StyleComponents {
     #[cfg(feature = "git")]
     pub fn changes(&self) -> bool {
         self.0.contains(&StyleComponent::Changes)
+    }
+
+    #[cfg(feature = "git")]
+    pub fn changes_highlight(&self) -> bool {
+        self.0.contains(&StyleComponent::ChangesHighlight)
     }
 
     pub fn grid(&self) -> bool {

--- a/tests/git_line_highlights.rs
+++ b/tests/git_line_highlights.rs
@@ -1,0 +1,86 @@
+#![cfg(feature = "git")]
+mod utils;
+use std::path::Path;
+use utils::command::bat;
+
+fn repository() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("example.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    for args in [vec!["init"], vec!["add", "example.txt"]] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+    }
+    dir
+}
+
+fn render(dir: &Path, args: &[&str]) -> Vec<u8> {
+    bat()
+        .current_dir(dir)
+        .args([
+            "--paging=never",
+            "--decorations=always",
+            "--color=always",
+            "--theme=ansi",
+            "--terminal-width=30",
+        ])
+        .args(args)
+        .arg("example.txt")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
+}
+
+#[test]
+fn modified_and_added_lines_match_explicit_highlights() {
+    let dir = repository();
+    std::fs::write(
+        dir.path().join("example.txt"),
+        "alpha\nBETA\ngamma\ndelta\n",
+    )
+    .unwrap();
+    assert_eq!(
+        render(dir.path(), &["--style=changes-highlight"]),
+        render(dir.path(), &["--style=plain", "-H2", "-H4"])
+    );
+    assert_eq!(
+        render(dir.path(), &["--style=changes-highlight", "-H1"]),
+        render(dir.path(), &["--style=plain", "-H1:2", "-H4"])
+    );
+}
+
+#[test]
+fn deletion_marks_adjacent_surviving_line() {
+    let dir = repository();
+    std::fs::write(dir.path().join("example.txt"), "beta\ngamma\n").unwrap();
+    assert_eq!(
+        render(dir.path(), &["--style=changes-highlight"]),
+        render(dir.path(), &["--style=plain", "-H1"])
+    );
+}
+
+#[test]
+fn unchanged_files_and_colorless_output_remain_plain() {
+    let dir = repository();
+    assert_eq!(
+        render(dir.path(), &["--style=changes-highlight"]),
+        render(dir.path(), &["--style=plain"])
+    );
+    std::fs::write(dir.path().join("example.txt"), "changed\n").unwrap();
+    assert_eq!(
+        render(dir.path(), &["--style=changes-highlight", "--color=never"]),
+        b"changed\n"
+    );
+    assert_eq!(
+        render(
+            dir.path(),
+            &["--style=changes-highlight,-changes-highlight"]
+        ),
+        render(dir.path(), &["--style=plain"])
+    );
+}


### PR DESCRIPTION
Small Git change markers can be difficult to spot in large files.

Add a `changes-highlight` style component that uses the theme's line highlight on lines with Git modification markers. It works independently of sidebar markers and is included in `full`. Combine it with explicit highlight ranges, preserve colorless output, and mark the surviving adjacent line for deletions. Expose the option to library callers as `PrettyPrinter::vcs_modification_highlighting()`.

Fixes #2529 and #1523.

Validation: three Git-backed regression tests passed, covering modified/added lines, deletion markers, explicit-highlight unions, unchanged files, style removal, and colorless output. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. Help snapshots, manual, and completions updated. GitHub CI passed.