### PR TITLE
Stream plain output without waiting for newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Stream plain piped output without waiting for a newline, including infinite devices, see #0 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Stream plain piped output without waiting for a newline, including infinite devices, see #0 (@Matei02355)
+- Stream plain piped output without waiting for a newline, including infinite devices, see #3949 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -146,6 +146,19 @@ impl Controller<'_> {
         stdout_identifier: Option<&Identifier>,
         is_first: bool,
     ) -> Result<()> {
+        // Plain byte-for-byte output does not need line or syntax buffering.
+        // In particular, a device or FIFO need not produce a newline to make progress.
+        let raw_stream = self.config.loop_through
+            && matches!(
+                self.config.binary,
+                crate::BinaryBehavior::NoPrinting | crate::BinaryBehavior::AsText
+            )
+            && !self.config.show_nonprintable
+            && self.config.squeeze_lines.is_none()
+            && matches!(&self.config.visible_lines, VisibleLines::Ranges(ranges) if ranges.includes_all_lines())
+            && matches!(writer, OutputHandle::IoWrite(_));
+        let mut input = input;
+        input.metadata.raw_stream = raw_stream;
         let mut opened_input = {
             #[cfg(feature = "lessopen")]
             match self.preprocessor {
@@ -158,6 +171,12 @@ impl Controller<'_> {
             #[cfg(not(feature = "lessopen"))]
             input.open(stdin, stdout_identifier)?
         };
+        if raw_stream {
+            if let OutputHandle::IoWrite(writer) = writer {
+                opened_input.reader.copy_to(*writer)?;
+                return Ok(());
+            }
+        }
         opened_input.reader.unbuffered = self.config.unbuffered;
         #[cfg(feature = "git")]
         let line_changes = if self.config.visible_lines.diff_mode()

--- a/src/input.rs
+++ b/src/input.rs
@@ -91,6 +91,7 @@ impl InputKind<'_> {
 pub(crate) struct InputMetadata {
     pub(crate) user_provided_name: Option<PathBuf>,
     pub(crate) size: Option<u64>,
+    pub(crate) raw_stream: bool,
 }
 
 pub struct Input<'a> {
@@ -195,6 +196,7 @@ impl<'a> Input<'a> {
         stdout_identifier: Option<&Identifier>,
     ) -> Result<OpenedInput<'a>> {
         let description = self.description().clone();
+        let raw_stream = self.metadata.raw_stream;
         match self.kind {
             InputKind::StdIn => {
                 if let Some(stdout) = stdout_identifier {
@@ -209,7 +211,7 @@ impl<'a> Input<'a> {
                     kind: OpenedInputKind::StdIn,
                     description,
                     metadata: self.metadata,
-                    reader: InputReader::try_new(stdin)?,
+                    reader: InputReader::with_raw_stream(stdin, raw_stream)?,
                 })
             }
 
@@ -238,14 +240,14 @@ impl<'a> Input<'a> {
                         file = input_identifier.into_inner().expect("The file was lost in the clircle::Identifier, this should not have happened...");
                     }
 
-                    InputReader::try_new(BufReader::new(file))?
+                    InputReader::with_raw_stream(BufReader::new(file), raw_stream)?
                 },
             }),
             InputKind::CustomReader(reader) => Ok(OpenedInput {
                 description,
                 kind: OpenedInputKind::CustomReader,
                 metadata: self.metadata,
-                reader: InputReader::try_new(BufReader::new(reader))?,
+                reader: InputReader::with_raw_stream(BufReader::new(reader), raw_stream)?,
             }),
         }
     }
