### PR TITLE
Support opt-in inherited project configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add opt-in `.batconfig` files for inherited project settings with `--local-config`, see #0 (@Matei02355)
+- Add opt-in `.batconfig` files for inherited project settings with `--local-config`, see #3962 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add opt-in `.batconfig` files for inherited project settings with `--local-config`, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -769,6 +769,29 @@ There is also now a systemwide configuration file, which is located under `/etc/
 Linux and Mac OS and `C:\ProgramData\bat\config` on windows. If the system wide configuration
 file is present, the content of the user configuration will simply be appended to it.
 
+### Project configuration
+
+Pass `--local-config` on the command line to read `.batconfig` files from the
+current directory and its ancestors. They use the same format as the user
+configuration, so a repository can carry settings such as:
+
+```text
+--map-syntax "*.custom:Rust"
+```
+
+Files are read from the filesystem root toward the current directory. Nearer
+settings override ancestor and user settings; environment variables such as
+`BAT_THEME` and explicit command-line options take precedence. `BAT_OPTS`, when
+set, replaces the system/user configuration before local files are applied.
+Paths and syntax mappings retain their normal interpretation relative to the
+current directory. Selecting input files elsewhere does not change which
+configuration files are read.
+
+Local configuration is disabled by default. The opt-in flag must be supplied on
+the command line, and `--no-config` disables local files too. Enable this only in
+directories you trust, because configuration can specify pager or preprocessor
+commands.
+
 ### Format
 
 The configuration file is a simple list of command line arguments. Use `bat --help` to see a full list of possible options and values. In addition, you can add comments by prepending a line with the `#` character.

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -181,6 +181,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-u'                      , 'u'                     , [CompletionResultType]::ParameterName, 'u')
             [CompletionResult]::new('--unbuffered'            , 'unbuffered'            , [CompletionResultType]::ParameterName, 'Enable unbuffered input reading for streaming use cases')
             [CompletionResult]::new('--completion'            , 'completion'            , [CompletionResultType]::ParameterName, 'Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]')
