### PR TITLE
Detect redirected stdin filenames on Linux and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Detect syntax from a regular file redirected to stdin on Linux and Android, see #0 (@Matei02355)
+- Detect syntax from a regular file redirected to stdin on Linux and Android, see #3959 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Detect syntax from a regular file redirected to stdin on Linux and Android, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -65,13 +65,22 @@ Display multiple files at once
 bat src/*.rs
 ```
 
-Read from stdin, determine the syntax automatically (note, highlighting will
-only work if the syntax can be determined from the first line of the file,
-usually through a shebang such as `#!/bin/sh`)
+Read from stdin and determine the syntax from the first line, usually through
+a shebang such as `#!/bin/sh`:
 
 ```bash
 curl -s https://sh.rustup.rs | bat
 ```
+
+On Linux and Android, redirecting a regular file into stdin also uses that
+file's path for syntax detection when procfs is available:
+
+```bash
+bat < README.md
+```
+
+An explicit `--file-name` or `--language` takes precedence. If the path cannot
+be recovered, detection falls back to the input's first line.
 
 Read from stdin, specify the language explicitly
 

--- a/src/bin/bat/input.rs
+++ b/src/bin/bat/input.rs
@@ -6,7 +6,27 @@ pub fn new_file_input<'a>(file: &'a Path, name: Option<&'a Path>) -> Input<'a> {
 }
 
 pub fn new_stdin_input(name: Option<&Path>) -> Input<'_> {
-    named(Input::stdin(), name)
+    let detected_name = if name.is_none() { stdin_path() } else { None };
+    named(Input::stdin(), name.or(detected_name.as_deref()))
+}
+
+/// Recover a filename hint without opening or reading the redirected file.
+/// The input remains stdin, so its current offset and IO-circle checks are preserved.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn stdin_path() -> Option<std::path::PathBuf> {
+    let descriptor = Path::new("/proc/self/fd/0");
+    if !descriptor.metadata().ok()?.is_file() {
+        return None;
+    }
+
+    // canonicalize also rejects deleted files and anonymous descriptors whose
+    // procfs link target is a descriptive label rather than an existing path.
+    std::fs::canonicalize(descriptor).ok()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn stdin_path() -> Option<std::path::PathBuf> {
+    None
 }
 
 fn named<'a>(input: Input<'a>, name: Option<&Path>) -> Input<'a> {

--- a/tests/redirected_stdin.rs
+++ b/tests/redirected_stdin.rs
@@ -1,0 +1,110 @@
+#![cfg(any(target_os = "linux", target_os = "android"))]
+
+mod utils;
+
+use std::fs::File;
+use std::io::{Seek, SeekFrom};
+use std::process::Stdio;
+use utils::command::{bat, bat_raw_command};
+
+const OPTIONS: &[&str] = &[
+    "--style=plain",
+    "--color=always",
+    "--theme=Monokai Extended",
+    "--paging=never",
+];
+const JSON: &str = "{\"message\": \"hello\", \"count\": 42}\n";
+
+fn redirected(file: File, args: &[&str]) -> std::process::Output {
+    bat_raw_command()
+        .args(OPTIONS)
+        .args(args)
+        .stdin(Stdio::from(file))
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn redirected_file_is_detected_without_consuming_or_reopening_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("input.json");
+    std::fs::write(&path, format!("skip!\n{JSON}")).unwrap();
+    let mut file = File::open(&path).unwrap();
+    file.seek(SeekFrom::Start(6)).unwrap();
+    let actual = redirected(file, &[]);
+    let expected = bat()
+        .args(OPTIONS)
+        .args(["--language=json"])
+        .write_stdin(JSON)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(actual.status.success());
+    assert!(actual.stderr.is_empty());
+    assert_eq!(actual.stdout, expected);
+}
+
+#[test]
+fn explicit_filename_and_language_take_precedence() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("input.json");
+    std::fs::write(&path, JSON).unwrap();
+    for args in [["--file-name=input.txt"], ["--language=txt"]] {
+        let actual = redirected(File::open(&path).unwrap(), &args);
+        let expected = bat()
+            .args(OPTIONS)
+            .args(["--language=txt"])
+            .write_stdin(JSON)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        assert!(actual.status.success());
+        assert_eq!(actual.stdout, expected);
+    }
+}
+
+#[test]
+fn redirected_stdin_still_obeys_mappings_and_explicit_dash_inputs() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("input.custom");
+    std::fs::write(&path, JSON).unwrap();
+    let actual = redirected(
+        File::open(&path).unwrap(),
+        &["--map-syntax=*.custom:JSON", "-", "-"],
+    );
+    let expected = bat()
+        .args(OPTIONS)
+        .args(["--language=json"])
+        .write_stdin(JSON)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(actual.status.success());
+    assert_eq!(actual.stdout, expected);
+}
+
+#[test]
+fn pipes_and_deleted_files_keep_the_stdin_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("input.json");
+    std::fs::write(&path, JSON).unwrap();
+    let file = File::open(&path).unwrap();
+    std::fs::remove_file(&path).unwrap();
+    let actual = redirected(file, &[]);
+    let expected = bat()
+        .args(OPTIONS)
+        .write_stdin(JSON)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(actual.status.success());
+    assert_eq!(actual.stdout, expected);
+}


### PR DESCRIPTION
`bat < file.json` currently loses the filename that would normally select JSON highlighting.

Recover the regular-file path through procfs on Linux and Android and use it as a filename hint. Preserve the original stdin reader and offset, custom mappings, repeated `-` inputs, and IO-circle detection. Explicit filename and language options take precedence; unavailable paths, pipes, and deleted files use the existing fallback.

Implements #2652 on Linux and Android. Platform support is documented in the README.

Validation: four new process tests and all 261 existing integration tests passed. Tests cover a file redirected from a nonzero offset, explicit overrides, custom mappings, repeated stdin, pipes, and deleted files. All-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed.