### PR TITLE
Honor XDG config and cache directory overrides on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Honor absolute `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` overrides on Windows while preserving bat-specific overrides and native defaults, see #0 (@Matei02355)
+- Honor absolute `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` overrides on Windows while preserving bat-specific overrides and native defaults, see #3954 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Honor absolute `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` overrides on Windows while preserving bat-specific overrides and native defaults, see #0 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/README.md
+++ b/README.md
@@ -760,6 +760,13 @@ export BAT_CONFIG_PATH="/path/to/bat/bat.conf"
 export BAT_CONFIG_DIR="/path/to/bat"
 ```
 
+On every platform, including Windows, absolute `XDG_CONFIG_HOME` and `XDG_CACHE_HOME`
+values select `<XDG_CONFIG_HOME>/bat` and `<XDG_CACHE_HOME>/bat`. The bat-specific
+`BAT_CONFIG_DIR` and `BAT_CACHE_PATH` overrides take precedence. Empty or relative
+XDG paths are ignored. Without these overrides, Windows uses its native application
+data folders. For MSYS2 or Git Bash, use a Windows path such as `C:/msys64/home/me/.config`
+for `XDG_CONFIG_HOME`.
+
 A default configuration file can be created with the `--generate-config-file` option.
 ```bash
 bat --generate-config-file

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -323,6 +323,12 @@ is dependent on your operating system. To get the default path for your system, 
 Alternatively, you can use the BAT_CONFIG_PATH environment variable to point {{PROJECT_EXECUTABLE}} to a non-default
 location of the configuration file.
 
+On all platforms, including Windows, absolute \fBXDG_CONFIG_HOME\fR and
+\fBXDG_CACHE_HOME\fR values select the configuration and cache base directories,
+with a \fBbat\fR subdirectory appended. \fBBAT_CONFIG_DIR\fR and
+\fBBAT_CACHE_PATH\fR take precedence. Empty and relative XDG values are ignored;
+Windows otherwise uses its native application data directories.
+.PP
 To generate a default configuration file, call:
 
 \fB{{PROJECT_EXECUTABLE}} --generate-config-file\fR

--- a/src/bin/bat/directories.rs
+++ b/src/bin/bat/directories.rs
@@ -5,7 +5,7 @@ use etcetera::BaseStrategy;
 use once_cell::sync::Lazy;
 
 /// Wrapper for 'etcetera' that checks BAT_CACHE_PATH and BAT_CONFIG_DIR and falls back to the