+            [CompletionResult]::new('--local-config', 'local-config', [CompletionResultType]::ParameterName, 'Read project configuration from the current directory and ancestors')
             [CompletionResult]::new('--no-config'             , 'no-config'             , [CompletionResultType]::ParameterName, 'Do not use the configuration file')
             [CompletionResult]::new('--no-custom-assets'      , 'no-custom-assets'      , [CompletionResultType]::ParameterName, 'Do not load custom assets')
             [CompletionResult]::new('--lessopen'              , 'lessopen'              , [CompletionResultType]::ParameterName, 'Enable the $LESSOPEN preprocessor')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -243,6 +243,7 @@ _bat() {
 			--config-file
 			--generate-config-file
 			--no-config
+			--local-config
 			--no-custom-assets
 			--no-lessopen
 		" -- "$cur"))

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -194,6 +194,8 @@ complete -c $bat -l list-themes -f -d "List syntax highlighting themes" -n __fis
 
 complete -c $bat -s m -l map-syntax -x -a "(__bat_complete_map_syntax)" -d "Map <glob pattern>:<language syntax>" -n __bat_no_excl_args
 
+complete -c $bat -l local-config -d "Read project configuration from the current directory and ancestors"
+
 complete -c $bat -l no-config -d "Do not use the configuration file"
 
 complete -c $bat -l no-custom-assets -d "Do not load custom assets"

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -65,6 +65,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --diagnostic'[show diagnostic information for bug reports]'
         --quiet-empty'[do not produce any output when the input is empty]'
         -P'[disable paging]'
+        "--local-config[read project configuration from the current directory and ancestors]"
         "--no-config[don't use the configuration file]"
         "--no-custom-assets[don't load custom assets]"
         '(--no-lessopen)'--lessopen'[enable the $LESSOPEN preprocessor]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -327,6 +327,12 @@ To generate a default configuration file, call:
 
 \fB{{PROJECT_EXECUTABLE}} --generate-config-file\fR
 
+With \fB--local-config\fR, additionally reads .batconfig files in the current
+directory and its ancestors, from the filesystem root downwards. Nearer files
+override ancestor and user configuration. Selected environment variables and
+command-line options take precedence. BAT_OPTS replaces system/user configuration
+before local files are read. Input paths do not affect configuration discovery.
+
 These are related options:
 .HP
 \fB\-\-config\-file\fR
@@ -340,6 +346,13 @@ Generates a default configuration file.
 \fB\-\-no\-config\fR
 .IP
 Do not use the configuration file.
+.HP
+\fB\-\-local\-config\fR
+.IP
+Read .batconfig files from the current directory and its ancestors.
+This opt-in flag must be supplied on the command line and is ignored with
+\fB--no-config\fR. Enable it only for trusted directories, since configuration
+can specify pager or preprocessor commands.
 .SH "ADDING CUSTOM LANGUAGES"
 {{PROJECT_EXECUTABLE}} supports Sublime Text \fB.sublime-syntax\fR language files, and can be
 customized to add additional languages to your local installation. To do this, add the \fB.sublime-syntax\fR language
@@ -385,6 +398,12 @@ Alternatively, the preprocessor may be enabled by default by adding the '\-\-les
 To temporarily disable the preprocessor if it is enabled by default, call:
 
 \fB{{PROJECT_EXECUTABLE}} --no-lessopen\fR
+
+With \fB--local-config\fR, additionally reads .batconfig files in the current
+directory and its ancestors, from the filesystem root downwards. Nearer files
+override ancestor and user configuration. Selected environment variables and
+command-line options take precedence. BAT_OPTS replaces system/user configuration
+before local files are read. Input paths do not affect configuration discovery.
 
 These are related options:
 .HP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -235,6 +235,13 @@ Options:
           automatically disabled in unbuffered mode, and syntax highlighting may be imperfect on
           partial lines.
 
+      --local-config
+          Read .batconfig files from the current directory and its ancestors, from the filesystem
+          root downwards. Local settings override the user configuration; environment variables and
+          command-line options take precedence. This flag must be supplied on the command line and
+          is ignored with --no-config. Enable it only in directories you trust: configuration can
+          specify a pager or preprocessor command.
+
       --completion <SHELL>
           Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]
 

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -64,6 +64,8 @@ Options:
           Display all supported languages.
   -u, --unbuffered
           Enable unbuffered input reading for streaming use cases.
+      --local-config
+          Read .batconfig files from the current directory and its ancestors
       --completion <SHELL>
           Show shell completion for a certain shell. [possible values: bash, fish, zsh, ps1]
   -E, --quiet-empty

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -7,7 +7,10 @@ use std::thread::available_parallelism;
 
 use crate::{
     clap_app,
-    config::{get_args_from_config_file, get_args_from_env_opts_var, get_args_from_env_vars},
+    config::{
+        get_args_from_config_file, get_args_from_env_opts_var, get_args_from_env_vars,
+        get_args_from_local_config,
+    },
 };
 use bat::style::StyleComponentList;
 use bat::theme::{theme, ThemeName, ThemeOptions, ThemePreference};
