### PR TITLE
Bound input reads before buffering lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
+- Add `--max-bytes` (`--head`) to bound reads before line buffering, see #0 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
-- Add `--max-bytes` (`--head`) to bound reads before line buffering, see #0 (@Matei02355)
+- Add `--max-bytes` (`--head`) to bound reads before line buffering, see #3947 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -146,6 +146,8 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--italic-text'           , 'italic-text'           , [CompletionResultType]::ParameterName, 'Use italics in output (always, *never*)')
             [CompletionResult]::new('--decorations'           , 'decorations'           , [CompletionResultType]::ParameterName, 'When to show the decorations (*auto*, never, always).')
             [CompletionResult]::new('--paging'                , 'paging'                , [CompletionResultType]::ParameterName, 'Specify when to use the pager, or use ''-P'' to disable (*auto*, never, always).')
+            [CompletionResult]::new('--max-bytes'             , 'max-bytes'             , [CompletionResultType]::ParameterName, 'Read at most N bytes per input.')
+            [CompletionResult]::new('--head'                  , 'head'                  , [CompletionResultType]::ParameterName, 'Alias for --max-bytes.')
             [CompletionResult]::new('--pager'                 , 'pager'                 , [CompletionResultType]::ParameterName, 'Determine which pager to use.')
         #   [CompletionResult]::new('-m'                      , 'm'                     , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
             [CompletionResult]::new('--map-syntax'            , 'map-syntax'            , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -228,6 +228,8 @@ _bat() {
 			--sanitize
 			--strip-ansi
 			--style
+			--max-bytes
+			--head
 			--line-range
 			--list-languages
 			--lessopen

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,6 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -l max-bytes -x -d "Read at most N bytes per input" -n __bat_no_excl_args
+complete -c $bat -l head -x -d "Alias for --max-bytes" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -46,6 +46,8 @@ _{{PROJECT_EXECUTABLE}}_main() {
         '(-P --no-paging)'--no-paging'[alias for --paging=never]'
         --pager='[determine which pager to use]:command:'
         '(-m --map-syntax)'{-m+,--map-syntax=}'[map a glob pattern to an existing syntax name]: :->syntax-maps'
+        --max-bytes='[read at most N bytes per input]:bytes:'
+        --head='[alias for --max-bytes]:bytes:'
         --ignored-suffix='[ignore extension]:suffix:'
         '(--theme)'--theme='[set the color theme for syntax highlighting]:theme:->theme_preferences'
         '(--theme-dark)'--theme-dark='[set the color theme for syntax highlighting for dark backgrounds]:theme:->themes'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -245,6 +245,14 @@ changes, grid, header\-filename, numbers, snip
 Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
 rule, numbers, snip.
 .HP
+\fB\-\-max-bytes\fR <N>, \fB\-\-head\fR <N>
+.IP
+Read at most N bytes from each input before line buffering. Useful for devices and
+streams without newlines. Zero reads no content. The limit may split a multibyte
+character. Binary detection and formatting still apply; use '\-\-binary=as-text'
+to display binary bytes. With LESSOPEN, the limit applies to preprocessor output
+and does not bound the preprocessor's own reads.
+.HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...
 .IP
 Only print the specified range of lines for each file. For example:

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -214,6 +214,14 @@ Options:
             * numbers: show line numbers in the side bar.
             * snip: draw separation lines between distinct line ranges.
 
+      --max-bytes <N>
+          Read at most N bytes from each input, before line buffering. --head is an alias. Useful
+          for devices and streams that may not contain newlines. A zero limit reads no content. This
+          is a byte limit, so input may end within a multibyte character. Binary detection and
+          output formatting still apply; use --binary=as-text to display binary bytes. When using
+          LESSOPEN, the limit applies to the preprocessor output; it does not bound the
+          preprocessor's own reads.
+
   -r, --line-range <N:M>
           Only print the specified range of lines for each file. For example:
             '--line-range 30:40' prints lines 30 to 40

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -480,6 +480,7 @@ impl App {
                 "--sanitize",
             ),
             quiet_empty: self.matches.get_flag("quiet-empty"),
+            max_bytes: self.matches.get_one::<u64>("max-bytes").copied(),
             unbuffered: self.matches.get_flag("unbuffered"),
             number_nonblank: self.matches.get_flag("number-nonblank")
                 || self.number_nonblank_from_cli,

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -569,6 +569,24 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("max-bytes")
+                .long("max-bytes")
+                .alias("head")
+                .overrides_with("max-bytes")
+                .value_name("N")
+                .value_parser(clap::value_parser!(u64))
+                .hide_short_help(true)
+                .help("Read at most N bytes from each input.")
+                .long_help(
+                    "Read at most N bytes from each input, before line buffering. --head is an alias. Useful for \
+                     devices and streams that may not contain newlines. A zero limit reads no \
+                     content. This is a byte limit, so input may end within a multibyte character. \
+                     Binary detection and output formatting still apply; use --binary=as-text \
+                     to display binary bytes. When using LESSOPEN, the limit applies to the \
+                     preprocessor output; it does not bound the preprocessor's own reads."
+                ),
+        )
+        .arg(
             Arg::new("line-range")
                 .long("line-range")
                 .short('r')

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,9 @@ pub struct Config<'a> {
     /// Whether or not to produce no output when input is empty
     pub quiet_empty: bool,
 
+    /// Maximum input bytes to read from each source
+    pub max_bytes: Option<u64>,
+
     /// Whether or not to use unbuffered input reading for streaming use cases
     pub unbuffered: bool,
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -146,6 +146,10 @@ impl Controller<'_> {
         stdout_identifier: Option<&Identifier>,
         is_first: bool,
     ) -> Result<()> {
+        let input = match self.config.max_bytes {
+            Some(limit) => input.with_max_bytes(limit),
+            None => input,
+        };
         let mut opened_input = {
             #[cfg(feature = "lessopen")]
             match self.preprocessor {

--- a/src/input.rs
+++ b/src/input.rs
@@ -91,6 +91,7 @@ impl InputKind<'_> {
 pub(crate) struct InputMetadata {
     pub(crate) user_provided_name: Option<PathBuf>,
     pub(crate) size: Option<u64>,
+    pub(crate) max_bytes: Option<u64>,
 }
 
 pub struct Input<'a> {
@@ -164,6 +165,13 @@ impl<'a> Input<'a> {
         }
     }
 
+    /// Limit how many bytes are read from this input, before line buffering.
+    /// The limit applies to bytes, so it may end within a character or line.
+    pub fn with_max_bytes(mut self, limit: u64) -> Self {
+        self.metadata.max_bytes = Some(self.metadata.max_bytes.map_or(limit, |old| old.min(limit)));
+        self
+    }
+
     pub fn is_stdin(&self) -> bool {
         matches!(self.kind, InputKind::StdIn)
     }
@@ -195,6 +203,7 @@ impl<'a> Input<'a> {
         stdout_identifier: Option<&Identifier>,
     ) -> Result<OpenedInput<'a>> {
         let description = self.description().clone();
+        let max_bytes = self.metadata.max_bytes.unwrap_or(u64::MAX);
         match self.kind {
             InputKind::StdIn => {
                 if let Some(stdout) = stdout_identifier {
@@ -209,7 +218,7 @@ impl<'a> Input<'a> {
                     kind: OpenedInputKind::StdIn,
                     description,
                     metadata: self.metadata,
-                    reader: InputReader::try_new(stdin)?,
+                    reader: InputReader::try_new(stdin.take(max_bytes))?,
                 })
             }
 
@@ -238,14 +247,14 @@ impl<'a> Input<'a> {
                         file = input_identifier.into_inner().expect("The file was lost in the clircle::Identifier, this should not have happened...");
                     }
 
-                    InputReader::try_new(BufReader::new(file))?
+                    InputReader::try_new(BufReader::new(file.take(max_bytes)))?
                 },
             }),
             InputKind::CustomReader(reader) => Ok(OpenedInput {
                 description,
                 kind: OpenedInputKind::CustomReader,
                 metadata: self.metadata,
-                reader: InputReader::try_new(BufReader::new(reader))?,
+                reader: InputReader::try_new(BufReader::new(reader.take(max_bytes)))?,
             }),
         }
     }

