### PR TITLE
Add optional file metadata to headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
+- Add header components for absolute paths, modification times, and permissions, see #0 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
 ## Features
-- Add header components for absolute paths, modification times, and permissions, see #0 (@Matei02355)
+- Add header components for absolute paths, modification times, and permissions, see #3950 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "grep-cli",
  "indexmap",
  "itertools",
+ "jiff",
  "minus",
  "nix",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ grep-cli = { version = "0.1.12", optional = true }
 regex = { version = "1.12.3", optional = true }
 walkdir = { version = "2.5", optional = true }
 bytesize = { version = "2.3.1" }
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 encoding_rs = "0.8.35"
 execute = { version = "0.3.0", optional = true }
 terminal-colorsaurus = "1.0"

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -5,7 +5,7 @@ using namespace System.Management.Automation.Language
 Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
-    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
+    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'header-path', 'header-modified', 'header-permissions', 'grid', 'rule', 'numbers', 'snip')
     $ArrayCompletion = @('bash', 'fish', 'zsh', 'ps1')
     $ArrayWhen       = @('auto', 'never', 'always')
     $ArrayYesNo      = @('never', 'always')
@@ -152,7 +152,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
-            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, header-path, header-modified, header-permissions, grid, rule, numbers, snip).')
         #   [CompletionResult]::new('-r'                      , 'r'                     , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
         #   [CompletionResult]::new('-A'                      , 'A'                     , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -176,6 +176,9 @@ _bat() {
 			header
 			header-filename
 			header-filesize
+			header-path
+			header-modified
+			header-permissions
 			grid
 			rule
 			numbers

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -82,6 +82,9 @@ function __bat_style_opts
         "header,alias for header-filename" \
         "header-filename,filename above content" \
         "header-filesize,filesize above content" \
+        "header-path,absolute source path" \
+        "header-modified,modification time in UTC" \
+        "header-permissions,file permissions" \
         "grid,lines b/w sidebar/header/content" \
         "numbers,line numbers in sidebar" \
         "rule,separate files" \

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -56,7 +56,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
-            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+            default auto full plain changes header header-filename header-filesize header-path header-modified header-permissions grid rule numbers snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
         '(* -)'{-L,--list-languages}'[display all supported languages]'
         '(-u --unbuffered)'--unbuffered'[enable unbuffered input reading for streaming use cases]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -242,8 +242,11 @@ replacing them.
 By default, the following components are enabled:
 changes, grid, header\-filename, numbers, snip
 .IP
-Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
-rule, numbers, snip.
+Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, header-path, header-modified, header-permissions, grid,
+rule, numbers, snip. Header path, modification time (UTC), and permissions are
+available as separate fields. The full style includes them; default does not.
+Permissions use Unix mode bits on Unix and a read-only indicator elsewhere.
+Unavailable metadata, such as for standard input, is displayed as a dash.
 .HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...
 .IP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -208,6 +208,9 @@ Options:
             * header: alias for 'header-filename'.
             * header-filename: show filenames before the content.
             * header-filesize: show file sizes before the content.
+            * header-path: show absolute source paths.
+            * header-modified: show modification times in UTC.
+            * header-permissions: show file permissions.
             * grid: vertical/horizontal lines to separate side bar
                     and the header from the content.
             * rule: horizontal lines to delimit files.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -57,7 +57,8 @@ Options:
           Squeeze consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