@@ -79,7 +82,7 @@ impl App {
         let number_from_cli = cli_matches.get_flag("number");
         let number_nonblank_from_cli = cli_matches.get_flag("number-nonblank");
 
-        let matches = Self::matches(interactive_output)?;
+        let matches = Self::matches(interactive_output, cli_matches.get_flag("local-config"))?;
 
         if matches.get_flag("help") {
             let help_type = if wild::args_os().any(|arg| arg == "--help") {
@@ -195,7 +198,7 @@ impl App {
         clap_app::build_app(interactive_output).get_matches_from(wild::args_os())
     }
 
-    fn matches(interactive_output: bool) -> Result<ArgMatches> {
+    fn matches(interactive_output: bool, use_local_config: bool) -> Result<ArgMatches> {
         // Check if we should skip config file processing for special arguments
         // that don't require full application setup (version, diagnostic)
         let should_skip_config = wild::args_os().any(|arg| {
@@ -239,6 +242,15 @@ impl App {
         } else {
             config_args.map_err(|_| "Could not parse configuration file")?
         };
+
+        if use_local_config {
+            let local_args = get_args_from_local_config();
+            args.extend(if help_requested {
+                local_args.unwrap_or_default()
+            } else {
+                local_args?
+            });
+        }
 
         // Selected env vars supersede config vars
         args.extend(get_args_from_env_vars());

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -615,6 +615,20 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("local-config")
+                .long("local-config")
+                .action(ArgAction::SetTrue)
+                .help("Read .batconfig files from the current directory and its ancestors")
+                .long_help(
+                    "Read .batconfig files from the current directory and its ancestors, \
+                     from the filesystem root downwards. Local settings override the user \
+                     configuration; environment variables and command-line options take \
+                     precedence. This flag must be supplied on the command line and is \
+                     ignored with --no-config. Enable it only in directories you trust: \
+                     configuration can specify a pager or preprocessor command.",
+                ),
+        )
+        .arg(
             Arg::new("no-config")
                 .long("no-config")
                 .action(ArgAction::SetTrue)

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -130,6 +130,33 @@ fn same_file(a: &Path, b: &Path) -> bool {
     }
 }
 
+/// Read project configuration from ancestors of the current directory, with
+/// nearer directories taking precedence. Call only after an explicit CLI opt-in.
+pub fn get_args_from_local_config() -> bat::error::Result<Vec<OsString>> {
+    let directory = env::current_dir()?;
+    let mut args = Vec::new();
+    for ancestor in directory.ancestors().collect::<Vec<_>>().into_iter().rev() {
+        let path = ancestor.join(".batconfig");
+        match fs::read_to_string(&path) {
+            Ok(content) => args.extend(get_args_from_str(&content).map_err(|error| {
+                format!(
+                    "Could not parse local configuration '{}': {error}",
+                    path.display()
+                )
+            })?),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "Could not read local configuration '{}': {error}",
+                    path.display()
+                )
+                .into());
+            }
+        }
+    }
+    Ok(args)
+}
+
 pub fn get_args_from_env_opts_var() -> Option<Result<Vec<OsString>, shell_words::ParseError>> {
     env::var("BAT_OPTS").ok().map(|s| get_args_from_str(&s))
 }

--- a/tests/local_config.rs
+++ b/tests/local_config.rs
@@ -1,0 +1,150 @@
+mod utils;
+
+use std::path::Path;
+use utils::command::bat_with_config;
+
+fn command(directory: &Path) -> assert_cmd::Command {
+    let mut command = bat_with_config();
+    command
+        .current_dir(directory)
+        .env("BAT_CONFIG_PATH", directory.join("user-config"))
+        .env("BAT_CACHE_PATH", directory.join("cache"))
+        .args([
+            "--paging=never",
+            "--color=always",
+            "--style=plain",
+            "--theme=Monokai Extended",
+        ]);
+    command
+}
+
+fn output(directory: &Path, args: &[&str]) -> Vec<u8> {
+    command(directory)
+        .args(args)
+        .write_stdin("fn main() { println!(\"hello\"); }\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone()
+}
+
+#[test]
+fn project_mappings_are_opt_in_and_inherited_in_directory_order() {
+    let root = tempfile::tempdir().unwrap();
+    let child = root.path().join("src/nested");
+    std::fs::create_dir_all(&child).unwrap();
+    std::fs::write(
+        root.path().join(".batconfig"),
+        "# Shared project mappings\n--map-syntax '*.data:JSON'\n--map-syntax '*.parent:Python'\n",
+    )
+    .unwrap();
+    std::fs::write(child.join(".batconfig"), "--map-syntax '*.data:Rust'\n").unwrap();
+
+    let rust = output(&child, &["--language=Rust"]);
+    let plain = output(&child, &["--language=txt"]);
+    assert_ne!(rust, plain);
+    assert_eq!(output(&child, &["--file-name=input.data"]), plain);
+    assert_eq!(
+        output(&child, &["--local-config", "--file-name=input.data"]),
+        rust
+    );
+    assert_eq!(
+        output(&child, &["--local-config", "--file-name=input.parent"]),
+        output(&child, &["--language=Python"])
+    );
+    assert_eq!(
+        output(root.path(), &["--local-config", "--file-name=input.data"]),
+        output(root.path(), &["--language=JSON"])
+    );
+}
+
+#[test]
+fn local_config_precedence_and_no_config_are_respected() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join("user-config"), "--language=JSON\n").unwrap();
+    std::fs::write(root.path().join(".batconfig"), "--language=Rust\n").unwrap();
+    assert_eq!(
+        output(root.path(), &["--local-config"]),
+        output(root.path(), &["--language=Rust"])
+    );
+    assert_eq!(
+        output(root.path(), &["--local-config", "--language=Python"]),
+        output(root.path(), &["--language=Python"])
+    );
+    assert_eq!(
+        output(root.path(), &["--local-config", "--no-config"]),
+        output(root.path(), &["--no-config", "--language=txt"])
+    );
+    command(root.path())
+        .env("BAT_OPTS", "--language=Python")
+        .arg("--local-config")
+        .write_stdin("fn main() { println!(\"hello\"); }\n")
+        .assert()
+        .success()
+        .stdout(output(root.path(), &["--language=Rust"]));
+}
+
+#[test]
+fn explicit_environment_settings_override_project_settings() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join(".batconfig"), "--tabs=8\n").unwrap();
+    command(root.path())
+        .env("BAT_TABS", "2")
+        .args(["--local-config", "--color=never", "--decorations=always"])
+        .write_stdin("x\ty\n")
+        .assert()
+        .success()
+        .stdout("x y\n");
+}
+
+#[test]
+fn malformed_project_config_reports_its_path_and_help_remains_available() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join(".batconfig"), "--theme='unfinished\n").unwrap();
+    command(root.path())
+        .arg("--local-config")
+        .write_stdin("hello\n")
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicates::str::contains(".batconfig"));
+    for bypass in ["--no-config", "--help", "--version"] {
+        command(root.path())
+            .args(["--local-config", bypass])
+            .write_stdin("hello\n")
+            .assert()
+            .success();
+    }
+    output(root.path(), &[]);
+    std::fs::remove_file(root.path().join(".batconfig")).unwrap();
+    std::fs::create_dir(root.path().join(".batconfig")).unwrap();
+    command(root.path())
+        .arg("--local-config")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "Could not read local configuration",
+        ));
+}
+
+#[test]
+fn local_config_requires_a_real_command_line_flag() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join(".batconfig"), "--language=Rust\n").unwrap();
+    std::fs::write(root.path().join("user-config"), "--local-config\n").unwrap();
+    assert_eq!(
+        output(root.path(), &[]),
+        output(root.path(), &["--language=txt"])
+    );
+    assert_eq!(
+        output(root.path(), &["--file-name=--local-config"]),
+        output(root.path(), &["--language=txt"])
+    );
+    std::fs::write(root.path().join("--local-config"), "ordinary file\n").unwrap();
+    command(root.path())
+        .args(["--color=never", "--", "--local-config"])
+        .assert()
+        .success()
+        .stdout("ordinary file\n");
+}


### PR DESCRIPTION
Project-specific syntax mappings currently have to live in each user's personal configuration and do not travel with a repository.

Add `--local-config` to read `.batconfig` files from the filesystem root down to the current directory. Nearer files override ancestor and user settings; explicit environment options and CLI arguments retain precedence. Local files use the existing configuration format, including comments and quoted arguments. Input paths do not change the configuration search directory.

The option requires an explicit command-line flag. `--no-config`, version/diagnostic output, and cache subcommands retain their bypass behavior. Malformed or unreadable local files report their paths; help remains available. Documentation explains that configuration can launch a pager/preprocessor and should only be enabled in trusted directories.

Fixes #3147.

Validation: five process regressions cover inheritance, mapping and option precedence, BAT_OPTS/environment settings, default-off behavior, option-like filenames, errors and help. All 261 existing integration tests, all-target/all-feature Clippy, formatting, Bash/Zsh syntax, and whitespace checks passed. README, manual, help and four shell completions updated.