-/// Windows known folder locations on Windows & the XDG Base Directory Specification everywhere else.
+/// XDG overrides on every platform, then native Windows folders or the XDG defaults.
 pub struct BatProjectDirs {
     cache_dir: PathBuf,
     config_dir: PathBuf,
@@ -15,22 +15,15 @@ impl BatProjectDirs {
     fn new() -> Option<BatProjectDirs> {
         let basedirs = etcetera::choose_base_strategy().ok()?;
 
-        // Checks whether or not `$BAT_CACHE_PATH` exists. If it doesn't, set the cache dir to our
-        // system's default cache home.
-        let cache_dir = if let Some(cache_dir) = env::var_os("BAT_CACHE_PATH").map(PathBuf::from) {
-            cache_dir
-        } else {
-            basedirs.cache_dir().join("bat")
-        };
+        let cache_dir = env::var_os("BAT_CACHE_PATH")
+            .map(PathBuf::from)
+            .or_else(|| xdg_home("XDG_CACHE_HOME").map(|path| path.join("bat")))
+            .unwrap_or_else(|| basedirs.cache_dir().join("bat"));
 
-        // Checks whether or not `$BAT_CONFIG_DIR` exists. If it doesn't, set the config dir to our
-        // system's default configuration home.
-        let config_dir = if let Some(config_dir) = env::var_os("BAT_CONFIG_DIR").map(PathBuf::from)
-        {
-            config_dir
-        } else {
-            basedirs.config_dir().join("bat")
-        };
+        let config_dir = env::var_os("BAT_CONFIG_DIR")
+            .map(PathBuf::from)
+            .or_else(|| xdg_home("XDG_CONFIG_HOME").map(|path| path.join("bat")))
+            .unwrap_or_else(|| basedirs.config_dir().join("bat"));
 
         Some(BatProjectDirs {
             cache_dir,
@@ -45,6 +38,13 @@ impl BatProjectDirs {
     pub fn config_dir(&self) -> &Path {
         &self.config_dir
     }
+}
+
+// XDG requires absolute paths; empty and relative values are ignored.
+fn xdg_home(name: &str) -> Option<PathBuf> {
+    env::var_os(name)
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
 }
 
 pub static PROJECT_DIRS: Lazy<BatProjectDirs> =

--- a/tests/xdg_directories.rs
+++ b/tests/xdg_directories.rs
@@ -1,0 +1,87 @@
+mod utils;
+use utils::command::{bat, bat_with_config};
+
+#[test]
+fn xdg_directories_are_used_for_paths_and_configuration() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_home = dir.path().join("config home");
+    let cache_home = dir.path().join("cache home");
+    std::fs::create_dir_all(config_home.join("bat")).unwrap();
+    std::fs::write(
+        config_home.join("bat/config"),
+        "--style=numbers\n--decorations=always\n--color=never\n",
+    )
+    .unwrap();
+    for (flag, expected) in [
+        ("--config-dir", config_home.join("bat")),
+        ("--cache-dir", cache_home.join("bat")),
+    ] {
+        bat()
+            .env("XDG_CONFIG_HOME", &config_home)
+            .env("XDG_CACHE_HOME", &cache_home)
+            .arg(flag)
+            .assert()
+            .success()
+            .stdout(format!("{}\n", expected.display()));
+    }
+    bat_with_config()
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_CACHE_HOME", &cache_home)
+        .write_stdin("configured\n")
+        .assert()
+        .success()
+        .stdout("   1 configured\n");
+}
+
+#[test]
+fn bat_directory_and_file_overrides_take_precedence() {
+    let dir = tempfile::tempdir().unwrap();
+    let explicit = dir.path().join("explicit");
+    for (flag, variable) in [
+        ("--config-dir", "BAT_CONFIG_DIR"),
+        ("--cache-dir", "BAT_CACHE_PATH"),
+    ] {
+        bat()
+            .env("XDG_CONFIG_HOME", dir.path().join("xdg"))
+            .env("XDG_CACHE_HOME", dir.path().join("xdg"))
+            .env(variable, &explicit)
+            .arg(flag)
+            .assert()
+            .success()
+            .stdout(format!("{}\n", explicit.display()));
+    }
+    let file = dir.path().join("chosen.conf");
+    bat()
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env("BAT_CONFIG_DIR", &explicit)
+        .env("BAT_CONFIG_PATH", &file)
+        .arg("--config-file")
+        .assert()
+        .success()
+        .stdout(format!("{}\n", file.display()));
+}
+
+#[test]
+fn empty_and_relative_xdg_paths_fall_back_to_native_defaults() {
+    for (flag, variable) in [
+        ("--config-dir", "XDG_CONFIG_HOME"),
+        ("--cache-dir", "XDG_CACHE_HOME"),
+    ] {
+        let expected = bat()
+            .env_remove(variable)
+            .arg(flag)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        for value in ["", "relative/path"] {
+            bat()
+                .env(variable, value)
+                .arg(flag)
+                .assert()
+                .success()
+                .stdout(expected.clone());
+        }
+    }
+}


### PR DESCRIPTION
Check `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` before the platform defaults on every platform. Keep `BAT_CONFIG_DIR` and `BAT_CACHE_PATH` highest priority, and keep native Windows application-data folders when no valid override is set. Ignore empty/relative XDG values, as required by the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/).

Document precedence and Windows path examples for MSYS2/Git Bash. Add cross-platform process tests that exercise actual configuration loading, both directory queries, bat-specific overrides, and invalid-value fallback.

Fixes #3000.
Fixes #3854.

Validation: all three new integration tests passed on Linux, covering the shared directory-selection code. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. Windows execution is left to the repository's Windows CI jobs; that platform has not been tested locally. GitHub CI pending.