### PR TITLE
Allow overriding global theme colors from the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add global foreground, gutter, and highlighted-line color overrides through `--set-theme-color`, see #0 (@Matei02355)
+- Add global foreground, gutter, and highlighted-line color overrides through `--set-theme-color`, see #3951 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add global foreground, gutter, and highlighted-line color overrides through `--set-theme-color`, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -458,6 +458,17 @@ bat --completion <shell>
 
 ### Highlighting theme
 
+If plain text is too bright with your chosen theme, keep syntax colors while
+using the terminal's normal text color:
+
+```bash
+bat --set-theme-color foreground default file.rs
+```
+
+To use a specific color instead, replace `default` with an RGB value such as
+`a0a0a0`. This controls the theme foreground; it does not change bold attributes.
+
+
 Use `bat --list-themes` to get a list of all available themes for syntax
 highlighting. By default, `bat` uses `Monokai Extended` or `Monokai Extended Light`
 for dark and light themes respectively. To select the `TwoDark` theme, call `bat`

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -149,6 +149,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--pager'                 , 'pager'                 , [CompletionResultType]::ParameterName, 'Determine which pager to use.')
         #   [CompletionResult]::new('-m'                      , 'm'                     , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
             [CompletionResult]::new('--map-syntax'            , 'map-syntax'            , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
+            [CompletionResult]::new('--set-theme-color', 'set-theme-color', [CompletionResultType]::ParameterName, 'Override a global theme color (name RRGGBB).')
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -149,7 +149,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--pager'                 , 'pager'                 , [CompletionResultType]::ParameterName, 'Determine which pager to use.')
         #   [CompletionResult]::new('-m'                      , 'm'                     , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
             [CompletionResult]::new('--map-syntax'            , 'map-syntax'            , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
-            [CompletionResult]::new('--set-theme-color', 'set-theme-color', [CompletionResultType]::ParameterName, 'Override a global theme color (name RRGGBB).')
+            [CompletionResult]::new('--set-theme-color', 'set-theme-color', [CompletionResultType]::ParameterName, 'Override a global theme color (name color).')
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -152,6 +152,10 @@ _bat() {
 		COMPREPLY=($(compgen -c -- "$cur"))
 		return 0
 		;;
+	--set-theme-color)
+		COMPREPLY=($(compgen -W "foreground gutterForeground lineHighlight" -- "$cur"))
+		return 0
+		;;
 	--theme)
 		local IFS=$'\n'
 		COMPREPLY=($(compgen -W "auto${IFS}auto:always${IFS}auto:system${IFS}dark${IFS}light${IFS}$("$1" --no-paging --list-themes)" -- "$cur"))
@@ -220,6 +224,7 @@ _bat() {
 			--map-syntax
 			--ignored-suffix
 			--theme
+			--set-theme-color
 			--theme-dark
 			--theme-light
 			--list-themes

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,5 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -l set-theme-color -x -a "foreground gutterForeground lineHighlight" -d "Override a global theme color (name RRGGBB)" -n __bat_no_excl_args

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -269,4 +269,4 @@ complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_exc
 
 # vim:ft=fish
 
-complete -c $bat -l set-theme-color -x -a "foreground gutterForeground lineHighlight" -d "Override a global theme color (name RRGGBB)" -n __bat_no_excl_args
+complete -c $bat -l set-theme-color -x -a "foreground gutterForeground lineHighlight" -d "Override a global theme color (name color)" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -47,6 +47,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --pager='[determine which pager to use]:command:'
         '(-m --map-syntax)'{-m+,--map-syntax=}'[map a glob pattern to an existing syntax name]: :->syntax-maps'
         --ignored-suffix='[ignore extension]:suffix:'
+        '*--set-theme-color[override a global theme color]:name:(foreground gutterForeground lineHighlight):RGB color:'
         '(--theme)'--theme='[set the color theme for syntax highlighting]:theme:->theme_preferences'
         '(--theme-dark)'--theme-dark='[set the color theme for syntax highlighting for dark backgrounds]:theme:->themes'
         '(--theme-light)'--theme-light='[set the color theme for syntax highlighting for light backgrounds]:theme:->themes'

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -47,7 +47,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --pager='[determine which pager to use]:command:'
         '(-m --map-syntax)'{-m+,--map-syntax=}'[map a glob pattern to an existing syntax name]: :->syntax-maps'
         --ignored-suffix='[ignore extension]:suffix:'
-        '*--set-theme-color[override a global theme color]:name:(foreground gutterForeground lineHighlight):RGB color:'
+        '*--set-theme-color[override a global theme color]:name:(foreground gutterForeground lineHighlight):RGB color or foreground default:'
         '(--theme)'--theme='[set the color theme for syntax highlighting]:theme:->theme_preferences'
         '(--theme-dark)'--theme-dark='[set the color theme for syntax highlighting for dark backgrounds]:theme:->themes'
         '(--theme-light)'--theme-light='[set the color theme for syntax highlighting for light backgrounds]:theme:->themes'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -193,6 +193,16 @@ Use the dark theme specified by \fB-\-theme-dark\fR.
 Use the light theme specified by \fB-\-theme-light\fR.
 .RE
 .HP
+\fB\-\-set\-theme\-color\fR <name> <RRGGBB>
+.IP
+Override a global theme color without rebuilding theme assets. Supported names are
+\fBforeground\fR, \fBgutterForeground\fR, and \fBlineHighlight\fR.
+Colors are six hexadecimal digits, optionally prefixed with \fB#\fR.
+Repeat this option to set several colors; the last value for each name wins.
+For example, \fB\-\-set\-theme\-color lineHighlight 444444\fR changes the
+background of lines selected with \fB\-\-highlight\-line\fR.
+Syntax-specific scope colors remain defined by the theme.
+.HP
 \fB\-\-theme\-dark\fR <theme>
 .IP
 Sets the theme name for syntax highlighting used when the terminal uses a dark background.

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -193,12 +193,14 @@ Use the dark theme specified by \fB-\-theme-dark\fR.
 Use the light theme specified by \fB-\-theme-light\fR.
 .RE
 .HP
-\fB\-\-set\-theme\-color\fR <name> <RRGGBB>
+\fB\-\-set\-theme\-color\fR <name> <color>
 .IP
 Override a global theme color without rebuilding theme assets. Supported names are
 \fBforeground\fR, \fBgutterForeground\fR, and \fBlineHighlight\fR.
 Colors are six hexadecimal digits, optionally prefixed with \fB#\fR.
 Repeat this option to set several colors; the last value for each name wins.
+For foreground and gutterForeground, \fBdefault\fR uses the terminal's normal
+text color while retaining syntax colors.
 For example, \fB\-\-set\-theme\-color lineHighlight 444444\fR changes the
 background of lines selected with \fB\-\-highlight\-line\fR.
 Syntax-specific scope colors remain defined by the theme.

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -148,6 +148,12 @@ Options:
             * dark: Use the dark theme specified by '--theme-dark'.
             * light: Use the light theme specified by '--theme-light'.
 
+      --set-theme-color <name> <RRGGBB>
+          Override a global theme color without rebuilding theme assets. Supported names:
+          foreground, gutterForeground, lineHighlight. Colors are six hexadecimal digits (RRGGBB or
+          '#RRGGBB'). Repeat this option to set multiple colors; the last value for a name wins. For
+          example: --set-theme-color lineHighlight 444444.
+
       --theme-light <theme>
           Sets the theme name for syntax highlighting used when the terminal uses a light
           background. Use '--list-themes' to see all available themes. To set a default theme, add

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -148,11 +148,12 @@ Options:
             * dark: Use the dark theme specified by '--theme-dark'.
             * light: Use the light theme specified by '--theme-light'.
 
-      --set-theme-color <name> <RRGGBB>
+      --set-theme-color <name> <color>
           Override a global theme color without rebuilding theme assets. Supported names:
           foreground, gutterForeground, lineHighlight. Colors are six hexadecimal digits (RRGGBB or
-          '#RRGGBB'). Repeat this option to set multiple colors; the last value for a name wins. For
-          example: --set-theme-color lineHighlight 444444.
+          '#RRGGBB'); foreground and gutterForeground also accept 'default' to use the terminal's
+          normal text color. Repeat this option to set multiple colors; the last value for a name
+          wins. For example: --set-theme-color lineHighlight 444444.
 
       --theme-light <theme>
           Sets the theme name for syntax highlighting used when the terminal uses a light

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -47,6 +47,8 @@ Options:
           Use the specified syntax for files matching the glob pattern ('*.cpp:C++').
       --theme <theme>
           Set the color theme for syntax highlighting.
+      --set-theme-color <name> <RRGGBB>
+          Override a global theme color.
       --theme-light <theme>
           Sets the color theme for syntax highlighting used for light backgrounds.
       --theme-dark <theme>

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -47,7 +47,7 @@ Options:
           Use the specified syntax for files matching the glob pattern ('*.cpp:C++').
       --theme <theme>
           Set the color theme for syntax highlighting.
-      --set-theme-color <name> <RRGGBB>
+      --set-theme-color <name> <color>
           Override a global theme color.
       --theme-light <theme>
           Sets the color theme for syntax highlighting used for light backgrounds.

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -99,18 +99,12 @@ impl App {
                 _ => interactive_output, // auto: use color if interactive
             };
 
-            let pager = matches.get_one::<String>("pager").map(|s| s.as_str());
-            let theme_options = Self::theme_options_from_matches(&matches);
-            let use_custom_assets = !matches.get_flag("no-custom-assets");
-
             Self::display_help(
                 interactive_output,
                 help_type,
                 use_pager,
                 use_color,
-                pager,
-                theme_options,
-                use_custom_assets,
+                &matches,
             )?;
             std::process::exit(0);
         }
