### PR TITLE
Recognize OPF metadata and MDWN Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Detect EPUB `.opf` metadata as XML and Ikiwiki `.mdwn` pages as Markdown, see #0 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Detect EPUB `.opf` metadata as XML and Ikiwiki `.mdwn` pages as Markdown, see #0 (@Matei02355)
+- Detect EPUB `.opf` metadata as XML and Ikiwiki `.mdwn` pages as Markdown, see #3953 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -527,6 +527,19 @@ mod tests {
     }
 
     #[test]
+    fn detect_epub_package_and_ikiwiki_markdown_extensions() {
+        let test = SyntaxDetectionTest::new();
+        for (filename, expected) in [
+            ("book.opf", "XML"),
+            ("BOOK.OPF", "XML"),
+            ("page.mdwn", "Markdown"),
+            ("PAGE.MDWN", "Markdown"),
+        ] {
+            assert_eq!(test.syntax_for_file(filename), expected, "{filename}");
+        }
+    }
+
+    #[test]
     fn syntax_detection_basic() {
         let test = SyntaxDetectionTest::new();
 

--- a/src/syntax_mapping/builtins/common/50-epub.toml
+++ b/src/syntax_mapping/builtins/common/50-epub.toml
@@ -1,0 +1,3 @@
+# EPUB package metadata is XML, including files without an XML declaration.
+[mappings]
+"XML" = ["*.opf"]

--- a/src/syntax_mapping/builtins/common/50-markdown.toml
+++ b/src/syntax_mapping/builtins/common/50-markdown.toml
@@ -1,2 +1,2 @@
 [mappings]
-"Markdown" = ["*.mkd"]
+"Markdown" = ["*.mkd", "*.mdwn"]


### PR DESCRIPTION
Extend built-in mappings so EPUB `.opf` files use XML highlighting even without an XML declaration, and Ikiwiki `.mdwn` pages use Markdown. The mappings follow the existing case-insensitive convention and are included in the supported-language listing.

Fixes #2422.
Fixes #2259.

Validation: all 15 asset/syntax-detection tests passed, including the new lowercase/uppercase filename regressions and existing mapping precedence checks. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. No generated syntax assets are changed. GitHub CI pending.