-          header, header-filename, header-filesize, grid, rule, numbers, snip).
+          header, header-filename, header-filesize, header-path, header-modified,
+          header-permissions, grid, rule, numbers, snip).
   -r, --line-range <N:M>
           Only print the lines from N to M.
   -L, --list-languages

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -534,7 +534,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).",
+                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, header-path, header-modified, header-permissions, grid, rule, numbers, snip).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -561,6 +561,9 @@ pub fn build_app(interactive_output: bool) -> Command {
                      * header: alias for 'header-filename'.\n  \
                      * header-filename: show filenames before the content.\n  \
                      * header-filesize: show file sizes before the content.\n  \
+                     * header-path: show absolute source paths.\n  \
+                     * header-modified: show modification times in UTC.\n  \
+                     * header-permissions: show file permissions.\n  \
                      * grid: vertical/horizontal lines to separate side bar\n          \
                        and the header from the content.\n  \
                      * rule: horizontal lines to delimit files.\n  \

--- a/src/input.rs
+++ b/src/input.rs
@@ -91,6 +91,8 @@ impl InputKind<'_> {
 pub(crate) struct InputMetadata {
     pub(crate) user_provided_name: Option<PathBuf>,
     pub(crate) size: Option<u64>,
+    pub(crate) modified: Option<std::time::SystemTime>,
+    pub(crate) permissions: Option<fs::Permissions>,
 }
 
 pub struct Input<'a> {
@@ -134,8 +136,11 @@ impl<'a> Input<'a> {
 
     fn _ordinary_file(path: &Path) -> Self {
         let kind = InputKind::OrdinaryFile(path.to_path_buf());
+        let file_metadata = fs::metadata(path).ok();
         let metadata = InputMetadata {
-            size: fs::metadata(path).map(|m| m.len()).ok(),
+            size: file_metadata.as_ref().map(|m| m.len()),
+            modified: file_metadata.as_ref().and_then(|m| m.modified().ok()),
+            permissions: file_metadata.as_ref().map(|m| m.permissions()),
             ..InputMetadata::default()
         };
 

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -21,6 +21,9 @@ use crate::paging::PagingMode;
 #[derive(Default)]
 struct ActiveStyleComponents {
     header_filename: bool,
+    header_path: bool,
+    header_modified: bool,
+    header_permissions: bool,
     #[cfg(feature = "git")]
     vcs_modification_markers: bool,
     grid: bool,
@@ -142,6 +145,24 @@ impl<'a> PrettyPrinter<'a> {
     /// Whether to show a header with the file name
     pub fn header(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.header_filename = yes;
+        self
+    }
+
+    /// Whether to show the absolute source path in the header.
+    pub fn header_path(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.header_path = yes;
+        self
+    }
+
+    /// Whether to show the last modification time in UTC.
+    pub fn header_modified(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.header_modified = yes;
+        self
+    }
+
+    /// Whether to show file permissions (Unix mode or a read-only indicator).
+    pub fn header_permissions(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.header_permissions = yes;
         self
     }
 
@@ -313,6 +334,24 @@ impl<'a> PrettyPrinter<'a> {
             self.config
                 .style_components
                 .insert(StyleComponent::HeaderFilename);
+        }
+        for (enabled, component) in [
+            (
+                self.active_style_components.header_path,
+                StyleComponent::HeaderPath,
+            ),
+            (
+                self.active_style_components.header_modified,
+                StyleComponent::HeaderModified,
+            ),
+            (
+                self.active_style_components.header_permissions,
+                StyleComponent::HeaderPermissions,
+            ),
+        ] {
+            if enabled {
+                self.config.style_components.insert(component);
+            }
         }
         if self.active_style_components.line_numbers {
             self.config

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -40,6 +40,51 @@ use crate::wrapping::WrappingMode;
 use crate::BinaryBehavior;
 use crate::StripAnsiMode;
 
+fn format_permissions(permissions: &std::fs::Permissions) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = permissions.mode();
+        let mut chars: Vec<char> = [
+            (0o400, 'r'),
+            (0o200, 'w'),
+            (0o100, 'x'),
+            (0o040, 'r'),
+            (0o020, 'w'),
+            (0o010, 'x'),
+            (0o004, 'r'),
+            (0o002, 'w'),
+            (0o001, 'x'),
+        ]
+        .into_iter()
+        .map(|(bit, ch)| if mode & bit != 0 { ch } else { '-' })
+        .collect();
+        for (bit, index, executable, non_executable) in [
+            (0o4000, 2, 's', 'S'),
+            (0o2000, 5, 's', 'S'),
+            (0o1000, 8, 't', 'T'),
+        ] {
+            if mode & bit != 0 {
+                chars[index] = if chars[index] == 'x' {
+                    executable
+                } else {
+                    non_executable
+                };
+            }
+        }
+        chars.into_iter().collect()
+    }
+    #[cfg(not(unix))]
+    {
+        if permissions.readonly() {
+            "read-only"
+        } else {
+            "read-write"
+        }
+        .to_owned()
+    }
+}
+
 // Return the displayed width of a character.
 //
 // Control characters (0x00..=0x1F and 0x7F) are rendered by the terminal
@@ -534,6 +579,18 @@ impl Printer for InteractivePrinter<'_> {
                 StyleComponent::HeaderFilesize,
                 self.config.style_components.header_filesize(),
             ),
+            (
+                StyleComponent::HeaderPath,
+                self.config.style_components.header_path(),
+            ),
+            (
+                StyleComponent::HeaderModified,
+                self.config.style_components.header_modified(),
+            ),
+            (
+                StyleComponent::HeaderPermissions,
+                self.config.style_components.header_permissions(),
+            ),
         ]
         .iter()
         .filter(|(_, is_enabled)| *is_enabled)
@@ -574,6 +631,49 @@ impl Printer for InteractivePrinter<'_> {
                     let header_filesize =
                         format!("Size: {}", self.colors.header_value.paint(bsize));
                     self.print_header_multiline_component(handle, &header_filesize)
+                }
+                StyleComponent::HeaderPath => {
+                    let path = match &input.kind {
+                        crate::input::OpenedInputKind::OrdinaryFile(path) => {
+                            path_abs::PathAbs::new(path)
+                                .ok()
+                                .map(|path| path.as_path().to_string_lossy().into_owned())
+                        }
+                        _ => None,
+                    }
+                    .unwrap_or_else(|| "-".into());
+                    self.print_header_multiline_component(
+                        handle,
+                        &format!(
+                            "Path: {}",
+                            self.colors.header_value.paint(sanitize_for_terminal(&path))
+                        ),
+                    )
+                }
+                StyleComponent::HeaderModified => {
+                    let modified = metadata
+                        .modified
+                        .and_then(|time| jiff::Timestamp::try_from(time).ok())
+                        .map(|time| time.strftime("%Y-%m-%d %H:%M:%S UTC").to_string())
+                        .unwrap_or_else(|| "-".into());
+                    self.print_header_multiline_component(
+                        handle,
+                        &format!("Modified: {}", self.colors.header_value.paint(modified)),
+                    )
+                }
+                StyleComponent::HeaderPermissions => {
+                    let permissions = metadata
+                        .permissions
+                        .as_ref()
+                        .map(format_permissions)
+                        .unwrap_or_else(|| "-".into());
+                    self.print_header_multiline_component(
+                        handle,
+                        &format!(
+                            "Permissions: {}",
+                            self.colors.header_value.paint(permissions)
+                        ),
+                    )
                 }
                 _ => Ok(()),
             })?;
