### PR TITLE
Add compact file headings with selected sidebars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--decorations=compact` for compact file headings while retaining selected line numbers and sidebars, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--decorations=compact` for compact file headings while retaining selected line numbers and sidebars, see #0 (@Matei02355)
+- Add `--decorations=compact` for compact file headings while retaining selected line numbers and sidebars, see #3952 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -93,6 +93,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         '*;--decorations' {
             $ArrayWhen |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            [CompletionResult]::new('compact', 'compact', [CompletionResultType]::ParameterValue, 'Compact headings with selected sidebars.')
             break
         }
         '*;--completion' {
@@ -144,7 +145,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--terminal-width'        , 'terminal-width'        , [CompletionResultType]::ParameterName, 'Explicitly set the width of the terminal instead of determining it automatically. If prefixed with ''+'' or ''-'', the value will be treated as an offset to the actual terminal width. See also: ''--wrap''.')
             [CompletionResult]::new('--color'                 , 'color'                 , [CompletionResultType]::ParameterName, 'When to use colors (*auto*, never, always).')
             [CompletionResult]::new('--italic-text'           , 'italic-text'           , [CompletionResultType]::ParameterName, 'Use italics in output (always, *never*)')
-            [CompletionResult]::new('--decorations'           , 'decorations'           , [CompletionResultType]::ParameterName, 'When to show the decorations (*auto*, never, always).')
+            [CompletionResult]::new('--decorations'           , 'decorations'           , [CompletionResultType]::ParameterName, 'When to show the decorations (*auto*, never, always, compact).')
             [CompletionResult]::new('--paging'                , 'paging'                , [CompletionResultType]::ParameterName, 'Specify when to use the pager, or use ''-P'' to disable (*auto*, never, always).')
             [CompletionResult]::new('--pager'                 , 'pager'                 , [CompletionResultType]::ParameterName, 'Determine which pager to use.')
         #   [CompletionResult]::new('-m'                      , 'm'                     , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -140,7 +140,11 @@ _bat() {
 		COMPREPLY=($(compgen -W "bash fish zsh ps1" -- "$cur"))
 		return 0
 		;;
-	--color | --decorations | --paging)
+	--decorations)
+		COMPREPLY=($(compgen -W "auto never always compact" -- "$cur"))
+		return 0
+		;;
+	--color | --paging)
 		COMPREPLY=($(compgen -W "auto never always" -- "$cur"))
 		return 0
 		;;

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -97,7 +97,7 @@ set -l color_opts '
     never\t
     always\t
 '
-set -l decorations_opts $color_opts
+set -l decorations_opts $color_opts 'compact\tCompact\ file\ headings'
 set -l paging_opts $color_opts
 
 # Include some examples so we can indicate the default.

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -40,7 +40,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         '(-n --number --diff --diff-context)'{-n,--number}'[show line numbers]'
         --color='[specify when to use colors]:when:(auto never always)'
         --italic-text='[use italics in output]:when:(always never)'
-        --decorations='[specify when to show the decorations]:when:(auto never always)'
+        --decorations='[specify when and how to show the decorations]:when:(auto never always compact)'
         '(-f --force-colorization)'--force-colorization'[force colorization and decorations]'
         --paging='[specify when to use the pager]:when:(auto never always)'
         '(-P --no-paging)'--no-paging'[alias for --paging=never]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -137,6 +137,11 @@ Specify when to use the decorations that have been specified via '\-\-style'. Th
 automatic mode only enables decorations if an interactive terminal is detected. The
 always mode will show decorations even when piping output. Possible
 values: *auto*, never, always.
+
+The \fBcompact\fR mode always enables selected decorations, uses single-line
+\fB===> filename <===\fR headings, and omits horizontal rules around files.
+Selected line numbers, change markers, and the vertical grid remain visible.
+Long headings are left to the terminal to wrap.
 .HP
 \fB\-f\fR, \fB\-\-force\-colorization\fR
 .IP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -106,7 +106,9 @@ Options:
       --decorations <when>
           Specify when to use the decorations that have been specified via '--style'. The automatic
           mode only enables decorations if an interactive terminal is detected. The always mode will
-          show decorations even when piping output. Possible values: *auto*, never, always.
+          show decorations even when piping output. The compact mode always shows the selected
+          decorations, uses single-line file headings, and omits horizontal rules around files.
+          Possible values: *auto*, never, always, compact.
 
   -f, --force-colorization
           Alias for '--decorations=always --color=always'. This is useful if the output of bat is

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -40,7 +40,7 @@ Options:
       --italic-text <when>
           Use italics in output (always, *never*)
       --decorations <when>
