### PR TITLE
Support GNOME system color scheme detection on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Support GNOME color scheme preferences on Linux with `--theme auto:system`, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Support GNOME color scheme preferences on Linux with `--theme auto:system`, see #0 (@Matei02355)
+- Support GNOME color scheme preferences on Linux with `--theme auto:system`, see #3961 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/README.md
+++ b/README.md
@@ -708,41 +708,19 @@ sidebar. Calling `bat` with `--tabs=0` will override it and let tabs be consumed
 
 ### Dark mode
 
-If you make use of the dark mode feature in **macOS**, you might want to configure `bat` to use a different
-theme based on the OS theme. The following snippet uses the `default` theme when in the _dark mode_
-and the `GitHub` theme when in the _light mode_.
+On **macOS** and **GNOME on Linux**, `bat` can choose a theme based on the system's
+light or dark preference. The following example uses `default` in dark mode and
+`GitHub` in light mode:
 
 ```bash
 alias cat="bat --theme auto:system --theme-dark default --theme-light GitHub"
 ```
 
-The same dark mode feature is now available in **GNOME** and affects the `org.gnome.desktop.interface color-scheme` setting. The following code converts the above to use said setting.
-
-```bash
-# .bashrc
-sys_color_scheme_is_dark() {
-    condition=$(gsettings get org.gnome.desktop.interface color-scheme)
-    condition=$(echo "$condition" | tr -d "[:space:]'")
-    if [ $condition == "prefer-dark" ]; then
-        return 0
-    else
-        return 1
-    fi
-}
-
-bat_alias_wrapper() {
-    #get color scheme
-    sys_color_scheme_is_dark
-    if [[ $? -eq 0 ]]; then
-        # bat command with dark color scheme
-        bat --theme=default "$@"
-    else
-        # bat command with light color scheme
-        bat --theme=GitHub "$@"
-    fi
-}
-alias cat='bat_alias_wrapper'
-```
+On Linux, this queries `org.gnome.desktop.interface color-scheme` using
+`gsettings`. The values `prefer-dark` and `prefer-light` select the respective
+theme. If `gsettings` is unavailable, the query times out, or the setting is
+`default` (no preference), `bat` uses its default theme. Ordinary `--theme auto`
+continues to detect the terminal's colors.
 
 
 ## Configuration file

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -185,8 +185,10 @@ Picks a dark or light theme depending on the terminal's colors.
 Use \fB-\-theme\-light\fR and \fB-\-theme\-dark\fR to customize the selected theme.
 .IP "auto:always"
 Variation of \fBauto\fR where where the terminal's colors are detected even when the output is redirected.
-.IP "auto:system (macOS only)"
+.IP "auto:system (macOS or GNOME on Linux)"
 Variation of \fBauto\fR where the color scheme is detected from the system-wide preference instead.
+On Linux, queries GNOME's color-scheme setting using gsettings.
+If the setting is unavailable or expresses no preference, uses the default theme.
 .IP "dark"
 Use the dark theme specified by \fB-\-theme-dark\fR.
 .IP "light"

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -144,7 +144,8 @@ Options:
             * auto: Picks a dark or light theme depending on the terminal's colors (default).
                     Use '--theme-light' and '--theme-dark' to customize the selected theme.
               * auto:always: Detect the terminal's colors even when the output is redirected.
-              * auto:system: Detect the color scheme from the system-wide preference (macOS only).
+              * auto:system: Detect the color scheme from the system-wide preference (macOS or GNOME
+              on Linux).
             * dark: Use the dark theme specified by '--theme-dark'.
             * light: Use the light theme specified by '--theme-light'.
 

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -436,7 +436,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                      * auto: Picks a dark or light theme depending on the terminal's colors (default).\n          \
                      Use '--theme-light' and '--theme-dark' to customize the selected theme.\n    \
                      * auto:always: Detect the terminal's colors even when the output is redirected.\n    \
-                     * auto:system: Detect the color scheme from the system-wide preference (macOS only).\n  \
+                     * auto:system: Detect the color scheme from the system-wide preference (macOS or GNOME on Linux).\n  \
                      * dark: Use the dark theme specified by '--theme-dark'.\n  \
                      * light: Use the light theme specified by '--theme-light'.",
                 ),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -169,7 +169,7 @@ pub enum DetectColorScheme {
     Auto,
     /// Always query the terminal for its colors.
     Always,
-    /// Detect the system-wide dark/light preference (macOS only).
+    /// Detect the system-wide dark/light preference (macOS or GNOME on Linux).
     System,
 }
 
