### PR TITLE
Support per-syntax decoration styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--style-for <language> <style>` and a library setter for per-syntax decorations, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--style-for <language> <style>` and a library setter for per-syntax decorations, see #0 (@Matei02355)
+- Add `--style-for <language> <style>` and a library setter for per-syntax decorations, see #3960 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -24,6 +24,19 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
     }
 
     $commandElements = $commandAst.CommandElements
+    $previous = @($commandElements | Where-Object { $_.Extent.EndOffset -lt $cursorPosition })
+    if ($previous.Count -ge 2 -and $previous[-1] -is [StringConstantExpressionAst] -and $previous[-1].Value -eq '--style-for') {
+        Get-MyLanguages | Where-Object { $_.MyParameter -like "$wordToComplete*" } |
+        ForEach-Object {
+            [CompletionResult]::new(("'" + $_.MyParameter + "'"), $_.MyParameter, [CompletionResultType]::ParameterValue, 'Syntax name')
+        }
+        return
+    }
+    if ($previous.Count -ge 3 -and $previous[-2] -is [StringConstantExpressionAst] -and $previous[-2].Value -eq '--style-for') {
+        $ArrayStyle | Where-Object { $_ -like "$wordToComplete*" } |
+        ForEach-Object { [CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_) }
+        return
+    }
     $command = @(
         '{{PROJECT_EXECUTABLE}}'
         for ($i = 1; $i -lt $commandElements.Count; $i++) {
@@ -152,6 +165,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
+            [CompletionResult]::new('--style-for', 'style-for', [CompletionResultType]::ParameterName, 'Select decorations for a syntax (language, then style).')
             [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
         #   [CompletionResult]::new('-r'                      , 'r'                     , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -76,8 +76,14 @@ _bat() {
 		return 0
 	fi
 
+	if (( cword >= 2 )) && [[ ${words[cword-2]} == --style-for ]]; then
+		prev=--style
+	elif [[ $prev == --style-for=* ]]; then
+		prev=--style
+	fi
+
 	case $prev in
-	-l | --language)
+	-l | --language | --style-for)
 		local IFS=$'\n'
 		COMPREPLY=($(compgen -W "$(
 			"$1" --no-paging --list-languages | while IFS=: read -r lang _; do
@@ -228,6 +234,7 @@ _bat() {
 			--sanitize
 			--strip-ansi
 			--style
+			--style-for
 			--line-range
 			--list-languages
 			--lessopen

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -231,6 +231,9 @@ complete -c $bat -s P -d "Disable paging" -n __bat_no_excl_args
 
 complete -c $bat -l style -x -k -a "(__fish_complete_list , __bat_style_opts)" -d "Specify which non-content elements to display" -n __bat_no_excl_args
 
+complete -c $bat -l style-for -x -k -a "(__bat_complete_list_languages)" -d "Select decorations for a syntax (language, then style)" -n __bat_no_excl_args
+complete -c $bat -f -k -a "(__fish_complete_list , __bat_style_opts)" -n 'set -l args (commandline -opc); test (count $args) -ge 3; and test "$args[-2]" = --style-for'
+
 complete -c $bat -l tabs -x -a "$tabs_opts" -d "Set tab width" -n __bat_no_excl_args
 
 complete -c $bat -l terminal-width -x -d "Set terminal <width>, +<offset>, or -<offset>" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -55,6 +55,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --squeeze-limit='[set the maximum number of consecutive empty lines]:limit:'
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
+        \*--style-for'[select decorations for a syntax]:language:->languages:style: _values "style" default auto full plain changes header header-filename header-filesize grid rule numbers snip'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
             default auto full plain changes header header-filename header-filesize grid rule numbers snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -245,6 +245,16 @@ changes, grid, header\-filename, numbers, snip
 Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
 rule, numbers, snip.
 .HP
+\fB\-\-style\-for\fR <language> <style\-components>
+.IP
+Select decorations for a full syntax name from '\-\-list\-languages', matched
+case\-insensitively. For example, '\-\-style\-for "Git Log" plain' removes
+decorations from Git logs. Repeat this option to configure more syntaxes.
+Lists containing only '+' or '\-' modifiers build on the general style;
+repeated entries for the same syntax are applied in order. Plain/number flags
+and '\-\-decorations=never' take precedence. Wrapping and tab settings remain
+global. This option can also be used in the configuration file.
+.HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...
 .IP
 Only print the specified range of lines for each file. For example:

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -182,6 +182,13 @@ Options:
           displaying untrusted file content (e.g. file-manager preview panes). Possible values:
           auto, always, *never*.
 
+      --style-for <language> <style>
+          Use different decorations for a syntax, for example '--style-for "Git Log" plain'. Use a
+          full name from '--list-languages'; names are matched case-insensitively. Repeat to
+          configure more syntaxes. Styles containing only '+'/'-' modifiers start from the general
+          style. Plain/number flags and '--decorations=never' take precedence. Wrapping and tab
+          settings remain global. This option can be used in the configuration file.
+
       --style <components>
           Configure which elements (line numbers, file headers, grid borders, Git modifications, ..)
           to display in addition to the file contents. The argument is a comma-separated list of

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -504,6 +504,7 @@ impl App {
                         .unwrap_or_default(),
                 ),
             },
+            styles_for_syntax: self.styles_for_syntax(&style_components)?,
             style_components,
             syntax_mapping,
             pager: self.matches.get_one::<String>("pager").map(|s| s.as_str()),
@@ -663,6 +664,45 @@ impl App {
         }
 
         Ok(styled_components)
+    }
+
+    fn styles_for_syntax(
+        &self,
+        general: &StyleComponents,
+    ) -> Result<Vec<(String, StyleComponents)>> {
+        let mut styles: Vec<(String, StyleComponents)> = Vec::new();
+        if let Some(values) = self.matches.get_many::<String>("style-for") {
+            let values: Vec<_> = values.collect();
+            for pair in values.chunks_exact(2) {
+                let language = pair[0];
+                if language.is_empty() {
+                    return Err("The language for --style-for cannot be empty".into());
+                }
+                let list = StyleComponentList::from_str(pair[1])?;
+                let index = styles
+                    .iter()
+                    .position(|(name, _)| name.eq_ignore_ascii_case(language));
+                let components = if let Some(index) = index {
+                    &mut styles[index].1
+                } else {
+                    styles.push((language.clone(), general.clone()));
+                    &mut styles.last_mut().unwrap().1
+                };
+                list.apply_to(components, self.interactive_output);
+            }
+        }
+        for (_, components) in &mut styles {
+            if let Some(forced) = self.forced_style_components() {
+                *components = forced;
+            }
+            if components.grid() {
+                components.0.remove(&StyleComponent::Rule);
+            }
+            if self.matches.get_flag("unbuffered") {
+                components.0.remove(&StyleComponent::LineNumbers);
+            }
+        }
+        Ok(styles)
     }
 
     pub(crate) fn theme_options(&self) -> ThemeOptions {

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -673,7 +673,7 @@ impl App {
         let mut styles: Vec<(String, StyleComponents)> = Vec::new();
         if let Some(values) = self.matches.get_many::<String>("style-for") {
             let values: Vec<_> = values.collect();
-            for pair in values.chunks_exact(2) {
+            for pair in values.as_chunks::<2>().0 {
                 let language = pair[0];
                 if language.is_empty() {
                     return Err("The language for --style-for cannot be empty".into());

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -521,6 +521,22 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .hide_short_help(true)
         )
         .arg(
+            Arg::new("style-for")
+                .long("style-for")
+                .num_args(2)
+                .value_names(["language", "style"])
+                .allow_hyphen_values(true)
+                .action(ArgAction::Append)
+                .hide_short_help(true)
+                .help("Use different decorations for a syntax.")
+                .long_help("Use different decorations for a syntax, for example \
+                    '--style-for \"Git Log\" plain'. Use a full name from '--list-languages'; \
+                    names are matched case-insensitively. Repeat to configure more syntaxes. \
+                    Styles containing only '+'/'-' modifiers start from the general style. \
+                    Plain/number flags and '--decorations=never' take precedence. \
+                    Wrapping and tab settings remain global. This option can be used in the configuration file."),
+        )
+        .arg(
             Arg::new("style")
                 .long("style")
                 .action(ArgAction::Append)

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,10 @@ pub struct Config<'a> {
     /// Style elements (grid, line numbers, ...)
     pub style_components: StyleComponents,
 
+    /// Per-syntax decorations, keyed by the full syntax name (case insensitive).
+    /// Later entries take precedence. Wrapping and tab settings remain global.
+    pub styles_for_syntax: Vec<(String, StyleComponents)>,
+
     /// If and how text should be wrapped
     pub wrapping_mode: WrappingMode,
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -158,6 +158,59 @@ impl Controller<'_> {
             #[cfg(not(feature = "lessopen"))]
             input.open(stdin, stdout_identifier)?
         };
+        let custom_config = self.config_for_syntax(&mut opened_input)?;
+        let controller = Controller {
+            config: custom_config.as_ref().unwrap_or(self.config),
+            assets: self.assets,
+            #[cfg(feature = "lessopen")]
+            preprocessor: None,
+        };
+        controller.print_opened_input(opened_input, writer, is_first)
+    }
+
+    fn config_for_syntax(&self, input: &mut OpenedInput) -> Result<Option<Config<'_>>> {
+        if self.config.loop_through || self.config.styles_for_syntax.is_empty() {
+            return Ok(None);
+        }
+        if input.reader.content_type.is_some_and(|c| c.is_binary())
+            && !self.config.show_nonprintable
+            && !matches!(
+                self.config.binary,
+                crate::nonprintable_notation::BinaryBehavior::AsText
+            )
+        {
+            return Ok(None);
+        }
+        let name = match self.assets.get_syntax(
+            self.config.language,
+            self.config.fallback_syntax,
+            input,
+            &self.config.syntax_mapping,
+        ) {
+            Ok(syntax) => &syntax.syntax.name,
+            Err(Error::UndetectedSyntax(_)) => "Plain Text",
+            Err(error) => return Err(error),
+        };
+        Ok(self
+            .config
+            .styles_for_syntax
+            .iter()
+            .rev()
+            .find_map(|(language, style)| {
+                language.eq_ignore_ascii_case(name).then(|| {
+                    let mut config = self.config.clone();
+                    config.style_components = style.clone();
+                    config
+                })
+            }))
+    }
+
+    fn print_opened_input(
+        &self,
+        mut opened_input: OpenedInput,
+        writer: &mut OutputHandle,
+        is_first: bool,
+    ) -> Result<()> {
         opened_input.reader.unbuffered = self.config.unbuffered;
         #[cfg(feature = "git")]
         let line_changes = if self.config.visible_lines.diff_mode()

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -64,6 +64,26 @@ impl<'a> PrettyPrinter<'a> {
         }
     }
 
+    /// Select decorations for a full syntax name, matched case-insensitively.
+    /// Wrapping and tab settings remain global. Later calls for the same syntax win.
+    pub fn style_for(
+        &mut self,
+        language: impl Into<String>,
+        components: &[StyleComponent],
+    ) -> &mut Self {
+        self.config.styles_for_syntax.push((
+            language.into(),
+            crate::style::StyleComponents(
+                components
+                    .iter()
+                    .flat_map(|component| component.components(true))
+                    .copied()
+                    .collect(),
+            ),
+        ));
+        self
+    }
+
     /// Add an input which should be pretty-printed
     pub fn input(&mut self, input: Input<'a>) -> &mut Self {
         self.inputs.push(input);

--- a/src/style.rs
+++ b/src/style.rs
@@ -160,6 +160,14 @@ impl ComponentAction {
 pub struct StyleComponentList(Vec<(ComponentAction, StyleComponent)>);
 
 impl StyleComponentList {
+    /// Apply this list to an existing set, preserving it for modifier-only lists.
+    pub fn apply_to(&self, components: &mut StyleComponents, interactive_terminal: bool) {
+        if self.contains_override() {
+            components.clear();
+        }
+        self.expand_into(&mut components.0, interactive_terminal);
+    }
+
     fn expand_into(&self, components: &mut HashSet<StyleComponent>, interactive_terminal: bool) {
         for (action, component) in self.0.iter() {
             let subcomponents = component.components(interactive_terminal);

--- a/tests/per_syntax_styles.rs
+++ b/tests/per_syntax_styles.rs
@@ -1,0 +1,204 @@
+mod utils;
+
+use utils::command::bat;
+
+const OPTIONS: &[&str] = &[
+    "--color=never",
+    "--decorations=always",
+    "--paging=never",
+    "--wrap=never",
+    "--terminal-width=80",
+];
+
+fn stdin_output(args: &[&str], content: &str) -> String {
+    String::from_utf8(
+        bat()
+            .args(OPTIONS)
+            .args(args)
+            .write_stdin(content)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn each_input_selects_its_own_style_without_color() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = dir.path().join("example.json");
+    let text = dir.path().join("example.txt");
+    std::fs::write(&json, "{}\n").unwrap();
+    std::fs::write(&text, "text\n").unwrap();
+    let expected = format!("{{}}\n{}", stdin_output(&["--style=numbers"], "text\n"));
+    bat()
+        .args(OPTIONS)
+        .args(["--style=numbers", "--style-for", "json", "plain"])
+        .args([json, text])
+        .assert()
+        .success()
+        .stdout(expected);
+}
+
+#[test]
+fn syntax_styles_follow_detection_explicit_language_and_fallbacks() {
+    let expected = stdin_output(&["--style=numbers"], "{}\n");
+    for syntax_args in [
+        vec!["--language=json"],
+        vec!["--file-name=input.json"],
+        vec!["--file-name=input.custom", "--map-syntax=*.custom:JSON"],
+        vec!["--fallback-syntax=json"],
+    ] {
+        let mut args = vec!["--style=plain", "--style-for", "JSON", "numbers"];
+        args.extend(syntax_args);
+        assert_eq!(stdin_output(&args, "{}\n"), expected);
+    }
+    assert_eq!(
+        stdin_output(
+            &[
+                "--style=numbers",
+                "--style-for",
+                "Bourne Again Shell (bash)",
+                "plain"
+            ],
+            "#!/bin/sh\necho hello\n"
+        ),
+        "#!/bin/sh\necho hello\n"
+    );
+}
+
+#[test]
+fn repeated_syntax_styles_apply_modifiers_in_order() {
+    let output = stdin_output(
+        &[
+            "--language=json",
+            "--style=numbers,header",
+            "--file-name=test.json",
+            "--style-for",
+            "JSON",
+            "-header",
+            "--style-for",
+            "json",
+            "+grid",
+        ],
+        "{}\n",
+    );
+    assert_eq!(output, stdin_output(&["--style=numbers,grid"], "{}\n"));
+    assert_eq!(
+        stdin_output(
+            &[
+                "--language=json",
+                "--style=numbers",
+                "--style-for",
+                "JSON",
+                "full",
+                "--style-for",
+                "JSON",
+                "plain"
+            ],
+            "{}\n"
+        ),
+        "{}\n"
+    );
+}
+
+#[test]
+fn explicit_plain_number_and_decoration_flags_take_precedence() {
+    for flag in ["--plain", "--number", "--decorations=never", "--unbuffered"] {
+        let actual = stdin_output(
+            &[
+                "--language=json",
+                "--style=plain",
+                "--style-for",
+                "JSON",
+                "numbers",
+                flag,
+            ],
+            "{}\n",
+        );
+        let expected = stdin_output(&["--style=plain", flag], "{}\n");
+        assert_eq!(actual, expected, "{flag}");
+    }
+}
+
+#[test]
+fn pipe_output_stays_plain_and_invalid_styles_are_reported() {
+    bat()
+        .args([
+            "--style-for",
+            "JSON",
+            "full",
+            "--language=json",
+            "--color=never",
+        ])
+        .write_stdin("{}\n")
+        .assert()
+        .success()
+        .stdout("{}\n");
+    bat()
+        .args(["--style-for", "JSON", "nonexistent-style"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Unknown style"));
+}
+
+#[test]
+fn library_syntax_styles_expand_aliases_and_honor_the_last_entry() {
+    use bat::style::StyleComponent;
+    let mut full_output = String::new();
+    bat::PrettyPrinter::new()
+        .input_from_bytes(b"{}\n")
+        .language("json")
+        .colored_output(false)
+        .style_for("JSON", &[StyleComponent::Full])
+        .print_with_writer(Some(&mut full_output))
+        .unwrap();
+    assert!(full_output.contains("Size: -"), "{full_output}");
+    let mut output = String::new();
+    bat::PrettyPrinter::new()
+        .input_from_bytes(b"{}\n")
+        .language("json")
+        .colored_output(false)
+        .line_numbers(true)
+        .style_for("JSON", &[StyleComponent::Full])
+        .style_for("json", &[StyleComponent::Plain])
+        .print_with_writer(Some(&mut output))
+        .unwrap();
+    assert_eq!(output, "{}\n");
+}
+
+#[cfg(feature = "git")]
+#[test]
+fn selected_style_loads_git_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("example.json");
+    std::fs::write(&path, "{\n  \"value\": 1\n}\n").unwrap();
+    for args in [vec!["init", "--quiet"], vec!["add", "example.json"]] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+    }
+    std::fs::write(&path, "{\n  \"value\": 2\n}\n").unwrap();
+    let render = |args: &[&str]| {
+        bat()
+            .args(OPTIONS)
+            .args(args)
+            .arg(&path)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone()
+    };
+    let expected = render(&["--style=changes"]);
+    assert_ne!(expected, render(&["--style=plain"]));
+    assert_eq!(
+        expected,
+        render(&["--style=plain", "--style-for", "JSON", "changes"])
+    );
+}


### PR DESCRIPTION
Git logs can benefit from plain output while source files retain line numbers and headers. A single global style cannot express that preference.

Add `--style-for <language> <style>` using full syntax names, with case-insensitive matching and ordered +/- modifiers. Select the style separately for each detected input, including explicit languages, filename mappings, and fallbacks. Plain/number flags and disabled decorations keep their existing precedence; wrapping and tab settings remain global. Library callers can use `PrettyPrinter::style_for`.

Fixes #1708.

Validation: seven new process/library regressions and all 261 existing integration tests passed. Coverage includes mixed inputs without colors, first-line detection, explicit/fallback syntax, repeated modifiers, flag precedence, Git marker loading, pipe output, and library aliases. All-target/all-feature Clippy with warnings denied, formatting, Bash/Zsh syntax, and whitespace checks passed. Manual, help, and four shell completions updated.