-          When to show the decorations (*auto*, never, always).
+          When to show the decorations (*auto*, never, always, compact).
       --paging <when>
           Specify when to use the pager, or use `-P` to disable (*auto*, never, always).
   -m, --map-syntax <glob:syntax>

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -433,11 +433,12 @@ impl App {
             term_width: maybe_term_width.unwrap_or(Term::stdout().size().1 as usize),
             loop_through: !(self.interactive_output
                 || self.matches.get_one::<String>("color").map(|s| s.as_str()) == Some("always")
-                || self
-                    .matches
-                    .get_one::<String>("decorations")
-                    .map(|s| s.as_str())
-                    == Some("always")
+                || matches!(
+                    self.matches
+                        .get_one::<String>("decorations")
+                        .map(String::as_str),
+                    Some("always" | "compact")
+                )
                 || self.matches.get_flag("force-colorization")
                 || self.number_from_cli
                 || self.number_nonblank_from_cli),
@@ -505,6 +506,11 @@ impl App {
                 ),
             },
             style_components,
+            compact_headers: self
+                .matches
+                .get_one::<String>("decorations")
+                .map(String::as_str)
+                == Some("compact"),
             syntax_mapping,
             pager: self.matches.get_one::<String>("pager").map(|s| s.as_str()),
             use_italic_text: self

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -329,15 +329,16 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long("decorations")
                 .overrides_with("decorations")
                 .value_name("when")
-                .value_parser(["auto", "never", "always"])
+                .value_parser(["auto", "never", "always", "compact"])
                 .default_value("auto")
                 .hide_default_value(true)