@@ -128,9 +122,7 @@ impl App {
         help_type: HelpType,
         use_pager: bool,
         use_color: bool,
-        pager: Option<&str>,
-        theme_options: ThemeOptions,
-        use_custom_assets: bool,
+        matches: &ArgMatches,
     ) -> Result<()> {
         use crate::assets::assets_from_cache_or_binary;
         use crate::directories::PROJECT_DIRS;
@@ -160,16 +152,17 @@ impl App {
         let help_config = Config {
             style_components: StyleComponents::new(StyleComponent::Plain.components(false)),
             paging_mode,
-            pager,
+            pager: matches.get_one::<String>("pager").map(|s| s.as_str()),
             colored_output: use_color,
             true_color: use_color,
             language: if use_color { Some("help") } else { None },
-            theme: theme(theme_options).to_string(),
+            theme: theme(Self::theme_options_from_matches(matches)).to_string(),
+            theme_colors: Self::theme_colors_from_matches(matches)?,
             ..Default::default()
         };
 
         let cache_dir = PROJECT_DIRS.cache_dir();
-        let assets = assets_from_cache_or_binary(use_custom_assets, cache_dir)?;
+        let assets = assets_from_cache_or_binary(!matches.get_flag("no-custom-assets"), cache_dir)?;
         Controller::new(&help_config, &assets)
             .run(inputs, None)
             .ok();
@@ -484,6 +477,7 @@ impl App {
             number_nonblank: self.matches.get_flag("number-nonblank")
                 || self.number_nonblank_from_cli,
             theme: theme(self.theme_options()).to_string(),
+            theme_colors: Self::theme_colors_from_matches(&self.matches)?,
             visible_lines: match self.matches.try_contains_id("diff").unwrap_or_default()
                 && self.matches.get_flag("diff")
             {
@@ -667,6 +661,16 @@ impl App {
 
     pub(crate) fn theme_options(&self) -> ThemeOptions {
         Self::theme_options_from_matches(&self.matches)
+    }
+
+    fn theme_colors_from_matches(matches: &ArgMatches) -> Result<bat::theme::ThemeColorOverrides> {
+        let mut colors = bat::theme::ThemeColorOverrides::default();
+        if let Some(mut values) = matches.get_many::<String>("set-theme-color") {
+            while let (Some(name), Some(value)) = (values.next(), values.next()) {
+                colors.set(name, value)?;
+            }
+        }
+        Ok(colors)
     }
 
     fn theme_options_from_matches(matches: &ArgMatches) -> ThemeOptions {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -445,12 +445,13 @@ pub fn build_app(interactive_output: bool) -> Command {
             Arg::new("set-theme-color")
                 .long("set-theme-color")
                 .num_args(2)
-                .value_names(["name", "RRGGBB"])
+                .value_names(["name", "color"])
                 .action(ArgAction::Append)
                 .help("Override a global theme color.")
                 .long_help("Override a global theme color without rebuilding theme assets. Supported names: \
                     foreground, gutterForeground, lineHighlight. Colors are six hexadecimal digits \
-                    (RRGGBB or '#RRGGBB'). Repeat this option to set multiple colors; the last value \
+                    (RRGGBB or '#RRGGBB'); foreground and gutterForeground also accept 'default' \
+                    to use the terminal's normal text color. Repeat this option to set multiple colors; the last value \
                     for a name wins. For example: --set-theme-color lineHighlight 444444."),
         )
         .arg(

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -442,6 +442,18 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("set-theme-color")
+                .long("set-theme-color")
+                .num_args(2)
+                .value_names(["name", "RRGGBB"])
+                .action(ArgAction::Append)
+                .help("Override a global theme color.")
+                .long_help("Override a global theme color without rebuilding theme assets. Supported names: \
+                    foreground, gutterForeground, lineHighlight. Colors are six hexadecimal digits \
+                    (RRGGBB or '#RRGGBB'). Repeat this option to set multiple colors; the last value \
+                    for a name wins. For example: --set-theme-color lineHighlight 444444."),
+        )
+        .arg(
             Arg::new("theme-light")
                 .long("theme-light")
                 .overrides_with("theme-light")

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,9 @@ pub struct Config<'a> {
     /// The syntax highlighting theme
     pub theme: String,
 
+    /// Overrides for global foreground, gutter, and highlighted-line colors.
+    pub theme_colors: crate::theme::ThemeColorOverrides,
+
     /// File extension/name mappings
     pub syntax_mapping: SyntaxMapping<'a>,
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -22,15 +22,24 @@ use clircle::{Clircle, Identifier};
 pub struct Controller<'a> {
     config: &'a Config<'a>,
     assets: &'a HighlightingAssets,
+    custom_theme: Option<syntect::highlighting::Theme>,
     #[cfg(feature = "lessopen")]
     preprocessor: Option<LessOpenPreprocessor>,
 }
 
 impl Controller<'_> {
     pub fn new<'a>(config: &'a Config, assets: &'a HighlightingAssets) -> Controller<'a> {
+        let custom_theme = if config.theme_colors.is_empty() {
+            None
+        } else {
+            let mut theme = assets.get_theme(&config.theme).clone();
+            config.theme_colors.apply(&mut theme);
+            Some(theme)
+        };
         Controller {
             config,
             assets,
+            custom_theme,
             #[cfg(feature = "lessopen")]
             preprocessor: LessOpenPreprocessor::new().ok(),
         }
@@ -195,6 +204,7 @@ impl Controller<'_> {
             Box::new(InteractivePrinter::new(
                 self.config,
                 self.assets,
+                self.custom_theme.as_ref(),
                 &mut opened_input,
                 #[cfg(feature = "git")]
                 &line_changes,

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -263,6 +263,15 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Override a global theme color without modifying the underlying theme.
+    ///
+    /// Supported names are `foreground`, `gutterForeground`, and `lineHighlight`.
+    /// The value is six hexadecimal digits, optionally prefixed with `#`.
+    pub fn set_theme_color(&mut self, name: &str, value: &str) -> Result<&mut Self> {
+        self.config.theme_colors.set(name, value)?;
+        Ok(self)
+    }
+
     /// Specify custom file extension / file name to syntax mappings
     pub fn syntax_mapping(&mut self, mapping: SyntaxMapping<'a>) -> &mut Self {
         self.config.syntax_mapping = mapping;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -219,12 +219,16 @@ impl<'a> InteractivePrinter<'a> {
     pub(crate) fn new(
         config: &'a Config,
         assets: &'a HighlightingAssets,
+        custom_theme: Option<&'a Theme>,
         input: &mut OpenedInput,
         #[cfg(feature = "git")] line_changes: &'a Option<LineChanges>,
     ) -> Result<Self> {
-        let theme = assets.get_theme(&config.theme);
+        let theme = custom_theme.unwrap_or_else(|| assets.get_theme(&config.theme));
 
-        let background_color_highlight = theme.settings.line_highlight;
+        let background_color_highlight = theme
+            .settings
+            .line_highlight
+            .filter(|_| config.colored_output);
 
         let colors = if config.colored_output {
             Colors::colored(theme, config.true_color)

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,6 +5,68 @@ use std::fmt;
 use std::io::IsTerminal as _;
 use std::str::FromStr;
 
+/// Overrides for the global theme colors used by the terminal renderer.
+///
+/// Syntax-specific scope colors are left unchanged. Repeated assignments to the
+/// same setting use the last value.
+#[derive(Debug, Clone, Default)]
+pub struct ThemeColorOverrides {
+    foreground: Option<syntect::highlighting::Color>,
+    gutter_foreground: Option<syntect::highlighting::Color>,
+    line_highlight: Option<syntect::highlighting::Color>,
+}
+
+impl ThemeColorOverrides {
+    /// Set `foreground`, `gutterForeground`, or `lineHighlight` to an opaque RGB
+    /// color written as six hexadecimal digits, optionally prefixed with `#`.
+    pub fn set(&mut self, name: &str, value: &str) -> crate::error::Result<()> {
+        let target = match name {
+            "foreground" => &mut self.foreground,
+            "gutterForeground" => &mut self.gutter_foreground,
+            "lineHighlight" => &mut self.line_highlight,
+            _ => return Err(format!(
+                "unknown theme color '{name}'; expected foreground, gutterForeground, or lineHighlight"
+            ).into()),
+        };
+        let hex = value.strip_prefix('#').unwrap_or(value);
+        if hex.len() != 6 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(format!(
+                "invalid theme color '{value}'; expected six hexadecimal digits (RRGGBB)"
+            )
+            .into());
+        }
+        let rgb = u32::from_str_radix(hex, 16)?;
+        *target = Some(syntect::highlighting::Color {
+            r: (rgb >> 16) as u8,
+            g: (rgb >> 8) as u8,
+            b: rgb as u8,
+            a: 255,
+        });
+        Ok(())
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.foreground.is_none()
+            && self.gutter_foreground.is_none()
+            && self.line_highlight.is_none()
+    }
+
+    pub(crate) fn apply(&self, theme: &mut syntect::highlighting::Theme) {
+        for (target, value) in [
+            (&mut theme.settings.foreground, self.foreground),
+            (
+                &mut theme.settings.gutter_foreground,
+                self.gutter_foreground,
+            ),
+            (&mut theme.settings.line_highlight, self.line_highlight),
+        ] {
+            if value.is_some() {
+                *target = value;
+            }
+        }
+    }
+}
+
 /// Environment variable names.
 pub mod env {
     /// See [`crate::theme::ThemeOptions::theme`].

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -19,6 +19,7 @@ pub struct ThemeColorOverrides {
 impl ThemeColorOverrides {
     /// Set `foreground`, `gutterForeground`, or `lineHighlight` to an opaque RGB
     /// color written as six hexadecimal digits, optionally prefixed with `#`.
+    /// Foreground and gutter foreground also accept `default` for the terminal color.
     pub fn set(&mut self, name: &str, value: &str) -> crate::error::Result<()> {
         let target = match name {
             "foreground" => &mut self.foreground,
@@ -28,6 +29,15 @@ impl ThemeColorOverrides {
                 "unknown theme color '{name}'; expected foreground, gutterForeground, or lineHighlight"
             ).into()),
         };
+        if value == "default" && name != "lineHighlight" {
+            *target = Some(syntect::highlighting::Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 1,
+            });
+            return Ok(());
+        }
         let hex = value.strip_prefix('#').unwrap_or(value);
         if hex.len() != 6 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
             return Err(format!(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3247,7 +3247,7 @@ fn grid_for_file_without_newline() {
 fn ansi_highlight_underline() {
     bat()
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3476,7 +3476,7 @@ fn theme_arg_overrides_env() {
     bat()
         .env("BAT_THEME", "TwoDark")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3496,7 +3496,7 @@ fn theme_arg_overrides_env_withconfig() {
         .env("BAT_CONFIG_PATH", "bat-theme.conf")
         .env("BAT_THEME", "TwoDark")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3517,7 +3517,7 @@ fn theme_light_env_var_is_respected() {
         .env("COLORTERM", "truecolor")
         .arg("--theme=light")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3526,7 +3526,7 @@ fn theme_light_env_var_is_respected() {
         .write_stdin("Lorem Ipsum")
         .assert()
         .success()
-        .stdout("\x1B[48;2;208;218;231mLorem Ipsum\x1B[0m")
+        .stdout("\x1B[48;2;208;218;231;38;2;17;27;39mLorem Ipsum\x1B[0m")
         .stderr("");
 }
 
@@ -3537,7 +3537,7 @@ fn theme_dark_env_var_is_respected() {
         .env("COLORTERM", "truecolor")
         .arg("--theme=dark")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")
@@ -3546,7 +3546,7 @@ fn theme_dark_env_var_is_respected() {
         .write_stdin("Lorem Ipsum")
         .assert()
         .success()
-        .stdout("\x1B[48;2;33;48;67mLorem Ipsum\x1B[0m")
+        .stdout("\x1B[48;2;33;48;67;38;2;227;234;242mLorem Ipsum\x1B[0m")
         .stderr("");
 }
 
@@ -3556,7 +3556,7 @@ fn theme_env_overrides_config() {
         .env("BAT_CONFIG_PATH", "bat-theme.conf")
         .env("BAT_THEME", "ansi")
         .arg("--paging=never")
-        .arg("--color=never")
+        .arg("--color=always")
         .arg("--terminal-width=80")
         .arg("--wrap=never")
         .arg("--decorations=always")

--- a/tests/theme_color_overrides.rs
+++ b/tests/theme_color_overrides.rs
@@ -166,3 +166,53 @@ fn help_output_uses_overridden_foreground() {
     let output = String::from_utf8(output).unwrap();
     assert!(output.contains("38;2;18;52;86m"), "{output:?}");
 }
+
+#[test]
+fn terminal_default_foreground_keeps_plain_text_uncolored_and_syntax_colored() {
+    for name in ["foreground", "gutterForeground"] {
+        let mut overrides = bat::theme::ThemeColorOverrides::default();
+        overrides.set(name, "default").unwrap();
+    }
+    for earlier in ["123456", "default"] {
+        bat()
+            .args([
+                "--theme=Monokai Extended",
+                "--style=plain",
+                "--color=always",
+                "--language=txt",
+                "--set-theme-color",
+                "foreground",
+                earlier,
+                "--set-theme-color",
+                "foreground",
+                "default",
+            ])
+            .write_stdin("ordinary text\n")
+            .assert()
+            .success()
+            .stdout("ordinary text\n");
+    }
+    let output = bat()
+        .env("COLORTERM", "truecolor")
+        .args([
+            "--theme=Monokai Extended",
+            "--style=plain",
+            "--color=always",
+            "--language=Rust",
+            "--set-theme-color",
+            "foreground",
+            "default",
+        ])
+        .write_stdin("fn main() {}\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.contains("\x1b[38;2;"), "{output:?}");
+    assert!(!output.contains("38;2;248;248;242m"), "{output:?}");
+    assert!(bat::theme::ThemeColorOverrides::default()
+        .set("lineHighlight", "default")
+        .is_err());
+}

--- a/tests/theme_color_overrides.rs
+++ b/tests/theme_color_overrides.rs
@@ -1,0 +1,168 @@
+mod utils;
+use utils::command::bat;
+
+#[test]
+fn foreground_and_gutter_colors_are_independent() {
+    let output = bat()
+        .env("COLORTERM", "truecolor")
+        .args([
+            "--theme=Monokai Extended",
+            "--style=numbers",
+            "--decorations=always",
+            "--color=always",
+            "--language=txt",
+            "--set-theme-color",
+            "foreground",
+            "#123456",
+            "--set-theme-color",
+            "gutterForeground",
+            "abcdef",
+        ])
+        .write_stdin("example\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.contains("38;2;18;52;86mexample"), "{output:?}");
+    assert!(output.contains("38;2;171;205;239m"), "{output:?}");
+}
+
+#[test]
+fn line_highlight_override_respects_color_mode() {
+    for (color, expected) in [("always", true), ("never", false)] {
+        let output = bat()
+            .env("COLORTERM", "truecolor")
+            .args([
+                "--theme=Monokai Extended",
+                "--style=plain",
+                "--language=txt",
+                "--terminal-width=20",
+                "--highlight-line=1",
+                "--color",
+                color,
+                "--set-theme-color",
+                "lineHighlight",
+                "102030",
+            ])
+            .write_stdin("selected\nother\n")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).unwrap();
+        assert_eq!(output.contains("48;2;16;32;48m"), expected, "{output:?}");
+        if !expected {
+            assert_eq!(output, "selected\nother\n");
+        }
+    }
+}
+
+#[test]
+fn cli_overrides_config_colors_and_last_assignment_wins() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config");
+    std::fs::write(
+        &config,
+        "--set-theme-color foreground 010203\n--set-theme-color gutterForeground 040506\n",
+    )
+    .unwrap();
+    let output = utils::command::bat_with_config()
+        .env("BAT_CONFIG_PATH", &config)
+        .env("COLORTERM", "truecolor")
+        .args([
+            "--style=numbers",
+            "--decorations=always",
+            "--theme=Monokai Extended",
+            "--color=always",
+            "--language=txt",
+            "--set-theme-color",
+            "foreground",
+            "070809",
+            "--set-theme-color",
+            "foreground",
+            "0a0b0c",
+        ])
+        .write_stdin("example\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.contains("38;2;10;11;12mexample"), "{output:?}");
+    assert!(output.contains("38;2;4;5;6m"), "{output:?}");
+    assert!(!output.contains("38;2;7;8;9m"));
+}
+
+#[test]
+fn invalid_colors_and_missing_values_fail_before_content() {
+    for values in [
+        vec!["unknown", "123456"],
+        vec!["foreground", "abcd"],
+        vec!["lineHighlight", "xx1122"],
+        vec!["foreground", "ééé"],
+        vec!["foreground"],
+    ] {
+        bat()
+            .arg("--set-theme-color")
+            .args(values)
+            .write_stdin("private content\n")
+            .assert()
+            .failure()
+            .stdout("");
+    }
+}
+
+#[test]
+fn library_overrides_do_not_mutate_shared_assets() {
+    use bat::{
+        assets::HighlightingAssets, config::Config, controller::Controller, input::Input,
+        output::OutputHandle,
+    };
+    let assets = HighlightingAssets::from_binary();
+    let name = "Monokai Extended";
+    let before = assets.get_theme(name).settings.foreground;
+    let mut config = Config {
+        theme: name.into(),
+        colored_output: true,
+        true_color: true,
+        ..Default::default()
+    };
+    config.theme_colors.set("foreground", "123456").unwrap();
+    let controller = Controller::new(&config, &assets);
+    let mut output = String::new();
+    assert!(controller
+        .run(
+            vec![Input::from_reader(Box::new(&b"example\n"[..]))],
+            Some(&mut OutputHandle::FmtWrite(&mut output))
+        )
+        .unwrap());
+    assert!(output.contains("38;2;18;52;86mexample"), "{output:?}");
+    assert_eq!(assets.get_theme(name).settings.foreground, before);
+    assert!(bat::PrettyPrinter::new()
+        .set_theme_color("lineHighlight", "ffffff")
+        .is_ok());
+}
+
+#[test]
+fn help_output_uses_overridden_foreground() {
+    let output = bat()
+        .args([
+            "--color=always",
+            "--theme=Monokai Extended",
+            "--set-theme-color",
+            "foreground",
+            "123456",
+            "--help",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.contains("38;2;18;52;86m"), "{output:?}");
+}


### PR DESCRIPTION
Add the proposed `--set-theme-color <name> <RRGGBB>` option for `foreground`, `gutterForeground`, and `lineHighlight`, plus a PrettyPrinter setter. Repeat assignments to configure several colors; the last assignment for each name wins, including CLI overrides of config-file settings.

Validate names and RGB values before printing content. Clone the selected theme only when overrides are present, leaving cached/shared themes unchanged. Apply overrides to help output too. Respect `--color=never` for highlighted-line backgrounds. Update the manual, help snapshots, and completions.

Fixes #339.
Fixes #2764.

Validation: all six new regression tests and all 261 existing CLI integration tests passed. All-target/all-feature Clippy with warnings denied, formatting, whitespace, Bash syntax, and rendered Zsh syntax checks passed. Tests cover separate gutter/foreground colors, line highlighting, disabled colors, config/CLI precedence, malformed values, shared-asset isolation, and help output. GitHub CI pending.

Also fixes #3287: foreground and gutterForeground accept `default`, using the terminal's normal text color while keeping syntax colors. Seven color-override regressions, 261 integration tests and all-target/all-feature Clippy passed; README, manual, help and completions updated.