### PR TITLE
Highlight inclusive line and character regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Support inclusive line/character regions with `--highlight-line L.C:L.C`, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Support inclusive line/character regions with `--highlight-line L.C:L.C`, see #0 (@Matei02355)
+- Support inclusive line/character regions with `--highlight-line L.C:L.C`, see #3964 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/README.md
+++ b/README.md
@@ -745,6 +745,22 @@ alias cat='bat_alias_wrapper'
 ```
 
 
+### Highlight part of a line
+
+Use line-and-column positions with `--highlight-line` to select exact characters:
+
+```bash
+bat --highlight-line 2.3:.7 file   # characters 3–7 on line 2
+bat --highlight-line 2.3:4.5 file # line 2, character 3 through line 4, character 5
+```
+
+Both endpoints are included, and positions start at 1. Tabs count as one
+character; combining marks and emoji sequences stay together. ANSI escape
+sequences do not count. With `--show-all`, columns refer to the resulting marker
+text. Existing whole-line ranges can be mixed with character regions by repeating
+`--highlight-line`.
+
+
 ## Configuration file
 
 `bat` can also be customized with a configuration file. The location of the file is dependent

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -135,8 +135,8 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         default {
         #   [CompletionResult]::new('-l'                      , 'l'                     , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
             [CompletionResult]::new('--language'              , 'language'              , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
-        #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
-            [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+        #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N:M or characters L.C:L.C.')
+            [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N:M or characters L.C:L.C.')
             [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
             [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')
             [CompletionResult]::new('--tabs'                  , 'tabs'                  , [CompletionResultType]::ParameterName, 'Set the tab width to T spaces.')

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -176,7 +176,7 @@ complete -c $bat -s h -d "Print a concise overview" -n __fish_is_first_arg
 
 complete -c $bat -l help -f -d "Print all help information" -n __fish_is_first_arg
 
-complete -c $bat -s H -l highlight-line -x -d "Highlight line(s) N[:M]" -n __bat_no_excl_args
+complete -c $bat -s H -l highlight-line -x -d "Highlight lines N[:M] or characters L.C:L.C" -n __bat_no_excl_args
 
 complete -c $bat -l ignored-suffix -x -d "Ignore extension" -n __bat_no_excl_args
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -29,7 +29,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --binary='[specify how to treat binary content]:behavior:(no-printing as-text)'
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
-        \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
+        \*{-H+,--highlight-line=}'[highlight line or character ranges]:range'
         \*--file-name='[specify the name to display for a file]:name:_files'
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'
         --diff-context='[specify lines of context around added/removed/modified lines when using `--diff`]:lines'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -82,7 +82,19 @@ highlights lines 1 to 40
 highlights lines 40 to the end of the file
 .IP "\-\-highlight\-line 30:+10"
 highlights lines 30 to 40
+.IP "\-\-highlight\-line 2.3:.7"
+highlights characters 3 through 7 of line 2
+.IP "\-\-highlight\-line 2.3:4.5"
+highlights from line 2, character 3 through line 4, character 5
 .RE
+Character regions use inclusive LINE.COLUMN positions. A single position selects
+one character; an omitted end selects through the end of the file. A column
+without a line number refers to the starting line. Positions start at 1 and must
+be in ascending order. Columns count Unicode grapheme clusters before tab
+expansion; tabs count as one character, and ANSI escape sequences do not count.
+With --show-all, positions refer to the resulting marker text. Character ranges
+highlight only selected text, without padding to the terminal edge. If the theme
+has no line-highlight color, selected text is underlined instead.
 .HP
 \fB\-\-file\-name\fR <name>...
 .IP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -44,13 +44,20 @@ Options:
           
           [aliases: --fallback-language]
 
-  -H, --highlight-line <N:M>
-          Highlight the specified line ranges with a different background color For example:
+  -H, --highlight-line <range>
+          Highlight line ranges, or character regions using LINE.COLUMN positions. Positions start
+          at 1; tabs count as one character and combining marks stay with their character. ANSI
+          escapes do not count. With --show-all, columns refer to the resulting marker text.
+          Character ranges color only selected text and use underlining if the theme has no
+          highlight color. For example:
             '--highlight-line 40' highlights line 40
             '--highlight-line 30:40' highlights lines 30 to 40
             '--highlight-line :40' highlights lines 1 to 40
             '--highlight-line 40:' highlights lines 40 to the end of the file
             '--highlight-line 30:+10' highlights lines 30 to 40
+            '--highlight-line 2.3:.7' highlights characters 3 to 7 of line 2
+            '--highlight-line 2.3:4.5' highlights from line 2, character 3 through line 4, character
+            5
 
       --file-name <name>
           Specify the name to display for a file. Useful when piping data to bat from STDIN when bat

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -19,8 +19,8 @@ Options:
           Set the language for syntax highlighting.
       --fallback-syntax <fallback-syntax>
           Set a fallback language for undetected syntaxes. [aliases: --fallback-language]
-  -H, --highlight-line <N:M>
-          Highlight lines N through M.
+  -H, --highlight-line <range>
+          Highlight line or character ranges.
       --file-name <name>
           Specify the name to display for a file.
   -d, --diff

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -515,11 +515,23 @@ impl App {
             highlighted_lines: self
                 .matches
                 .get_many::<String>("highlight-line")
-                .map(|ws| ws.map(|s| LineRange::from(s.as_str())).collect())
+                .map(|ws| {
+                    ws.filter(|s| !s.contains('.'))
+                        .map(|s| LineRange::from(s.as_str()))
+                        .collect()
+                })
                 .transpose()?
                 .map(LineRanges::from)
                 .map(HighlightedLineRanges)
                 .unwrap_or_default(),
+            highlighted_regions: self
+                .matches
+                .get_many::<String>("highlight-line")
+                .into_iter()
+                .flatten()
+                .filter(|s| s.contains('.'))
+                .map(|s| s.parse())
+                .collect::<Result<Vec<_>>>()?,
             use_custom_assets: !self.matches.get_flag("no-custom-assets"),
             #[cfg(feature = "lessopen")]
             use_lessopen: self.matches.get_flag("lessopen"),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -138,16 +138,22 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .long("highlight-line")
                 .short('H')
                 .action(ArgAction::Append)
-                .value_name("N:M")
-                .help("Highlight lines N through M.")
+                .value_name("range")
+                .help("Highlight line or character ranges.")
                 .long_help(
-                    "Highlight the specified line ranges with a different background color \
+                    "Highlight line ranges, or character regions using LINE.COLUMN positions. \
+                     Positions start at 1; tabs count as one character and combining marks \
+                     stay with their character. ANSI escapes do not count. With --show-all, \
+                     columns refer to the resulting marker text. Character ranges color only \
+                     selected text and use underlining if the theme has no highlight color. \
                      For example:\n  \
                      '--highlight-line 40' highlights line 40\n  \
                      '--highlight-line 30:40' highlights lines 30 to 40\n  \
                      '--highlight-line :40' highlights lines 1 to 40\n  \
                      '--highlight-line 40:' highlights lines 40 to the end of the file\n  \
-                     '--highlight-line 30:+10' highlights lines 30 to 40",
+                     '--highlight-line 30:+10' highlights lines 30 to 40\n  \
+                     '--highlight-line 2.3:.7' highlights characters 3 to 7 of line 2\n  \
+                     '--highlight-line 2.3:4.5' highlights from line 2, character 3 through line 4, character 5",
                 ),
         )
         .arg(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::highlight_region::HighlightRegion;
 use crate::line_range::{HighlightedLineRanges, LineRanges};
 use crate::nonprintable_notation::{BinaryBehavior, NonprintableNotation};
 #[cfg(feature = "paging")]
@@ -93,6 +94,9 @@ pub struct Config<'a> {
 
     /// Ranges of lines which should be highlighted with a special background color
     pub highlighted_lines: HighlightedLineRanges,
+
+    /// Character ranges highlighted without coloring the rest of the line.
+    pub highlighted_regions: Vec<HighlightRegion>,
 
     /// Whether or not to allow custom assets. If this is false or if custom assets (a.k.a.
     /// cached assets) are not available, assets from the binary will be used instead.

--- a/src/highlight_region.rs
+++ b/src/highlight_region.rs
@@ -1,0 +1,170 @@
+//! Character regions for partial-line highlighting.
+
+use std::ops::Range;
+use std::str::FromStr;
+
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::error::{Error, Result};
+use crate::vscreen::{EscapeSequenceOffsets, EscapeSequenceOffsetsIterator};
+
+/// An inclusive range of one-based line and character positions.
+///
+/// Columns count Unicode grapheme clusters before tab expansion. ANSI escape
+/// sequences do not count as characters. With `--show-all`, columns refer to the
+/// resulting marker text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HighlightRegion {
+    start: (usize, usize),
+    end: (usize, usize),
+}
+
+impl HighlightRegion {
+    pub fn new(start: (usize, usize), end: (usize, usize)) -> Result<Self> {
+        if start.0 == 0 || start.1 == 0 || end.0 == 0 || end.1 == 0 || start > end {
+            return Err("Highlight positions must start at 1 and be in ascending order".into());
+        }
+        Ok(Self { start, end })
+    }
+
+    pub fn contains(&self, line: usize, column: usize) -> bool {
+        self.start <= (line, column) && (line, column) <= self.end
+    }
+}
+
+impl FromStr for HighlightRegion {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        if !value.contains('.') || !value.bytes().any(|b| b.is_ascii_digit()) {
+            return Err("Character ranges require a dot between line and column".into());
+        }
+        let (left, right) = value
+            .split_once(':')
+            .map_or((value, None), |(a, b)| (a, Some(b)));
+        let start = parse_position(left, 1, 1)?;
+        let end = match right {
+            None => start,
+            Some("") => (usize::MAX, usize::MAX),
+            Some(right) => parse_position(right, start.0, usize::MAX)?,
+        };
+        Self::new(start, end)
+    }
+}
+
+fn parse_position(
+    value: &str,
+    default_line: usize,
+    default_column: usize,
+) -> Result<(usize, usize)> {
+    let (line, column) = value.split_once('.').unwrap_or((value, ""));
+    let number = |raw: &str, default| -> Result<usize> {
+        if raw.is_empty() {
+            Ok(default)
+        } else if raw.bytes().all(|b| b.is_ascii_digit()) {
+            Ok(raw.parse()?)
+        } else {
+            Err(format!("Invalid character position: '{value}'").into())
+        }
+    };
+    Ok((number(line, default_line)?, number(column, default_column)?))
+}
+
+pub(crate) fn selected_byte_ranges(
+    line: &str,
+    line_number: usize,
+    regions: &[HighlightRegion],
+) -> Vec<Range<usize>> {
+    if !regions
+        .iter()
+        .any(|r| r.start.0 <= line_number && line_number <= r.end.0)
+    {
+        return Vec::new();
+    }
+    let mut visible = String::new();
+    let mut segments = Vec::new();
+    for sequence in EscapeSequenceOffsetsIterator::new(line.trim_end_matches(['\r', '\n'])) {
+        if let EscapeSequenceOffsets::Text { .. } = sequence {
+            let source = sequence.index_of_start()..sequence.index_past_end();
+            let start = visible.len();
+            visible.push_str(&line[source.clone()]);
+            segments.push((start..visible.len(), source));
+        }
+    }
+
+    let mut result: Vec<Range<usize>> = Vec::new();
+    let mut previous_selected = false;
+    for (column, (start, grapheme)) in visible.grapheme_indices(true).enumerate() {
+        let selected = regions.iter().any(|r| r.contains(line_number, column + 1));
+        if selected {
+            let end = start + grapheme.len();
+            let first = &segments[segments.partition_point(|(range, _)| range.end <= start)];
+            let last = &segments[segments.partition_point(|(range, _)| range.start < end) - 1];
+            let source_start = first.1.start + start - first.0.start;
+            let source_end = last.1.start + end - last.0.start;
+            if previous_selected {
+                result.last_mut().unwrap().end = source_end;
+            } else {
+                result.push(source_start..source_end);
+            }
+        }
+        previous_selected = selected;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_inclusive_positions_and_open_bounds() {
+        for (value, start, end) in [
+            ("2.3", (2, 3), (2, 3)),
+            ("2.3:.7", (2, 3), (2, 7)),
+            ("2.3:4.5", (2, 3), (4, 5)),
+            ("2.:.7", (2, 1), (2, 7)),
+            (":4.5", (1, 1), (4, 5)),
+            ("2.3:", (2, 3), (usize::MAX, usize::MAX)),
+            ("2.3:4", (2, 3), (4, usize::MAX)),
+        ] {
+            assert_eq!(
+                value.parse::<HighlightRegion>().unwrap(),
+                HighlightRegion::new(start, end).unwrap()
+            );
+        }
+        for value in [
+            "",
+            "2",
+            "0.2",
+            "2.0",
+            "3.2:2.4",
+            "2.7:.3",
+            "2.1:3.2:4",
+            "2.x",
+            "2.-1",
+            "2.+1",
+            "2..3",
+            "2.999999999999999999999999999999999",
+        ] {
+            assert!(value.parse::<HighlightRegion>().is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn coordinates_ignore_escapes_and_keep_graphemes_intact() {
+        let text = "a\x1b[31me\x1b[0m\u{301}中👩‍💻z\r\n";
+        let regions = ["1.2:.4".parse().unwrap()];
+        let ranges = selected_byte_ranges(text, 1, &regions);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(&text[ranges[0].clone()], "e\x1b[0m\u{301}中👩‍💻");
+        assert!(selected_byte_ranges(text, 2, &regions).is_empty());
+    }
+
+    #[test]
+    fn overlapping_and_out_of_bounds_ranges_are_clipped_to_content() {
+        let ranges = ["1.2:.4", "1.3:.6", "1.99:.100"].map(|s| s.parse().unwrap());
+        assert_eq!(selected_byte_ranges("abcdef\n", 1, &ranges), vec![1..6]);
+        assert!(selected_byte_ranges("\x1b[31m\n", 1, &ranges).is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod controller;
 mod decorations;
 mod diff;
 pub mod error;
+pub mod highlight_region;
 pub mod input;
 mod less;
 #[cfg(feature = "lessopen")]

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -249,6 +249,15 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Highlight an inclusive range of line and character positions.
+    pub fn highlight_region(
+        &mut self,
+        region: crate::highlight_region::HighlightRegion,
+    ) -> &mut Self {
+        self.config.highlighted_regions.push(region);
+        self
+    }
+
     /// Specify the maximum number of consecutive empty lines to print.
     pub fn squeeze_empty_lines(&mut self, maximum: Option<usize>) -> &mut Self {
         self.config.squeeze_lines = maximum;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -40,6 +40,47 @@ use crate::wrapping::WrappingMode;
 use crate::BinaryBehavior;
 use crate::StripAnsiMode;
 
+/// Split only at selected character boundaries, retaining the syntax style.
+/// Empty selections leave the original regions and allocation unchanged.
+fn split_highlighted_regions(
+    regions: &mut Vec<(syntect::highlighting::Style, &str)>,
+    selected: &[std::ops::Range<usize>],
+    underline: bool,
+) -> Vec<bool> {
+    if selected.is_empty() {
+        return Vec::new();
+    }
+    let mut result = Vec::new();
+    let mut highlighted = Vec::new();
+    let mut offset = 0;
+    let mut selection = 0;
+    for &(style, region) in regions.iter() {
+        let region_end = offset + region.len();
+        let mut position = offset;
+        while position < region_end {
+            while selection < selected.len() && selected[selection].end <= position {
+                selection += 1;
+            }
+            let active = selected
+                .get(selection)
+                .is_some_and(|r| r.contains(&position));
+            let end = selected.get(selection).map_or(region_end, |range| {
+                region_end.min(if active { range.end } else { range.start })
+            });
+            let mut style = style;
+            if active && underline {
+                style.font_style.insert(FontStyle::UNDERLINE);
+            }
+            result.push((style, &region[position - offset..end - offset]));
+            highlighted.push(active);
+            position = end;
+        }
+        offset = region_end;
+    }
+    *regions = result;
+    highlighted
+}
+
 // Return the displayed width of a character.
 //
 // Control characters (0x00..=0x1F and 0x7F) are rendered by the terminal
@@ -698,7 +739,7 @@ impl Printer for InteractivePrinter<'_> {
             line
         };
 
-        let regions = self.highlight_regions_for_line(&line)?;
+        let mut regions = self.highlight_regions_for_line(&line)?;
         if out_of_range {
             return Ok(());
         }
@@ -736,6 +777,17 @@ impl Printer for InteractivePrinter<'_> {
             .background_color_highlight
             .filter(|_| highlight_this_line);
 
+        let character_ranges = crate::highlight_region::selected_byte_ranges(
+            &line,
+            line_number,
+            &self.config.highlighted_regions,
+        );
+        let highlighted_parts = split_highlighted_regions(
+            &mut regions,
+            &character_ranges,
+            self.config.colored_output && self.background_color_highlight.is_none(),
+        );
+
         // Line decorations.
         if self.panel_width > 0 {
             let display_line_number =
@@ -762,7 +814,12 @@ impl Printer for InteractivePrinter<'_> {
             let colored_output = self.config.colored_output;
             let italics = self.config.use_italic_text;
 
-            for &(style, region) in &regions {
+            for (index, &(style, region)) in regions.iter().enumerate() {
+                let region_background = background_color.or_else(|| {
+                    (self.config.colored_output && highlighted_parts.get(index) == Some(&true))
+                        .then_some(self.background_color_highlight)
+                        .flatten()
+                });
                 let ansi_iterator = EscapeSequenceIterator::new(region);
                 for chunk in ansi_iterator {
                     match chunk {
@@ -780,7 +837,7 @@ impl Printer for InteractivePrinter<'_> {
                                     true_color,
                                     colored_output,
                                     italics,
-                                    background_color
+                                    region_background
                                 ),
                                 self.ansi_style.to_reset_sequence(),
                             )?;
@@ -817,7 +874,12 @@ impl Printer for InteractivePrinter<'_> {
                 writeln!(handle)?;
             }
         } else {
-            for &(style, region) in &regions {
+            for (index, &(style, region)) in regions.iter().enumerate() {
+                let region_background = background_color.or_else(|| {
+                    (self.config.colored_output && highlighted_parts.get(index) == Some(&true))
+                        .then_some(self.background_color_highlight)
+                        .flatten()
+                });
                 let ansi_iterator = EscapeSequenceIterator::new(region);
                 for chunk in ansi_iterator {
                     match chunk {
@@ -904,7 +966,7 @@ impl Printer for InteractivePrinter<'_> {
                                             self.config.true_color,
                                             self.config.colored_output,
                                             self.config.use_italic_text,
-                                            background_color
+                                            region_background
                                         ),
                                         self.ansi_style.to_reset_sequence(),
                                         panel_wrap.clone().unwrap()
@@ -942,7 +1004,7 @@ impl Printer for InteractivePrinter<'_> {
                                     self.config.true_color,
                                     self.config.colored_output,
                                     self.config.use_italic_text,
-                                    background_color
+                                    region_background
                                 )
                             )?;
                         }

--- a/tests/character_highlighting.rs
+++ b/tests/character_highlighting.rs
@@ -1,0 +1,177 @@
+mod utils;
+
+use utils::command::bat;
+
+fn output(input: &str, args: &[&str]) -> String {
+    String::from_utf8(
+        bat()
+            .env("COLORTERM", "truecolor")
+            .args([
+                "--color=always",
+                "--style=plain",
+                "--paging=never",
+                "--theme=Monokai Extended",
+                "--wrap=never",
+                "--tabs=4",
+            ])
+            .args((!args.contains(&"-A")).then_some("--language=txt"))
+            .args(args)
+            .write_stdin(input)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap()
+}
+
+/// Extract text carrying a background or underline, accounting for SGR resets.
+fn highlighted(output: &str) -> String {
+    let sgr = regex::Regex::new(r"\x1b\[([0-9;]*)m").unwrap();
+    let mut result = String::new();
+    let mut background = false;
+    let mut underline = false;
+    let mut position = 0;
+    for captures in sgr.captures_iter(output) {
+        let escape = captures.get(0).unwrap();
+        if background || underline {
+            result.push_str(&output[position..escape.start()]);
+        }
+        let values: Vec<u16> = captures[1]
+            .split(';')
+            .map(|s| s.parse().unwrap_or(0))
+            .collect();
+        let mut i = 0;
+        while i < values.len() {
+            match values[i] {
+                0 => {
+                    background = false;
+                    underline = false;
+                }
+                4 => underline = true,
+                24 => underline = false,
+                49 => background = false,
+                40..=47 | 100..=107 => background = true,
+                code @ (38 | 48) => {
+                    if code == 48 {
+                        background = true;
+                    }
+                    i += match values.get(i + 1) {
+                        Some(2) => 4,
+                        Some(5) => 2,
+                        _ => 0,
+                    };
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        position = escape.end();
+    }
+    if background || underline {
+        result.push_str(&output[position..]);
+    }
+    result
+}
+
+#[test]
+fn selects_exact_characters_across_lines_and_overlapping_ranges() {
+    assert_eq!(highlighted(&output("abcdef\n", &["-H", "1.2:.4"])), "bcd");
+    assert_eq!(highlighted(&output("abcdef\n", &["-H", "1.2"])), "b");
+    assert_eq!(
+        highlighted(&output("abcdef\n", &["-H", "1.2:.4", "-H", "1.3:.5"])),
+        "bcde"
+    );
+    assert_eq!(
+        highlighted(&output("abcd\nEFGH\nijkl\n", &["-H", "1.2:3.2"])),
+        "bcdEFGHij"
+    );
+    assert_eq!(
+        highlighted(&output("abcd\nEFGH\n", &["-H", ":2.2"])),
+        "abcdEF"
+    );
+    assert_eq!(
+        highlighted(&output("abcd\nEFGH\n", &["-H", "1.3:"])),
+        "cdEFGH"
+    );
+    assert!(highlighted(&output("abc\n", &["-H", "1.20:.30"])).is_empty());
+}
+
+#[test]
+fn unicode_graphemes_and_ansi_escapes_keep_their_positions() {
+    let text = "ae\u{301}中👩‍💻z\r\n";
+    assert_eq!(
+        highlighted(&output(text, &["-H", "1.2:.4"])),
+        "e\u{301}中👩‍💻"
+    );
+    assert_eq!(
+        highlighted(&output("a\x1b[31mbc\x1b[0md\n", &["-H", "1.2:.3"])),
+        "bc"
+    );
+    assert_eq!(highlighted(&output("ab\tcd\n", &["-H", "1.3"])), "  ");
+}
+
+#[test]
+fn character_highlights_follow_wrapping_without_extending_into_padding() {
+    for wrap in ["character", "word", "never"] {
+        let text = output(
+            "abcdefghij\n",
+            &["-H", "1.3:.8", "--terminal-width=4", "--wrap", wrap],
+        );
+        assert_eq!(
+            highlighted(&text).replace('\n', ""),
+            "cdefgh",
+            "{wrap}: {text:?}"
+        );
+    }
+    assert_eq!(
+        highlighted(&output("abc\n", &["-H", "1.2:.3", "--terminal-width=80"])),
+        "bc"
+    );
+}
+
+#[test]
+fn ansi_theme_and_disabled_colors_have_defined_behavior() {
+    assert_eq!(
+        highlighted(&output("abc\n", &["-H", "1.2", "--theme=ansi"])),
+        "b"
+    );
+    assert_eq!(output("abc\n", &["-H", "1.2", "--color=never"]), "abc\n");
+    assert_eq!(
+        highlighted(&output("a\tb\n", &["-A", "--tabs=1", "-H", "1.2"])),
+        "↹"
+    );
+}
+
+#[test]
+fn legacy_line_highlighting_and_character_ranges_can_be_mixed() {
+    let text = output(
+        "abc\ndef\n",
+        &["-H", "1.2", "-H", "2", "--terminal-width=3"],
+    );
+    assert_eq!(highlighted(&text).trim_end(), "bdef");
+    for value in ["1.0", "0.1", "1.4:.2", "1.x", ".", "1.2:3.4:5"] {
+        bat()
+            .args(["-H", value])
+            .write_stdin("abc\n")
+            .assert()
+            .failure()
+            .stdout("");
+    }
+}
+
+#[test]
+fn library_callers_can_highlight_character_regions() {
+    let mut text = String::new();
+    bat::PrettyPrinter::new()
+        .input_from_bytes(b"abcdef\n")
+        .language("txt")
+        .theme("Monokai Extended")
+        .colored_output(true)
+        .true_color(true)
+        .highlight_region("1.2:.4".parse().unwrap())
+        .print_with_writer(Some(&mut text))
+        .unwrap();
+    assert_eq!(highlighted(&text), "bcd");
+}


### PR DESCRIPTION
Line highlighting cannot currently select a small part of a line, such as the location of a diagnostic.

Extend `--highlight-line` with inclusive `LINE.COLUMN` positions: `-H 2.3:.7` highlights columns 3–7 on line 2, and `-H 2.3:4.5` spans multiple lines. Existing line ranges and relative line counts continue to work. Columns count Unicode grapheme clusters before tab expansion and ignore ANSI escapes; with `--show-all`, they address rendered marker text. Selected text follows wrapping without extending into padding, and themes without a highlight color use underlining. Library callers can use HighlightRegion and PrettyPrinter::highlight_region.

Fixes #672.

Validation: the complete test suite passed (460 tests, five ignored), including new parsing, Unicode, ANSI, tabs, wrapping, overlap, open-bound, invalid-range and library regressions. All-target/all-feature Clippy, formatting, Bash/Zsh syntax and whitespace checks passed. Updated README, manual, help and shell completions.