@@ -262,6 +264,37 @@ impl<'a> InputReader<'a> {
     #[cfg(test)]
     pub(crate) fn new<R: BufRead + 'a>(reader: R) -> InputReader<'a> {
         Self::try_new(reader).expect("reading the first line failed")
+    }
+
+    pub(crate) fn with_raw_stream<R: BufRead + 'a>(reader: R, raw: bool) -> io::Result<Self> {
+        if raw {
+            Ok(Self {
+                inner: Box::new(reader),
+                first_line: Vec::new(),
+                content_type: None,
+                unbuffered: false,
+            })
+        } else {
+            Self::try_new(reader)
+        }
+    }
+
+    pub(crate) fn copy_to(&mut self, writer: &mut dyn io::Write) -> io::Result<()> {
+        writer.write_all(&self.first_line)?;
+        self.first_line.clear();
+        let mut buffer = [0; 16 * 1024];
+        loop {
+            let count = match self.inner.read(&mut buffer) {
+                Ok(0) => return writer.flush(),
+                Ok(count) => count,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) => return Err(error),
+            };
+            writer.write_all(&buffer[..count])?;
+            // Stdout is line-buffered even when piped. Flush each available
+            // chunk so a short write without a newline is visible immediately.
+            writer.flush()?;
+        }
     }
 
     pub(crate) fn try_new<R: BufRead + 'a>(mut reader: R) -> io::Result<InputReader<'a>> {

--- a/src/lessopen.rs
+++ b/src/lessopen.rs
@@ -202,8 +202,8 @@ impl LessOpenPreprocessor {
 
         Ok(OpenedInput {
             kind,
-            reader: InputReader::try_new(BufReader::new(
-                if matches!(self.kind, LessOpenKind::TempFile) {
+            reader: InputReader::with_raw_stream(
+                BufReader::new(if matches!(self.kind, LessOpenKind::TempFile) {
                     let lessopen_string = match String::from_utf8(lessopen_stdout) {
                         Ok(string) => string,
                         Err(_) => {
@@ -238,8 +238,9 @@ impl LessOpenPreprocessor {
                             .as_ref()
                             .map(|s| shell_substitute_two(s, &path_str, "-")),
                     }
-                },
-            ))?,
+                }),
+                input.metadata.raw_stream,
+            )?,
             metadata: input.metadata,
             description: input.description,
         })

--- a/src/line_range.rs
+++ b/src/line_range.rs
@@ -448,6 +448,15 @@ impl LineRanges {
         }
     }
 
+    pub(crate) fn includes_all_lines(&self) -> bool {
+        self.ranges.iter().any(|range| {
+            matches!(range.lower, RangeBound::Absolute(0 | 1))
+                && matches!(range.upper, RangeBound::Absolute(usize::MAX))
+                && range.is_inside(1, MaxBufferedLineNumber::Tentative(2))
+                && range.is_inside(2, MaxBufferedLineNumber::Tentative(2))
+        })
+    }
+
     pub(crate) fn largest_offset_from_end(&self) -> usize {
         self.largest_offset_from_end
     }

--- a/tests/plain_streaming.rs
+++ b/tests/plain_streaming.rs
@@ -1,0 +1,109 @@
+mod utils;
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+use utils::command::bat;
+
+fn streaming_command() -> Command {
+    let mut command = Command::new(assert_cmd::cargo::cargo_bin!("bat"));
+    command
+        .args([
+            "--no-config",
+            "--paging=never",
+            "--color=never",
+            "--style=plain",
+        ])
+        .env_remove("BAT_OPTS")
+        .env_remove("LESSOPEN")
+        .env_remove("LESSCLOSE")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command
+}
+
+fn read_prefix(
+    stdout: std::process::ChildStdout,
+    length: usize,
+) -> mpsc::Receiver<std::io::Result<Vec<u8>>> {
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut output = vec![0; length];
+        let result = stdout
+            .take(length as u64)
+            .read_exact(&mut output)
+            .map(|_| output);
+        sender.send(result).ok();
+    });
+    receiver
+}
+
+fn wait_or_kill(child: &mut std::process::Child) -> std::process::ExitStatus {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            child.kill().ok();
+            child.wait().ok();
+            panic!("bat did not exit after its output pipe closed");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn short_input_is_visible_before_newline_or_eof() {
+    let mut child = streaming_command().stdin(Stdio::piped()).spawn().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let received = read_prefix(stdout, 5);
+    stdin.write_all(b"ready").unwrap();
+    stdin.flush().unwrap();
+    let result = received.recv_timeout(Duration::from_secs(5));
+    if result.is_err() {
+        child.kill().ok();
+    }
+    drop(stdin);
+    let status = wait_or_kill(&mut child);
+    assert_eq!(result.unwrap().unwrap(), b"ready");
+    assert!(status.success());
+}
+
+#[test]
+#[cfg(unix)]
+fn infinite_binary_input_stops_when_the_output_pipe_closes() {
+    let mut child = streaming_command().arg("/dev/zero").spawn().unwrap();
+    let received = read_prefix(child.stdout.take().unwrap(), 10);
+    let result = received.recv_timeout(Duration::from_secs(5));
+    if result.is_err() {
+        child.kill().ok();
+    }
+    let status = wait_or_kill(&mut child);
+    assert_eq!(result.unwrap().unwrap(), vec![0; 10]);
+    assert!(status.success());
+}
+
+#[test]
+fn byte_content_is_preserved_and_line_options_still_apply() {
+    let input = (0..=255).cycle().take(100_000).collect::<Vec<u8>>();
+    bat()
+        .write_stdin(input.clone())
+        .assert()
+        .success()
+        .stdout(input);
+    bat()
+        .arg("--line-range=2:3")
+        .write_stdin("one\ntwo\nthree\nfour\n")
+        .assert()
+        .success()
+        .stdout("two\nthree\n");
+    bat()
+        .arg("--squeeze-blank")
+        .write_stdin("one\n\n\ntwo\n")
+        .assert()
+        .success()
+        .stdout("one\n\ntwo\n");
+}


### PR DESCRIPTION
Even in plain pipe mode, bat currently reads an entire first line before writing anything. `bat /dev/zero | head -c 10` therefore hangs, and a short FIFO write stays invisible until a newline or EOF.

Use a bounded byte-copy path when output is plain, unfiltered, unsqueezed, and written to an I/O stream. Skip initial line buffering in this path and flush each available chunk. Preserve file/IO-circle checks, raw byte contents, interrupted-read handling, and normal line processing when line-based options are requested. Propagate the mode through LESSOPEN readers.

Fixes #2648.

Validation: three new streaming tests passed, including output before newline/EOF, an infinite device with a closed downstream pipe, 100,000 raw bytes, and line-filter/squeeze behavior. All 261 existing CLI integration tests and all-target/all-feature Clippy with warnings denied passed. Formatting and whitespace checks passed. GitHub CI pending.