@@ -274,13 +274,63 @@ impl ColorSchemeDetector for TerminalColorSchemeDetector {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn color_scheme_from_system() -> Option<ColorScheme> {
     crate::bat_warning!(
-        "Theme 'auto:system' is only supported on macOS, \
+        "Theme 'auto:system' is only supported on macOS and GNOME on Linux, \
         using default."
     );
     None
+}
+
+#[cfg(target_os = "linux")]
+fn color_scheme_from_system() -> Option<ColorScheme> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    let mut child = Command::new("gsettings")
+        .args(["get", "org.gnome.desktop.interface", "color-scheme"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // A stalled settings service must not prevent bat from displaying its input.
+    let deadline = Instant::now() + Duration::from_millis(200);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    return None;
+                }
+                break;
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Ok(None) | Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+
+    let mut output = String::new();
+    child
+        .stdout
+        .take()?
+        .take(64)
+        .read_to_string(&mut output)
+        .ok()?;
+    match output.trim() {
+        "'prefer-dark'" => Some(ColorScheme::Dark),
+        "'prefer-light'" => Some(ColorScheme::Light),
+        // The 'default' value does not express a preference.
+        _ => None,
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/tests/system_color_scheme.rs
+++ b/tests/system_color_scheme.rs
@@ -1,0 +1,93 @@
+#![cfg(target_os = "linux")]
+
+mod utils;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::time::Duration;
+use utils::command::bat;
+
+fn install_gsettings(directory: &Path, body: &str) {
+    let path = directory.join("gsettings");
+    std::fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\n[ \"$#\" = 3 ] && [ \"$1\" = get ] && \
+             [ \"$2\" = org.gnome.desktop.interface ] && \
+             [ \"$3\" = color-scheme ] || exit 1\n{body}\n"
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn render(directory: &Path, theme: &str) -> Vec<u8> {
+    bat()
+        .env("PATH", directory)
+        .args([
+            "--style=plain",
+            "--paging=never",
+            "--color=always",
+            "--language=json",
+            "--theme-dark=Monokai Extended",
+            "--theme-light=GitHub",
+            "--theme",
+            theme,
+        ])
+        .timeout(Duration::from_secs(5))
+        .write_stdin("{\"message\": \"hello\", \"count\": 42}\n")
+        .assert()
+        .success()
+        .stderr("")
+        .get_output()
+        .stdout
+        .clone()
+}
+
+#[test]
+fn system_preference_selects_the_configured_dark_or_light_theme() {
+    let directory = tempfile::tempdir().unwrap();
+    let dark = render(directory.path(), "dark");
+    let light = render(directory.path(), "light");
+    assert_ne!(dark, light);
+    for (setting, expected) in [("prefer-dark", dark), ("prefer-light", light)] {
+        install_gsettings(directory.path(), &format!("printf \"'{setting}'\\n\""));
+        assert_eq!(render(directory.path(), "auto:system"), expected);
+    }
+}
+
+#[test]
+fn unavailable_or_unspecified_settings_use_the_default_theme() {
+    let directory = tempfile::tempdir().unwrap();
+    let default = render(directory.path(), "default");
+    assert_eq!(render(directory.path(), "auto:system"), default);
+    for body in [
+        "printf \"'default'\\n\"",
+        "printf \"'unknown'\\n\"",
+        "printf \"'prefer-light'\\n\"; exit 1",
+        "echo 'settings unavailable' >&2; exit 1",
+        "printf '\\377'",
+        "while :; do :; done",
+        "while :; do printf 'too much output'; done",
+    ] {
+        install_gsettings(directory.path(), body);
+        assert_eq!(render(directory.path(), "auto:system"), default, "{body}");
+    }
+}
+
+#[test]
+fn fixed_themes_and_terminal_detection_do_not_query_gsettings() {
+    let directory = tempfile::tempdir().unwrap();
+    install_gsettings(directory.path(), "echo invoked > \"$SETTINGS_MARKER\"");
+    let marker = directory.path().join("called");
+    for theme in ["auto", "default", "dark", "light", "GitHub"] {
+        bat()
+            .env("PATH", directory.path())
+            .env("SETTINGS_MARKER", &marker)
+            .args(["--style=plain", "--paging=never", "--theme", theme])
+            .write_stdin("hello\n")
+            .assert()
+            .success();
+        assert!(!marker.exists(), "gsettings was invoked for {theme}");
+    }
+}


### PR DESCRIPTION
Linux users currently need a shell wrapper to select a theme from GNOME's light/dark preference.

Extend `--theme auto:system` to query `org.gnome.desktop.interface color-scheme` through `gsettings` on Linux. Explicit dark/light preferences select the configured themes. Missing settings, errors, an unspecified preference, and queries exceeding 200 ms fall back to the default theme. The helper cannot consume standard input or print diagnostics into bat's output. Ordinary terminal detection and fixed themes do not invoke it.

Fixes #3301.

Validation: three process regressions cover both preferences, unavailable/invalid settings, errors, hung/oversized output, and helper invocation boundaries. All 261 existing integration tests, all-target/all-feature Clippy with warnings denied, formatting, and whitespace checks passed. README wrapper instructions replaced with native support; manual and generated help updated.