### PR TITLE
Show merged configuration arguments and individual fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--show-config [field]` to inspect merged configuration arguments, see #0 (@Matei02355)
+- Add `--show-config [field]` to inspect merged configuration arguments, see #3955 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--show-config [field]` to inspect merged configuration arguments, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -769,6 +769,13 @@ There is also now a systemwide configuration file, which is located under `/etc/
 Linux and Mac OS and `C:\ProgramData\bat\config` on windows. If the system wide configuration
 file is present, the content of the user configuration will simply be appended to it.
 
+To inspect the merged configuration arguments from config files, environment
+variables, and the command line, run `bat --show-config`. Query one field with
+`bat --show-config theme` (or `bat --config theme`). Repeated options are listed
+in order, and automatic modes remain as configured. The full listing omits
+parser defaults; a single-field query includes its parser default when available.
+An unset field produces no output.
+
 ### Format
 
 The configuration file is a simple list of command line arguments. Use `bat --help` to see a full list of possible options and values. In addition, you can add comments by prepending a line with the `#` character.

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -185,6 +185,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--no-custom-assets'      , 'no-custom-assets'      , [CompletionResultType]::ParameterName, 'Do not load custom assets')
             [CompletionResult]::new('--lessopen'              , 'lessopen'              , [CompletionResultType]::ParameterName, 'Enable the $LESSOPEN preprocessor')
             [CompletionResult]::new('--no-lessopen'           , 'no-lessopen'           , [CompletionResultType]::ParameterName, 'Disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)')
+            [CompletionResult]::new('--show-config', 'show-config', [CompletionResultType]::ParameterName, 'Show merged configuration arguments.')
             [CompletionResult]::new('--config-file'           , 'config-file'           , [CompletionResultType]::ParameterName, 'Show path to the configuration file.')
             [CompletionResult]::new('--generate-config-file'  , 'generate-config-file'  , [CompletionResultType]::ParameterName, 'Generates a default configuration file.')
             [CompletionResult]::new('--config-dir'            , 'config-dir'            , [CompletionResultType]::ParameterName, 'Show bat''s configuration directory.')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -240,6 +240,7 @@ _bat() {
 			--version
 			--cache-dir
 			--config-dir
+			--show-config
 			--config-file
 			--generate-config-file
 			--no-config

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,5 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -l show-config -f -d "Show merged configuration arguments" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -70,6 +70,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         '(--no-lessopen)'--lessopen'[enable the $LESSOPEN preprocessor]'
         '(--lessopen)'--no-lessopen'[disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)]'
         '(* -)'--config-dir"[show bat's configuration directory]"
+        '(* -)'--show-config'[show merged configuration arguments]::field:'
         '(* -)'--config-file'[show path to the configuration file]'
         '(* -)'--generate-config-file'[generate a default configuration file]'
         '(* -)'--cache-dir"[show bat's cache directory]"

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -329,6 +329,16 @@ To generate a default configuration file, call:
 
 These are related options:
 .HP
+\fB\-\-show\-config\fR [field]
+.IP
+Show merged configuration arguments from system/user config files, environment
+variables, and the command line. The full listing is alphabetical and omits
+parser defaults. A field query prints its values without a label, including its
+parser default if present; an unset field produces no output. Repeatable values
+retain their order and automatic modes remain unresolved. The alias
+\fB\-\-config\fR is also accepted. This operation does not read input files,
+load theme assets, or start a pager.
+.HP
 \fB\-\-config\-file\fR
 .IP
 Show path to the configuration file.

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -238,6 +238,14 @@ Options:
       --completion <SHELL>
           Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]
 
+      --show-config [<field>]
+          Show configured argument values after merging system/user config files, environment
+          variables, and command-line arguments. List configured fields in alphabetical order,
+          omitting parser defaults. With a field name (for example, --show-config theme), print its
+          values without a label, including its parser default if present. An unset field produces
+          no output. Repeatable values retain their order and automatic modes remain unresolved.
+          This does not read input files, load assets, probe terminal colors, or start a pager.
+
       --diagnostic
           Show diagnostic information for bug reports.
 

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -66,6 +66,8 @@ Options:
           Enable unbuffered input reading for streaming use cases.
       --completion <SHELL>
           Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]
