### PR TITLE
Add pictographic and compact nonprintable notations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add symbols, period, and binary notations for non-printable characters, plus the `-c` shortcut, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add symbols, period, and binary notations for non-printable characters, plus the `-c` shortcut, see #0 (@Matei02355)
+- Add symbols, period, and binary notations for non-printable characters, plus the `-c` shortcut, see #3963 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/README.md
+++ b/README.md
@@ -745,6 +745,22 @@ alias cat='bat_alias_wrapper'
 ```
 
 
+### Alternative control-character notation
+
+With `--show-all` (`-A`), choose a notation using `-c` or
+`--nonprintable-notation`. `unicode` and `caret` retain their existing behavior.
+`symbols` uses pictographic marks such as ⇥, ⏎, ⌫, and ⎋ for common controls.
+`period` renders spaces, ASCII controls, and invalid UTF-8 bytes as periods.
+`binary` keeps symbols for tabs, line endings, and escapes, using periods for
+other controls and invalid bytes. Newline markers retain the line break, and
+`--tabs` controls the tab stops.
+
+```bash
+bat -A -c symbols file
+bat -A -c binary file
+```
+
+
 ## Configuration file
 
 `bat` can also be customized with a configuration file. The location of the file is dependent

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -11,7 +11,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
     $ArrayYesNo      = @('never', 'always')
     $ArrayWrap       = @('always', 'never', 'character', 'word')
     $ArrayBinary     = @('no-printing', 'as-text')
-    $ArrayPrint      = @('unicode', 'caret')
+    $ArrayPrint      = @('unicode', 'caret', 'symbols', 'period', 'binary')
 
     function Get-MyThemes(){
         $themes = {{PROJECT_EXECUTABLE}} --no-paging --list-themes | ForEach-Object {$_  -replace "^(.*)$", '''$1'''} | select-object
@@ -110,6 +110,11 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
             break
         }
+        '*;-c' {
+            $ArrayPrint |
+            ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
+            break
+        }
         '*;--nonprintable-notation' {
             $ArrayPrint |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterValue, $_)}
@@ -157,7 +162,8 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
         #   [CompletionResult]::new('-A'                      , 'A'                     , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')
             [CompletionResult]::new('--show-all'              , 'show-all'              , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')
-            [CompletionResult]::new('--nonprintable-notation' , 'nonprintable-notation' , [CompletionResultType]::ParameterName, 'Set notation for non-printable characters. (unicode, caret)')
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Set notation for non-printable characters.')
+            [CompletionResult]::new('--nonprintable-notation' , 'nonprintable-notation' , [CompletionResultType]::ParameterName, 'Set notation for non-printable characters. (unicode, caret, symbols, period, binary)')
             [CompletionResult]::new('--chop-long-lines'       , 'chop-long-lines'       , [CompletionResultType]::ParameterName, 'Truncate all lines longer than screen width. Alias for ''--wrap=never''.')
             [CompletionResult]::new('--binary'                , 'binary'                , [CompletionResultType]::ParameterName, 'How to treat binary content. (*no-printing*, as-text)')
             [CompletionResult]::new('--ignored-suffix'        , 'ignored-suffix'        , [CompletionResultType]::ParameterName, 'Ignore extension. For example: ''bat --ignored-suffix ".dev" my_file.json.dev'' will use JSON syntax, and ignore ''.dev''')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -124,8 +124,8 @@ _bat() {
 		COMPREPLY=($(compgen -W "no-printing as-text" -- "$cur"))
 		return 0
 		;;
-	--nonprintable-notation)
-		COMPREPLY=($(compgen -W "unicode caret" -- "$cur"))
+	-c | --nonprintable-notation)
+		COMPREPLY=($(compgen -W "unicode caret symbols period binary" -- "$cur"))
 		return 0
 		;;
 	--strip-ansi)
@@ -197,6 +197,7 @@ _bat() {
 		COMPREPLY=($(compgen -W "
 			--unbuffered
 			--show-all
+			-c
 			--nonprintable-notation
 			--binary
 			--plain

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -200,7 +200,7 @@ complete -c $bat -l no-custom-assets -d "Do not load custom assets"
 
 complete -c $bat -l no-lessopen -d "Disable the $LESSOPEN preprocessor if enabled (overrides --lessopen)"
 
-complete -c $bat -l nonprintable-notation -x -a "unicode caret" -d "Set notation for non-printable characters" -n __bat_no_excl_args
+complete -c $bat -s c -l nonprintable-notation -x -a "unicode caret symbols period binary" -d "Set notation for non-printable characters" -n __bat_no_excl_args
 
 complete -c $bat -s n -l number -d "Only show line numbers, no other decorations" -n __bat_no_excl_args
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -25,7 +25,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
     local -a args
     args=(
         '(-A --show-all)'{-A,--show-all}'[show non-printable characters (space, tab, newline, ..)]'
-        --nonprintable-notation='[specify how to display non-printable characters when using --show-all]:notation:(caret unicode)'
+        '(-c --nonprintable-notation)'{-c+,--nonprintable-notation=}'[specify how to display non-printable characters when using --show-all]:notation:(caret unicode symbols period binary)'
         --binary='[specify how to treat binary content]:behavior:(no-printing as-text)'
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -26,7 +26,7 @@ either '--language value', '--language=value', '-l value' or '-lvalue'.
 Show non\-printable characters like space, tab or newline. Use '\-\-tabs' to
 control the width of the tab\-placeholders.
 .HP
-\fB\-\-nonprintable\-notation\fR <notation>
+\fB\-c\fR, \fB\-\-nonprintable\-notation\fR <notation>
 .IP
 Specify how to display non-printable characters when using \-\-show\-all.
 
@@ -36,6 +36,15 @@ Possible values:
 Use character sequences like ^G, ^J, ^@, .. to identify non-printable characters
 .IP "unicode"
 Use special Unicode code points to identify non-printable characters
+.IP "symbols"
+Use pictographic symbols for common controls: tab ⇥, line feed ⏎, carriage return ←,
+backspace ⌫, vertical tab ⤓, form feed ↡, escape ⎋, and delete ⌦.
+Other controls use Unicode control pictures.
+.IP "period"
+Use periods for spaces, ASCII controls, and invalid UTF-8 bytes.
+.IP "binary"
+Use symbols for tabs, line endings, and escapes; periods for other ASCII controls
+and invalid UTF-8 bytes. Spaces use the usual middle-dot marker.
 .RE
 .HP
 \fB\-\-binary\fR <behavior>

--- a/assets/syntaxes/02_Extra/show-nonprintable.sublime-syntax
+++ b/assets/syntaxes/02_Extra/show-nonprintable.sublime-syntax
@@ -29,3 +29,15 @@ contexts:
       scope: comment.block.show-nonprintable.backspace
     - match: "\\\\u\\{[a-z0-9]+\\}"
       scope: comment.block.show-nonprintable.backspace
+    - match: "⇥"
+      scope: constant.character.escape.show-nonprintable.tab
+    - match: "⏎"
+      scope: keyword.operator.show-nonprintable.line-feed
+    - match: "←"
+      scope: string.show-nonprintable.carriage-return
+    - match: "⎋"
+      scope: entity.other.attribute-name.show-nonprintable.escape
+    - match: "⌫"
+      scope: comment.block.show-nonprintable.backspace
+    - match: "[⤓↡⌦]"
+      scope: constant.character.escape.show-nonprintable.control

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -13,12 +13,16 @@ Options:
           Show non-printable characters like space, tab or newline. This option can also be used to
           print binary files. Use '--tabs' to control the width of the tab-placeholders.
 
-      --nonprintable-notation <notation>
-          Set notation for non-printable characters.
+  -c, --nonprintable-notation <notation>
+          Set notation for non-printable characters with --show-all. Tab markers occupy the
+          configured tab width.
           
           Possible values:
             * unicode (␇, ␊, ␀, ..)
             * caret   (^G, ^J, ^@, ..)
+            * symbols (⇥, ⏎, ⌫, ⎋, ..; Unicode for other controls)
+            * period  (periods for spaces, controls and invalid bytes)
+            * binary  (symbols for tabs, line endings and escapes; periods for other controls)
 
       --binary <behavior>
           How to treat binary content. (default: no-printing)

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -9,7 +9,7 @@ Arguments:
 Options:
   -A, --show-all
           Show non-printable characters (space, tab, newline, ..).
-      --nonprintable-notation <notation>
+  -c, --nonprintable-notation <notation>
           Set notation for non-printable characters.
       --binary <behavior>
           How to treat binary content. (default: no-printing)

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -390,6 +390,9 @@ impl App {
             {
                 Some("unicode") => NonprintableNotation::Unicode,
                 Some("caret") => NonprintableNotation::Caret,
+                Some("symbols") => NonprintableNotation::Symbols,
+                Some("period") => NonprintableNotation::Period,
+                Some("binary") => NonprintableNotation::Binary,
                 _ => unreachable!("other values for --nonprintable-notation are not allowed"),
             },
             binary: match self.matches.get_one::<String>("binary").map(|s| s.as_str()) {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -65,17 +65,22 @@ pub fn build_app(interactive_output: bool) -> Command {
         .arg(
             Arg::new("nonprintable-notation")
                 .long("nonprintable-notation")
+                .short('c')
                 .action(ArgAction::Set)
                 .default_value("unicode")
-                .value_parser(["unicode", "caret"])
+                .value_parser(["unicode", "caret", "symbols", "period", "binary"])
                 .value_name("notation")
                 .hide_default_value(true)
                 .help("Set notation for non-printable characters.")
                 .long_help(
-                    "Set notation for non-printable characters.\n\n\
+                    "Set notation for non-printable characters with --show-all. \
+                    Tab markers occupy the configured tab width.\n\n\
                     Possible values:\n  \
                     * unicode (␇, ␊, ␀, ..)\n  \
-                    * caret   (^G, ^J, ^@, ..)",
+                    * caret   (^G, ^J, ^@, ..)\n  \
+                    * symbols (⇥, ⏎, ⌫, ⎋, ..; Unicode for other controls)\n  \
+                    * period  (periods for spaces, controls and invalid bytes)\n  \
+                    * binary  (symbols for tabs, line endings and escapes; periods for other controls)",
                 ),
         )
         .arg(

--- a/src/nonprintable_notation.rs
+++ b/src/nonprintable_notation.rs
@@ -9,6 +9,15 @@ pub enum NonprintableNotation {
     /// Use unicode notation (␇, ␊, ␀, ..)
     #[default]
     Unicode,
+
+    /// Use pictographic symbols for common controls (⇥, ⏎, ⌫, ⎋, ...).
+    Symbols,
+
+    /// Use periods for spaces, ASCII controls, and invalid UTF-8 bytes.
+    Period,
+
+    /// Use symbols for tabs, line endings, and escapes; periods for other controls.
+    Binary,
 }
 
 /// How to treat binary content

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -72,15 +72,28 @@ pub fn replace_nonprintable(
         if let Some((chr, skip_ahead)) = try_parse_utf8_char(&input[idx..]) {
             idx += skip_ahead;
             line_idx += 1;
+            let output_start = output.len();
 
             match chr {
                 // space
-                ' ' => output.push('·'),
+                ' ' => output.push(if nonprintable_notation == NonprintableNotation::Period {
+                    '.'
+                } else {
+                    '·'
+                }),
                 // tab
                 '\t' => {
                     let tab_stop = tab_width - ((line_idx - 1) % tab_width);
                     line_idx = 0;
-                    if tab_stop == 1 {
+                    if nonprintable_notation == NonprintableNotation::Period {
+                        output.push_str(&".".repeat(tab_stop));
+                    } else if matches!(
+                        nonprintable_notation,
+                        NonprintableNotation::Symbols | NonprintableNotation::Binary
+                    ) {
+                        output.push('⇥');
+                        output.push_str(&" ".repeat(tab_stop - 1));
+                    } else if tab_stop == 1 {
                         output.push('↹');
                     } else {
                         output.push('├');
@@ -90,33 +103,14 @@ pub fn replace_nonprintable(
                 }
                 // line feed
                 '\x0A' => {
-                    output.push_str(match nonprintable_notation {
-                        NonprintableNotation::Caret => "^J\x0A",
-                        NonprintableNotation::Unicode => "␊\x0A",
-                    });
+                    push_control_symbol(&mut output, chr, nonprintable_notation);
+                    output.push('\n');
                     line_idx = 0;
                 }
                 // ASCII control characters
-                '\x00'..='\x1F' => {
-                    let c = u32::from(chr);
-
-                    match nonprintable_notation {
-                        NonprintableNotation::Caret => {
-                            let caret_character = char::from_u32(0x40 + c).unwrap();
-                            write!(output, "^{caret_character}").ok();
-                        }
-
-                        NonprintableNotation::Unicode => {
-                            let replacement_symbol = char::from_u32(0x2400 + c).unwrap();
-                            output.push(replacement_symbol)
-                        }
-                    }
+                '\x00'..='\x1F' | '\x7F' => {
+                    push_control_symbol(&mut output, chr, nonprintable_notation);
                 }
-                // delete
-                '\x7F' => match nonprintable_notation {
-                    NonprintableNotation::Caret => output.push_str("^?"),
-                    NonprintableNotation::Unicode => output.push('\u{2421}'),
-                },
                 // printable ASCII
                 c if c.is_ascii_alphanumeric()
                     || c.is_ascii_punctuation()
@@ -127,13 +121,75 @@ pub fn replace_nonprintable(
                 // everything else
                 c => output.push_str(&c.escape_unicode().collect::<String>()),
             }
+            if matches!(
+                nonprintable_notation,
+                NonprintableNotation::Symbols
+                    | NonprintableNotation::Period
+                    | NonprintableNotation::Binary
+            ) && !matches!(chr, '\t' | '\n')
+            {
+                // Escape sequences such as \\u{e9} occupy more columns than the
+                // original character. Keep the new notation's tab stops aligned.
+                line_idx += unicode_width::UnicodeWidthStr::width(&output[output_start..])
+                    .saturating_sub(1);
+            }
         } else {
-            write!(output, "\\x{:02X}", input[idx]).ok();
+            if matches!(
+                nonprintable_notation,
+                NonprintableNotation::Period | NonprintableNotation::Binary
+            ) {
+                output.push('.');
+                line_idx += 1;
+            } else {
+                write!(output, "\\x{:02X}", input[idx]).ok();
+                if nonprintable_notation == NonprintableNotation::Symbols {
+                    line_idx += 4;
+                }
+            }
             idx += 1;
         }
     }
 
     output
+}
+
+fn push_control_symbol(output: &mut String, control: char, notation: NonprintableNotation) {
+    use NonprintableNotation::*;
+    match notation {
+        Caret => {
+            output.push('^');
+            output.push(if control == '\x7f' {
+                '?'
+            } else {
+                char::from_u32(0x40 + u32::from(control)).unwrap()
+            });
+        }
+        Period => output.push('.'),
+        Symbols | Binary => {
+            let symbol = match control {
+                '\n' => Some('⏎'),
+                '\r' => Some('←'),
+                '\x1b' => Some('⎋'),
+                '\x08' if notation == Symbols => Some('⌫'),
+                '\x0b' if notation == Symbols => Some('⤓'),
+                '\x0c' if notation == Symbols => Some('↡'),
+                '\x7f' if notation == Symbols => Some('⌦'),
+                _ => None,
+            };
+            if let Some(symbol) = symbol {
+                output.push(symbol);
+            } else if notation == Binary {
+                output.push('.');
+            } else {
+                push_control_symbol(output, control, Unicode);
+            }
+        }
+        Unicode => output.push(if control == '\x7f' {
+            '\u{2421}'
+        } else {
+            char::from_u32(0x2400 + u32::from(control)).unwrap()
+        }),
+    }
 }
 
 /// Strips ANSI escape sequences from the input.

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -177,6 +177,12 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Select the notation used when non-printable characters are shown.
+    pub fn nonprintable_notation(&mut self, notation: crate::NonprintableNotation) -> &mut Self {
+        self.config.nonprintable_notation = notation;
+        self
+    }
+
     /// Whether to show "snip" markers between visible line ranges (default: no)
     pub fn snip(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.snip = yes;

--- a/tests/nonprintable_modes.rs
+++ b/tests/nonprintable_modes.rs
@@ -1,0 +1,102 @@
+mod utils;
+
+use utils::command::bat;
+
+fn output(mode: &str, input: &[u8], extra: &[&str]) -> String {
+    String::from_utf8(
+        bat()
+            .args([
+                "-A",
+                "-c",
+                mode,
+                "--color=never",
+                "--style=plain",
+                "--tabs=4",
+            ])
+            .args(extra)
+            .write_stdin(input)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn new_notations_display_common_controls_and_invalid_bytes() {
+    let input = b"\x00\x08\t\n\x0b\x0c\r\x1b\x7f\xff";
+    assert_eq!(output("symbols", input, &[]), "␀⌫⇥ ⏎\n⤓↡←⎋⌦\\xFF");
+    assert_eq!(output("period", input, &[]), ".....\n......");
+    assert_eq!(output("binary", input, &[]), "..⇥ ⏎\n..←⎋..");
+}
+
+#[test]
+fn notation_does_not_expose_control_bytes_or_modify_printable_punctuation() {
+    let controls: Vec<u8> = (0..=31).chain([127, 128, 255]).collect();
+    for mode in ["symbols", "period", "binary"] {
+        let text = output(mode, &controls, &[]);
+        assert!(!text.bytes().any(|b| b < 32 && b != b'\n' || b == 127));
+        assert_eq!(output(mode, b"a.b;[]{}?!", &[]), "a.b;[]{}?!");
+    }
+}
+
+#[test]
+fn tab_stops_follow_displayed_markers() {
+    for width in 1..=8 {
+        for input in [b"abc\tX".as_slice(), b"\xff\tX", "é\tX".as_bytes()] {
+            for mode in ["symbols", "period", "binary"] {
+                let text = output(mode, input, &[&format!("--tabs={width}")]);
+                let before_x = text.strip_suffix('X').unwrap();
+                assert_eq!(
+                    unicode_width::UnicodeWidthStr::width(before_x) % width,
+                    0,
+                    "{mode}, width {width}: {text:?}"
+                );
+            }
+        }
+    }
+    assert_eq!(output("period", b"\xff\tX\n", &[]), "....X.\n");
+}
+
+#[test]
+fn new_markers_wrap_at_display_columns() {
+    for mode in ["symbols", "period", "binary"] {
+        let text = output(
+            mode,
+            b"abc\tdef\x08ghi\n",
+            &[
+                "--decorations=always",
+                "--wrap=character",
+                "--terminal-width=4",
+            ],
+        );
+        assert!(text.lines().count() > 1);
+        for line in text.lines() {
+            assert!(unicode_width::UnicodeWidthStr::width(line) <= 4, "{line:?}");
+        }
+    }
+}
+
+#[test]
+fn notation_is_opt_in_and_available_to_library_callers() {
+    for mode in ["symbols", "period", "binary"] {
+        bat()
+            .args(["-c", mode])
+            .write_stdin("ordinary text\twith whitespace\n")
+            .assert()
+            .success()
+            .stdout("ordinary text\twith whitespace\n");
+    }
+    let mut printer = bat::PrettyPrinter::new();
+    let mut text = String::new();
+    printer
+        .input_from_bytes(b"hello\x08\x1b\n")
+        .show_nonprintable(true)
+        .nonprintable_notation(bat::NonprintableNotation::Symbols)
+        .colored_output(false)
+        .print_with_writer(Some(&mut text))
+        .unwrap();
+    assert_eq!(text, "hello⌫⎋⏎\n");
+}


### PR DESCRIPTION
Unicode control pictures can be difficult to read in some terminal fonts, and showing full escape names for every control makes binary inspection noisy.

Add `symbols`, `period`, and `binary` choices to `--nonprintable-notation`, plus the `-c` shortcut. Symbols use pictographic marks for common controls; period mode uses dots for spaces, ASCII controls and invalid bytes; binary mode retains symbols for tabs, line endings and escapes while simplifying other controls. Existing unicode/caret modes and the default remain unchanged. New modes keep tab stops aligned after visible escapes, and new glyphs receive matching utility-syntax scopes. Library callers can select the notation through PrettyPrinter.

Fixes #3427.

Validation: five new process/library regressions cover controls, invalid UTF-8, tab widths 1–8, Unicode escapes, wrapping, printable punctuation and opt-in behavior. All 261 existing integration tests, all-target/all-feature Clippy, formatting, Bash/Zsh syntax and whitespace checks passed. Rebuilt syntax-cache output was checked for marker colors and exact displayed text. README, manual, help and four shell completions updated.