-                .help("When to show the decorations (*auto*, never, always).")
+                .help("When to show the decorations (*auto*, never, always, compact).")
                 .long_help(
                     "Specify when to use the decorations that have been specified \
                     via '--style'. The automatic mode only enables decorations if \
                     an interactive terminal is detected. The always mode will show \
-                    decorations even when piping output. Possible values: *auto*, never, always.",
+                    decorations even when piping output. The compact mode always shows the selected decorations, uses single-line \
+                    file headings, and omits horizontal rules around files. Possible values: *auto*, never, always, compact.",
                 )
         )
         .arg(

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,9 @@ pub struct Config<'a> {
     /// Style elements (grid, line numbers, ...)
     pub style_components: StyleComponents,
 
+    /// Use single-line file headings and omit horizontal header/footer rules.
+    pub compact_headers: bool,
+
     /// If and how text should be wrapped
     pub wrapping_mode: WrappingMode,
 

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -139,6 +139,13 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Use compact file headings without horizontal header/footer rules.
+    /// Selected line numbers, change markers, and the vertical grid remain visible.
+    pub fn compact_headers(&mut self, yes: bool) -> &mut Self {
+        self.config.compact_headers = yes;
+        self
+    }
+
     /// Whether to show a header with the file name
     pub fn header(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.header_filename = yes;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -354,6 +354,9 @@ impl<'a> InteractivePrinter<'a> {
         handle: &mut OutputHandle,
         style: Style,
     ) -> Result<()> {
+        if self.config.compact_headers {
+            return Ok(());
+        }
         writeln!(
             handle,
             "{}",
@@ -363,6 +366,9 @@ impl<'a> InteractivePrinter<'a> {
     }
 
     fn print_horizontal_line(&mut self, handle: &mut OutputHandle, grid_char: char) -> Result<()> {
+        if self.config.compact_headers {
+            return Ok(());
+        }
         if self.panel_width == 0 {
             self.print_horizontal_line_term(handle, self.colors.grid)?;
         } else {
@@ -428,6 +434,9 @@ impl<'a> InteractivePrinter<'a> {
         handle: &mut OutputHandle,
         content: &str,
     ) -> Result<()> {
+        if self.config.compact_headers {
+            return writeln!(handle, "{content}");
+        }
         let content_width = self.config.term_width - self.get_header_component_indent_length();
         if content.chars().count() <= content_width {
             return self.print_header_component_with_indent(handle, content);
@@ -545,7 +554,10 @@ impl Printer for InteractivePrinter<'_> {
             self.print_horizontal_line(handle, '┬')?;
         } else {
             // Only pad space between files, if we haven't already drawn a horizontal rule
-            if add_header_padding && !self.config.style_components.rule() {
+            if add_header_padding
+                && !self.config.style_components.rule()
+                && !self.config.compact_headers
+            {
                 writeln!(handle)?;
             }
         }
@@ -554,16 +566,25 @@ impl Printer for InteractivePrinter<'_> {
             .iter()
             .try_for_each(|component| match component {
                 StyleComponent::HeaderFilename => {
-                    let header_filename = format!(
-                        "{}{}{mode}",
-                        description
-                            .kind()
-                            .map(|kind| format!("{}: ", sanitize_for_terminal(kind)))
-                            .unwrap_or_else(|| "".into()),
-                        self.colors
-                            .header_value
-                            .paint(sanitize_for_terminal(description.title())),
-                    );
+                    let header_filename = if self.config.compact_headers {
+                        format!(
+                            "===> {}{mode} <===",
+                            self.colors
+                                .header_value
+                                .paint(sanitize_for_terminal(description.title()))
+                        )
+                    } else {
+                        format!(
+                            "{}{}{mode}",
+                            description
+                                .kind()
+                                .map(|kind| format!("{}: ", sanitize_for_terminal(kind)))
+                                .unwrap_or_else(|| "".into()),
+                            self.colors
+                                .header_value
+                                .paint(sanitize_for_terminal(description.title())),
+                        )
+                    };
                     self.print_header_multiline_component(handle, &header_filename)
                 }
                 StyleComponent::HeaderFilesize => {

--- a/tests/compact_headings.rs
+++ b/tests/compact_headings.rs
@@ -1,0 +1,99 @@
+mod utils;
+use utils::command::bat;
+
+#[test]
+fn compact_mode_retains_numbers_and_vertical_grid_without_header_rules() {
+    bat()
+        .args([
+            "--color=never",
+            "--paging=never",
+            "--terminal-width=80",
+            "--decorations=compact",
+        ])
+        .write_stdin("first\nsecond\n")
+        .assert()
+        .success()
+        .stdout("===> STDIN <===\n   1 │ first\n   2 │ second\n");
+}
+
+#[test]
+fn compact_multiple_files_have_one_heading_each_and_keep_sizes_if_selected() {
+    bat().args(["--color=never", "--paging=never", "--decorations=compact", "--style=header,header-filesize", "single-line.txt", "single-line.txt"])
+        .assert().success().stdout("===> single-line.txt <===\nSize: 11 B\nSingle Line\n===> single-line.txt <===\nSize: 11 B\nSingle Line\n");
+}
+
+#[test]
+fn compact_mode_respects_plain_and_number_only_styles() {
+    for (style, expected) in [("plain", "text\n"), ("numbers", "   1 text\n")] {
+        bat()
+            .args([
+                "--color=never",
+                "--paging=never",
+                "--decorations=compact",
+                "--style",
+                style,
+            ])
+            .write_stdin("text\n")
+            .assert()
+            .success()
+            .stdout(expected);
+    }
+}
+
+#[test]
+fn compact_mode_preserves_binary_and_empty_metadata() {
+    bat()
+        .args(["--color=never", "--paging=never", "--decorations=compact"])
+        .write_stdin("\0binary")
+        .assert()
+        .success()
+        .stdout("===> STDIN   <BINARY> <===\n");
+    bat()
+        .args(["--color=never", "--paging=never", "--decorations=compact"])
+        .write_stdin("")
+        .assert()
+        .success()
+        .stdout("===> STDIN   <EMPTY> <===\n");
+    bat()
+        .args([
+            "--color=never",
+            "--paging=never",
+            "--decorations=compact",
+            "--quiet-empty",
+        ])
+        .write_stdin("")
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn compact_headings_sanitize_names_and_work_in_narrow_output() {
+    bat()
+        .args([
+            "--color=never",
+            "--paging=never",
+            "--decorations=compact",
+            "--file-name=long\u{1b}[31mname.txt",
+            "--terminal-width=1",
+        ])
+        .write_stdin("xy\n")
+        .assert()
+        .success()
+        .stdout("===> long^[[31mname.txt <===\nx\ny\n");
+}
+
+#[test]
+fn library_supports_compact_headings() {
+    let mut output = String::new();
+    bat::PrettyPrinter::new()
+        .input_from_bytes(b"text\n")
+        .header(true)
+        .line_numbers(true)
+        .grid(true)
+        .compact_headers(true)
+        .colored_output(false)
+        .print_with_writer(Some(&mut output))
+        .unwrap();
+    assert_eq!(output, "===> READER <===\n   1 │ text\n");
+}


### PR DESCRIPTION
Add `--decorations=compact` and `PrettyPrinter::compact_headers`. Compact mode always enables the selected decorations, prints `===> filename <===` headings, and omits horizontal header/footer rules. Keep line numbers, Git markers, the vertical grid, requested metadata fields, and line wrapping for content.

Respect plain/number-only styles, binary/empty indicators, quiet-empty mode, and filename sanitization. Long headings remain a single output line for the terminal to wrap. Update help, manual, and completions.

Fixes #3303.

Validation: all six new regression tests, all 261 existing CLI integration tests, and all 27 style snapshots passed. All-target/all-feature Clippy with warnings denied, formatting, whitespace, Bash syntax, and rendered Zsh syntax checks passed. GitHub CI pending.