### PR TITLE
Display mapped extensions consistently in language lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Bugfixes
 
-- Display simple mapped extensions consistently in language listings and avoid duplicates, see #0 (@Matei02355)
+- Display simple mapped extensions consistently in language listings and avoid duplicates, see #3966 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+
+- Display simple mapped extensions consistently in language listings and avoid duplicates, see #0 (@Matei02355)
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -91,7 +91,17 @@ where
     for mapping in mappings {
         if let (matcher, MappingTarget::MapTo(s)) = mapping {
             let globs = map.entry(*s).or_insert_with(Vec::new);
-            globs.push(matcher.glob().glob().into());
+            let pattern = matcher.glob().glob();
+            let displayed = pattern
+                .strip_prefix("*.")
+                .filter(|extension| {
+                    !extension.is_empty()
+                        && extension
+                            .chars()
+                            .all(|c| c.is_alphanumeric() || matches!(c, '.' | '-' | '_' | '+'))
+                })
+                .unwrap_or(pattern);
+            globs.push(displayed.into());
         }
     }
     map
@@ -133,8 +143,11 @@ pub fn get_languages(config: &Config, cache_dir: &Path) -> Result<String> {
 
     for lang in &mut languages {
         if let Some(additional_paths) = configured_languages.get(lang.name.as_str()) {
-            lang.file_extensions
-                .extend(additional_paths.iter().cloned());
+            for path in additional_paths {
+                if !lang.file_extensions.contains(path) {
+                    lang.file_extensions.push(path.clone());
+                }
+            }
         }
     }
 

--- a/tests/listed_extensions.rs
+++ b/tests/listed_extensions.rs
@@ -1,0 +1,88 @@
+mod utils;
+use utils::command::bat;
+
+fn listing(extra: &[&str]) -> String {
+    let output = bat()
+        .args([
+            "--list-languages",
+            "--paging=never",
+            "--color=never",
+            "--terminal-width=500",
+        ])
+        .args(extra)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(output).unwrap()
+}
+
+#[test]
+fn native_and_mapped_extensions_share_the_same_display_format() {
+    for args in [vec![], vec!["--decorations=always"]] {
+        let output = listing(&args);
+        let diff = output
+            .lines()
+            .find(|line| line.starts_with("Diff"))
+            .unwrap();
+        assert!(diff.contains("debdiff"), "{diff}");
+        assert!(!diff.contains("*.debdiff"), "{diff}");
+        assert!(diff.contains("patch"), "{diff}");
+    }
+}
+
+#[test]
+fn complex_globs_and_exact_filenames_remain_explicit() {
+    let output = listing(&[
+        "--map-syntax=*.customsuffix:Rust",
+        "--map-syntax=*.d.custom:Rust",
+        "--map-syntax=*.[ab]:Rust",
+        "--map-syntax=*.{c,h}:Rust",
+        "--map-syntax=**/*.scoped:Rust",
+        "--map-syntax=Project.lock:Rust",
+        "--map-syntax=.hiddenconfig:Rust",
+        "--map-syntax=*.rs:Rust",
+    ]);
+    let rust = output
+        .lines()
+        .find(|line| line.starts_with("Rust:"))
+        .unwrap();
+    let entries: Vec<_> = rust.strip_prefix("Rust:").unwrap().split(',').collect();
+    for expected in [
+        "customsuffix",
+        "d.custom",
+        "*.[ab]",
+        "**/*.scoped",
+        "Project.lock",
+        ".hiddenconfig",
+    ] {
+        assert!(entries.contains(&expected), "missing {expected}: {rust}");
+    }
+    assert!(rust.contains("*.{c,h}"), "{rust}");
+    assert_eq!(entries.iter().filter(|e| **e == "rs").count(), 1, "{rust}");
+    assert!(!rust.contains("*.customsuffix"), "{rust}");
+}
+
+#[test]
+fn formatting_the_listing_does_not_change_mapping_behavior() {
+    let input = "fn main() {}\n";
+    let render = |args: &[&str]| {
+        bat()
+            .args(["--color=always", "--style=plain", "--paging=never"])
+            .args(args)
+            .write_stdin(input)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone()
+    };
+    assert_eq!(
+        render(&[
+            "--map-syntax=*.customsuffix:Rust",
+            "--file-name=example.customsuffix"
+        ]),
+        render(&["--language=Rust"]),
+    );
+}


### PR DESCRIPTION
Language listings show native extensions as `diff` or `patch` but simple configured mappings as `*.debdiff`, making equivalent extensions look different.

Display simple `*.extension` patterns as extensions in both listing formats and omit duplicates. Keep exact filenames, path patterns, character classes and brace patterns intact. Syntax matching itself is unchanged.

Fixes #2946.

Validation: all 261 integration tests and three new regressions passed. The regressions cover formatted and piped output, native and mapped extensions, compound suffixes, complex patterns, duplicate extensions, and actual syntax selection. All-target/all-feature Clippy, formatting and whitespace checks passed.