--- a/src/lessopen.rs
+++ b/src/lessopen.rs
@@ -203,7 +203,7 @@ impl LessOpenPreprocessor {
         Ok(OpenedInput {
             kind,
             reader: InputReader::try_new(BufReader::new(
-                if matches!(self.kind, LessOpenKind::TempFile) {
+                (if matches!(self.kind, LessOpenKind::TempFile) {
                     let lessopen_string = match String::from_utf8(lessopen_stdout) {
                         Ok(string) => string,
                         Err(_) => {
@@ -238,7 +238,8 @@ impl LessOpenPreprocessor {
                             .as_ref()
                             .map(|s| shell_substitute_two(s, &path_str, "-")),
                     }
-                },
+                })
+                .take(input.metadata.max_bytes.unwrap_or(u64::MAX)),
             ))?,
             metadata: input.metadata,
             description: input.description,

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -227,6 +227,12 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Read at most this many bytes from each input, before line buffering.
+    pub fn max_bytes(&mut self, limit: u64) -> &mut Self {
+        self.config.max_bytes = Some(limit);
+        self
+    }
+
     /// Specify the lines that should be printed (default: all)
     pub fn line_ranges(&mut self, ranges: LineRanges) -> &mut Self {
         self.config.visible_lines = VisibleLines::Ranges(ranges);
@@ -375,6 +381,12 @@ impl<'a> Input<'a> {
     /// A new input from STDIN.
     pub fn from_stdin() -> Self {
         input::Input::stdin().into()
+    }
+
+    /// Read at most this many bytes from this input before line buffering.
+    pub fn max_bytes(mut self, limit: u64) -> Self {
+        self.input = self.input.with_max_bytes(limit);
+        self
     }
 
     /// The filename of the input.

--- a/tests/input_byte_limit.rs
+++ b/tests/input_byte_limit.rs
@@ -1,0 +1,92 @@
+mod utils;
+use utils::command::bat;
+
+#[test]
+fn limits_apply_before_first_line_buffering_and_can_split_characters() {
+    for (args, expected) in [
+        (vec!["--max-bytes=3"], b"abc".as_slice()),
+        (vec!["--head=0"], b""),
+        (vec!["--max-bytes=99"], b"abcdef"),
+        (vec!["--max-bytes=2", "--max-bytes=4"], b"abcd"),
+    ] {
+        bat()
+            .args(args)
+            .write_stdin("abcdef")
+            .assert()
+            .success()
+            .stdout(expected);
+    }
+    bat()
+        .arg("--max-bytes=1")
+        .write_stdin("é\n")
+        .assert()
+        .success()
+        .stdout(vec![0xc3]);
+}
+
+#[test]
+fn each_file_and_stdin_occurrence_has_its_own_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    for name in ["one", "two"] {
+        std::fs::write(dir.path().join(name), "abcdef").unwrap();
+    }
+    bat()
+        .arg("--max-bytes=2")
+        .arg(dir.path().join("one"))
+        .arg(dir.path().join("two"))
+        .assert()
+        .success()
+        .stdout("abab");
+    bat()
+        .args(["--max-bytes=2", "-", "-"])
+        .write_stdin("abcdef")
+        .assert()
+        .success()
+        .stdout("abcd");
+}
+
+#[test]
+#[cfg(unix)]
+fn a_device_without_newlines_is_bounded() {
+    bat()
+        .args(["--max-bytes=17", "--binary=as-text", "/dev/zero"])
+        .timeout(std::time::Duration::from_secs(5))
+        .assert()
+        .success()
+        .stdout(vec![0; 17]);
+}
+
+#[test]
+fn library_limits_underlying_reader_requests() {
+    struct LimitedSource;
+    impl std::io::Read for LimitedSource {
+        fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+            assert!(output.len() <= 7, "read beyond configured byte limit");
+            output.fill(b'x');
+            Ok(output.len())
+        }
+    }
+    let mut output = String::new();
+    bat::PrettyPrinter::new()
+        .colored_output(false)
+        .input(bat::Input::from_reader(Box::new(LimitedSource)).max_bytes(7))
+        .max_bytes(9)
+        .print_with_writer(Some(&mut output))
+        .unwrap();
+    assert_eq!(output, "xxxxxxx");
+}
+
+#[test]
+#[cfg(all(unix, feature = "lessopen"))]
+fn preprocessor_output_is_limited() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("input.txt");
+    std::fs::write(&path, "abcdef").unwrap();
+    bat()
+        .env("LESSOPEN", "|cat %s")
+        .args(["--lessopen", "--max-bytes=3"])
+        .arg(path)
+        .assert()
+        .success()
+        .stdout("abc");
+}


### PR DESCRIPTION
Line-based reads can wait indefinitely on devices or streams that never produce a newline. Truncating a line after reading it does not address that problem.

Add `--max-bytes N` (alias `--head`) to limit each input before line buffering. Cap underlying file/custom-reader reads, preserve unread stdin data for subsequent `-` inputs, and handle zero and partial-character limits as byte operations. Apply the limit to LESSOPEN output, while documenting that it cannot bound the preprocessor's own reads. Add global and per-input library options; the smaller limit wins.

Fixes #2784.

Validation: five regression tests passed with LESSOPEN enabled, including bounded `/dev/zero` input with a timeout, repeated stdin, separate files, zero/large limits, partial UTF-8 bytes, preprocessor output, and a library reader that rejects oversized read requests. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. Manual, help snapshots, and completions updated. GitHub CI pending.