+      --show-config [<field>]
+          Show merged configuration arguments, optionally for one field.
   -E, --quiet-empty
           Produce no output when the input is empty.
   -h, --help

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -537,6 +537,69 @@ impl App {
         })
     }
 
+    /// Display argument values after config files, environment, and CLI parsing.
+    /// Keep automatic modes and ordered repeatable values as configured.
+    pub fn show_config(&self, field: &str) -> Result<String> {
+        use clap::parser::ValueSource;
+        use std::fmt::Write as _;
+        let app = clap_app::build_app(self.interactive_output);
+        let excluded = [
+            "help",
+            "version",
+            "show-config",
+            "no-config",
+            "completion",
+            "diagnostic",
+            "list-languages",
+            "list-themes",
+            "config-file",
+            "generate-config-file",
+            "config-dir",
+            "cache-dir",
+            "acknowledgements",
+        ];
+        let mut fields = app
+            .get_arguments()
+            .filter_map(|arg| arg.get_long().map(|name| (name, arg.get_id().as_str())))
+            .filter(|(_, id)| !excluded.contains(id))
+            .collect::<Vec<_>>();
+        fields.sort_unstable();
+        let mut output = String::new();
+        if field != "*" {
+            let id = fields
+                .iter()
+                .find(|(name, _)| *name == field)
+                .map(|(_, id)| *id)
+                .ok_or_else(|| format!("unknown configuration field '{field}'"))?;
+            if let Some(values) = self.matches.get_raw(id) {
+                for value in values {
+                    writeln!(
+                        output,
+                        "{}",
+                        bat::sanitize_for_terminal(&value.to_string_lossy())
+                    )?;
+                }
+            }
+            return Ok(output);
+        }
+        for (name, id) in fields {
+            // Hide parser defaults when listing the user's configured values.
+            if self.matches.value_source(id) == Some(ValueSource::DefaultValue) {
+                continue;
+            }
+            if let Some(values) = self.matches.get_raw(id) {
+                for value in values {
+                    writeln!(
+                        output,
+                        "{name}: {}",
+                        bat::sanitize_for_terminal(&value.to_string_lossy())
+                    )?;
+                }
+            }
+        }
+        Ok(output)
+    }
+
     pub fn inputs(&self) -> Result<Vec<Input<'_>>> {
         let filenames: Option<Vec<&Path>> = self
             .matches

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -662,6 +662,25 @@ pub fn build_app(interactive_output: bool) -> Command {
 
     app = app
         .arg(
+            Arg::new("show-config")
+                .long("show-config")
+                .alias("config")
+                .overrides_with("show-config")
+                .num_args(0..=1)
+                .default_missing_value("*")
+                .value_name("field")
+                .conflicts_with_all(["FILE", "list-languages", "list-themes", "config-file",
+                    "generate-config-file", "config-dir", "cache-dir", "acknowledgements", "diagnostic"])
+                .help("Show merged configuration arguments, optionally for one field.")
+                .long_help("Show configured argument values after merging system/user config files, \
+                    environment variables, and command-line arguments. List configured fields in \
+                    alphabetical order, omitting parser defaults. With a field name (for example, \
+                    --show-config theme), print its values without a label, including its parser \
+                    default if present. An unset field produces no output. Repeatable values retain \
+                    their order and automatic modes remain unresolved. This does not read input \
+                    files, load assets, probe terminal colors, or start a pager."),
+        )
+        .arg(
             Arg::new("config-file")
                 .long("config-file")
                 .action(ArgAction::SetTrue)

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -377,6 +377,13 @@ fn invoke_bugreport(app: &App, cache_dir: &Path) {
 /// `Ok(false)` if any intermediate errors occurred (were printed).
 fn run() -> Result<bool> {
     let app = App::new()?;
+    if let Some(field) = app.matches.get_one::<String>("show-config") {
+        if app.matches.subcommand().is_some() {
+            return Err("--show-config cannot be combined with a subcommand".into());
+        }
+        write!(io::stdout(), "{}", app.show_config(field)?)?;
+        return Ok(true);
+    }
     let config_dir = PROJECT_DIRS.config_dir();
     let cache_dir = PROJECT_DIRS.cache_dir();
 

--- a/tests/show_config.rs
+++ b/tests/show_config.rs
@@ -1,0 +1,97 @@
+mod utils;
+use utils::command::{bat, bat_with_config};
+
+#[test]
+fn configuration_query_merges_config_environment_and_cli() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("config");
+    std::fs::write(
+        &config,
+        "--theme=TwoDark\n--italic-text=always\n--wrap=never\n",
+    )
+    .unwrap();
+    for (extra, expected) in [(vec![], "ansi\n"), (vec!["--theme=GitHub"], "GitHub\n")] {
+        bat_with_config()
+            .env("BAT_CONFIG_PATH", &config)
+            .env("BAT_THEME", "ansi")
+            .args(extra)
+            .args(["--show-config", "theme"])
+            .assert()
+            .success()
+            .stdout(expected);
+    }
+    bat_with_config()
+        .env("BAT_CONFIG_PATH", &config)
+        .env("BAT_THEME", "ansi")
+        .arg("--show-config")
+        .assert()
+        .success()
+        .stdout("italic-text: always\ntheme: ansi\nwrap: never\n");
+}
+
+#[test]
+fn repeatable_values_keep_order_and_automatic_modes_are_not_resolved() {
+    bat()
+        .args([
+            "--show-config",
+            "map-syntax",
+            "--map-syntax=*.x:XML",
+            "--map-syntax=*.y:JSON",
+        ])
+        .assert()
+        .success()
+        .stdout("*.x:XML\n*.y:JSON\n");
+    bat()
+        .args(["--config", "theme", "--theme=auto:always"])
+        .assert()
+        .success()
+        .stdout("auto:always\n");
+    bat()
+        .args(["--show-config", "color"])
+        .assert()
+        .success()
+        .stdout("auto\n");
+    bat()
+        .args(["--show-config", "language"])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn configuration_query_does_not_load_assets_or_start_pager() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("metadata.yaml"),
+        "this is not cache metadata",
+    )
+    .unwrap();
+    bat()
+        .env("BAT_CACHE_PATH", dir.path())
+        .env("BAT_PAGER", "nonexistent-pager-for-config-test")
+        .args(["--paging=always", "--show-config", "pager"])
+        .assert()
+        .success()
+        .stdout("nonexistent-pager-for-config-test\n");
+}
+
+#[test]
+fn query_rejects_unknown_fields_and_conflicting_operations() {
+    for args in [
+        vec!["--show-config=unknown"],
+        vec!["--show-config", "--list-languages"],
+        vec!["--show-config=theme", "nonexistent-file"],
+        vec!["--show-config=theme", "cache", "--build"],
+    ] {
+        bat().args(args).assert().failure().stdout("");
+    }
+}
+
+#[test]
+fn query_escapes_terminal_controls_in_values() {
+    bat()
+        .args(["--show-config=pager", "--pager=less\u{1b}[31m\n"])
+        .assert()
+        .success()
+        .stdout("less^[[31m^J\n");
+}


### PR DESCRIPTION
Add `--show-config [field]`, also available as `--config [field]`, to inspect argument values after system/user config files, environment variables, and CLI parsing.

List explicitly configured fields alphabetically, with repeatable values in their original order. A field query prints values without labels and includes a parser default when available. Automatic modes remain as configured; this is a configuration view, not a dump of terminal-dependent runtime state. Escape terminal controls and reject conflicting file/operation arguments. Queries do not read input, load assets, probe terminal colors, or start a pager.

Fixes #2507.

Validation: five new regression tests and all 261 existing CLI integration tests passed. Tests cover config/environment/CLI precedence, ordered mappings, defaults/unset fields, aliases, malformed fields, conflicting operations, invalid asset metadata, pager isolation, and terminal controls. All-target/all-feature Clippy with warnings denied, formatting, whitespace, Bash syntax, and rendered Zsh syntax checks passed. GitHub CI pending.