@@ -1021,5 +1121,22 @@ impl Colors {
             git_modified: Yellow.normal(),
             line_number: gutter_style,
         }
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn permission_display_includes_special_mode_bits() {
+    use std::os::unix::fs::PermissionsExt;
+    for (mode, expected) in [
+        (0o000, "---------"),
+        (0o754, "rwxr-xr--"),
+        (0o4754, "rwsr-xr--"),
+        (0o7640, "rwSr-S--T"),
+    ] {
+        assert_eq!(
+            format_permissions(&std::fs::Permissions::from_mode(mode)),
+            expected
+        );
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -14,6 +14,9 @@ pub enum StyleComponent {
     Header,
     HeaderFilename,
     HeaderFilesize,
+    HeaderPath,
+    HeaderModified,
+    HeaderPermissions,
     LineNumbers,
     Snip,
     Full,
@@ -38,6 +41,9 @@ impl StyleComponent {
             StyleComponent::Header => &[StyleComponent::HeaderFilename],
             StyleComponent::HeaderFilename => &[StyleComponent::HeaderFilename],
             StyleComponent::HeaderFilesize => &[StyleComponent::HeaderFilesize],
+            StyleComponent::HeaderPath => &[StyleComponent::HeaderPath],
+            StyleComponent::HeaderModified => &[StyleComponent::HeaderModified],
+            StyleComponent::HeaderPermissions => &[StyleComponent::HeaderPermissions],
             StyleComponent::LineNumbers => &[StyleComponent::LineNumbers],
             StyleComponent::Snip => &[StyleComponent::Snip],
             StyleComponent::Full => &[
@@ -46,6 +52,9 @@ impl StyleComponent {
                 StyleComponent::Grid,
                 StyleComponent::HeaderFilename,
                 StyleComponent::HeaderFilesize,
+                StyleComponent::HeaderPath,
+                StyleComponent::HeaderModified,
+                StyleComponent::HeaderPermissions,
                 StyleComponent::LineNumbers,
                 StyleComponent::Snip,
             ],
@@ -75,6 +84,9 @@ impl FromStr for StyleComponent {
             "header" => Ok(StyleComponent::Header),
             "header-filename" => Ok(StyleComponent::HeaderFilename),
             "header-filesize" => Ok(StyleComponent::HeaderFilesize),
+            "header-path" => Ok(StyleComponent::HeaderPath),
+            "header-modified" => Ok(StyleComponent::HeaderModified),
+            "header-permissions" => Ok(StyleComponent::HeaderPermissions),
             "numbers" => Ok(StyleComponent::LineNumbers),
             "snip" => Ok(StyleComponent::Snip),
             "full" => Ok(StyleComponent::Full),
@@ -107,7 +119,11 @@ impl StyleComponents {
     }
 
     pub fn header(&self) -> bool {
-        self.header_filename() || self.header_filesize()
+        self.header_filename()
+            || self.header_filesize()
+            || self.header_path()
+            || self.header_modified()
+            || self.header_permissions()
     }
 
     pub fn header_filename(&self) -> bool {
@@ -116,6 +132,18 @@ impl StyleComponents {
 
     pub fn header_filesize(&self) -> bool {
         self.0.contains(&StyleComponent::HeaderFilesize)
+    }
+
+    pub fn header_path(&self) -> bool {
+        self.0.contains(&StyleComponent::HeaderPath)
+    }
+
+    pub fn header_modified(&self) -> bool {
+        self.0.contains(&StyleComponent::HeaderModified)
+    }
+
+    pub fn header_permissions(&self) -> bool {
+        self.0.contains(&StyleComponent::HeaderPermissions)
     }
 
     pub fn numbers(&self) -> bool {

--- a/tests/file_header_details.rs
+++ b/tests/file_header_details.rs
@@ -33,8 +33,17 @@ fn file_details_report_source_path_time_and_permissions() {
         .clone();
     let output = String::from_utf8(output).unwrap();
     assert!(output.contains("File: virtual.json\n"), "{output}");
-    assert!(
-        output.contains(&format!("Path: {}\n", path.display())),
+    let rendered_path = output
+        .lines()
+        .find_map(|line| line.strip_prefix("Path: "))
+        .expect("the header should include the source path");
+    let rendered_path = std::path::Path::new(rendered_path);
+    assert!(rendered_path.is_absolute(), "{output}");
+    // Windows may render an extended-length path prefix. Compare the actual
+    // source files rather than the spelling of their equivalent paths.
+    assert_eq!(
+        rendered_path.canonicalize().unwrap(),
+        path.canonicalize().unwrap(),
         "{output}"
     );
     assert!(

--- a/tests/file_header_details.rs
+++ b/tests/file_header_details.rs
@@ -1,0 +1,85 @@
+mod utils;
+use utils::command::bat;
+
+#[test]
+fn file_details_report_source_path_time_and_permissions() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("example.json");
+    std::fs::write(&path, "{}\n").unwrap();
+    let file = std::fs::File::options().write(true).open(&path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(std::time::UNIX_EPOCH))
+        .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o640))
+            .unwrap();
+    }
+    drop(file);
+    let output = bat()
+        .args([
+            "--style=header-filename,header-path,header-modified,header-permissions",
+            "--decorations=always",
+            "--color=never",
+            "--terminal-width=240",
+            "--file-name=virtual.json",
+            "-r0:0",
+        ])
+        .arg(&path)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.contains("File: virtual.json\n"), "{output}");
+    assert!(
+        output.contains(&format!("Path: {}\n", path.display())),
+        "{output}"
+    );
+    assert!(
+        output.contains("Modified: 1970-01-01 00:00:00 UTC\n"),
+        "{output}"
+    );
+    #[cfg(unix)]
+    assert!(output.contains("Permissions: rw-r-----\n"), "{output}");
+    #[cfg(not(unix))]
+    assert!(output.contains("Permissions: read-write\n"), "{output}");
+}
+
+#[test]
+fn full_style_includes_details_while_default_does_not() {
+    for (style, present) in [("full", true), ("default", false)] {
+        let output = bat()
+            .arg(format!("--style={style}"))
+            .args([
+                "--decorations=always",
+                "--color=never",
+                "--terminal-width=80",
+            ])
+            .write_stdin("input\n")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).unwrap();
+        for field in ["Path: -", "Modified: -", "Permissions: -"] {
+            assert_eq!(output.contains(field), present, "{style}: {output}");
+        }
+    }
+}
+
+#[test]
+fn library_callers_can_select_individual_metadata_fields() {
+    let mut output = String::new();
+    bat::PrettyPrinter::new()
+        .input_from_bytes(b"input\n")
+        .colored_output(false)
+        .header_path(true)
+        .header_modified(true)
+        .header_permissions(true)
+        .print_with_writer(Some(&mut output))
+        .unwrap();
+    assert_eq!(output, "Path: -\nModified: -\nPermissions: -\ninput\n");
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3225,7 +3225,7 @@ fn grid_for_file_without_newline() {
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
-        .arg("--style=full")
+        .arg("--style=full,-header-path,-header-modified,-header-permissions")
         .arg("single-line.txt")
         .assert()
         .success()
@@ -4331,7 +4331,7 @@ fn style_components_can_be_removed() {
         .write_stdin("test")
         .assert()
         .success()
-        .stdout("     STDIN\n     Size: -\n   1 test\n")
+        .stdout("     STDIN\n     Size: -\n     Path: -\n     Modified: -\n     Permissions: -\n   1 test\n")
         .stderr("");
 }
 

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -40,6 +40,7 @@ snapshot_tests! {
     changes_grid_header_numbers: "changes,grid,header,numbers",
     changes_grid_header_rule:    "changes,grid,header,rule",
     changes_grid_header_numbers_rule: "changes,grid,header,numbers,rule",
-    full:                        "full",
+    // Variable file metadata is covered separately in file_header_details.rs.
+    full:                        "full,-header-path,-header-modified,-header-permissions",
     plain:                       "plain",
 }

--- a/tests/snapshots/generate_snapshots.py
+++ b/tests/snapshots/generate_snapshots.py
@@ -20,7 +20,11 @@ def generate_snapshots():
 
 
 def generate_style_snapshot(style):
-    generate_snapshot(style.replace(",", "_"), ["--style={}".format(style)])
+    name = style.replace(",", "_")
+    if style == "full":
+        # Variable file metadata is covered separately in file_header_details.rs.
+        style += ",-header-path,-header-modified,-header-permissions"
+    generate_snapshot(name, ["--style={}".format(style)])
 
 
 def generate_snapshot(name: str, arguments: Iterable[str]):


### PR DESCRIPTION
Add individually selectable `header-path`, `header-modified`, and `header-permissions` style components and corresponding PrettyPrinter setters. `full` includes the new fields; the default style stays unchanged.

Show the actual absolute input path even when a filename hint is supplied, modification time in UTC, and Unix mode bits (including special permissions), or read-only/read-write status on other platforms. Inputs without file metadata show `-`. Reuse the file metadata query already used for file size. Update help, manual, and shell completions.

Fixes #1701.
Fixes #2042.

Validation: three new CLI/library tests, the Unix special-permission unit test, all 261 existing CLI integration tests, and all 27 style snapshots passed. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. The metadata tests use a fixed timestamp and permissions; layout snapshots exclude variable file metadata. GitHub CI pending.