### PR TITLE
Stream each input through a separate filter command

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -61,6 +61,8 @@ jobs:
     - uses: actions/checkout@v6
     - run: cargo fmt -- --check
     - run: cargo clippy --locked --all-targets --all-features -- -D warnings
+    - name: Test notebook previews with the host Python interpreter
+      run: cargo test --locked --test input_process notebook_preview -- --ignored
 
   min_version:
     name: Minimum supported rust version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add a notebook preview preprocessor example and document binary string previews with `--process`, see #3967 (@Matei02355)
+
 - Add `--process` to stream each input through a command while retaining its filename and syntax, see #3967 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--process` to stream each input through a command while retaining its filename and syntax, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--process` to stream each input through a command while retaining its filename and syntax, see #0 (@Matei02355)
+- Add `--process` to stream each input through a command while retaining its filename and syntax, see #3967 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/README.md
+++ b/README.md
@@ -745,6 +745,24 @@ alias cat='bat_alias_wrapper'
 ```
 
 
+### Processing inputs
+
+Use `--process` to run a formatter or filter for each file while keeping its
+filename and syntax highlighting:
+
+```bash
+bat --process "python -m json.tool" first.json second.json
+printf '{"answer":42}\n' | bat --process "python -m json.tool" --language=json
+```
+
+Each command reads one input from standard input. Its output is streamed into
+bat, so filters can produce large outputs without buffering the entire result.
+Arguments support shell-style quoting; pipes, redirections and variable
+expansion require an explicit shell command. A process failure makes bat fail,
+and process diagnostics go to standard error. Line numbers, line ranges and
+highlights refer to the processed text. Git change markers are omitted;
+`--diff` and `--lessopen` cannot be combined with `--process`.
+
 ## Configuration file
 
 `bat` can also be customized with a configuration file. The location of the file is dependent

--- a/README.md
+++ b/README.md
@@ -763,6 +763,25 @@ and process diagnostics go to standard error. Line numbers, line ranges and
 highlights refer to the processed text. Git change markers are omitted;
 `--diff` and `--lessopen` cannot be combined with `--process`.
 
+For a Jupyter notebook, the [notebook preview example](examples/notebook-preview.py)
+converts version 4 cells and their saved textual outputs to Markdown. It requires
+Python 3 and never executes cells. Download the script and use its local path:
+
+```bash
+bat --process "python3 /path/to/notebook-preview.py" --language=markdown analysis.ipynb
+```
+
+The preview retains cell order, code, Markdown, stream output, results and error
+tracebacks. Images and other nontext outputs are represented by their MIME types;
+attachments are not rendered. This example reads the complete notebook into memory.
+
+On systems with `strings`, inspect printable strings in executables or other binary
+files without running them. `-a` scans the entire input, including when read from stdin:
+
+```bash
+bat --process "strings -a" --language=txt /path/to/executable
+```
+
 ## Configuration file
 
 `bat` can also be customized with a configuration file. The location of the file is dependent

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -146,6 +146,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--italic-text'           , 'italic-text'           , [CompletionResultType]::ParameterName, 'Use italics in output (always, *never*)')
             [CompletionResult]::new('--decorations'           , 'decorations'           , [CompletionResultType]::ParameterName, 'When to show the decorations (*auto*, never, always).')
             [CompletionResult]::new('--paging'                , 'paging'                , [CompletionResultType]::ParameterName, 'Specify when to use the pager, or use ''-P'' to disable (*auto*, never, always).')
+            [CompletionResult]::new('--process', 'process', [CompletionResultType]::ParameterName, 'Filter each input through a command.')
             [CompletionResult]::new('--pager'                 , 'pager'                 , [CompletionResultType]::ParameterName, 'Determine which pager to use.')
         #   [CompletionResult]::new('-m'                      , 'm'                     , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')
             [CompletionResult]::new('--map-syntax'            , 'map-syntax'            , [CompletionResultType]::ParameterName, 'Use the specified syntax for files matching the glob pattern (''*.cpp:C++'').')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -148,7 +148,7 @@ _bat() {
 		COMPREPLY=($(compgen -W "always never" -- "$cur"))
 		return 0
 		;;
-	--pager)
+	--pager | --process)
 		COMPREPLY=($(compgen -c -- "$cur"))
 		return 0
 		;;
@@ -217,6 +217,7 @@ _bat() {
 			--paging
 			--no-paging
 			--pager
+			--process
 			--map-syntax
 			--ignored-suffix
 			--theme

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,5 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -l process -x -d "Filter each input through a command" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -45,6 +45,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --paging='[specify when to use the pager]:when:(auto never always)'
         '(-P --no-paging)'--no-paging'[alias for --paging=never]'
         --pager='[determine which pager to use]:command:'
+        --process='[filter each input through a command]:command:'
         '(-m --map-syntax)'{-m+,--map-syntax=}'[map a glob pattern to an existing syntax name]: :->syntax-maps'
         --ignored-suffix='[ignore extension]:suffix:'
         '(--theme)'--theme='[set the color theme for syntax highlighting]:theme:->theme_preferences'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -84,6 +84,16 @@ highlights lines 40 to the end of the file
 highlights lines 30 to 40
 .RE
 .HP
+\fB\-\-process\fR <command>
+.IP
+Run a separate filter for each input before displaying it. The command reads
+that input from standard input; its output retains the original filename and
+syntax selection. Arguments use shell-style quoting without implicit shell
+expansion. Standard error is inherited and a failed process makes bat fail.
+For example, \fB\-\-process "python -m json.tool"\fR formats JSON inputs.
+Line numbers and ranges refer to processed output. Git change markers are
+omitted. This option conflicts with \fB\-\-diff\fR and \fB\-\-lessopen\fR.
+.HP
 \fB\-\-file\-name\fR <name>...
 .IP
 Specify the name to display for a file. Useful when piping data to {{PROJECT_EXECUTABLE}} from STDIN when {{PROJECT_EXECUTABLE}} does not otherwise know the filename. Note that the provided file name is also used for syntax detection.

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -52,6 +52,14 @@ Options:
             '--highlight-line 40:' highlights lines 40 to the end of the file
             '--highlight-line 30:+10' highlights lines 30 to 40
 
+      --process <command>
+          Run a separate command for each input, passing that input on its standard input. Display
+          the command's output with the original file name and syntax. Arguments use shell-style
+          quoting; shell operators are not interpreted. For example: --process 'python -m json.tool'
+          data.json. Standard error is inherited, and a failed process makes bat fail. Line ranges
+          and numbers apply to processed output. Git change markers and LESSOPEN preprocessing are
+          not applied to filtered inputs.
+
       --file-name <name>
           Specify the name to display for a file. Useful when piping data to bat from STDIN when bat
           does not otherwise know the filename. Note that the provided file name is also used for

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -21,6 +21,8 @@ Options:
           Set a fallback language for undetected syntaxes. [aliases: --fallback-language]
   -H, --highlight-line <N:M>
           Highlight lines N through M.
+      --process <command>
+          Filter each input through a command before displaying it.
       --file-name <name>
           Specify the name to display for a file.
   -d, --diff

--- a/examples/notebook-preview.py
+++ b/examples/notebook-preview.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Read a version 4 Jupyter notebook from stdin and write a Markdown preview.
+
+Usage: bat --process "python3 /path/to/notebook-preview.py" -l markdown file.ipynb
+Format: https://nbformat.readthedocs.io/en/latest/format_description.html
+Uses only the Python standard library. Cells are never executed.
+"""
+
+import json
+import re
+import sys
+
+
+def multiline(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list) and all(isinstance(part, str) for part in value):
+        return "".join(value)
+    raise ValueError("expected a string or a list of strings")
+
+
+def fenced(text, language="text"):
+    length = max([2] + [len(run) for run in re.findall(r"`+", text)]) + 1
+    fence = "`" * length
+    return f"{fence}{language}\n{text}" + ("" if text.endswith("\n") else "\n") + f"{fence}\n"
+
+
+def object_value(value, description):
+    if not isinstance(value, dict):
+        raise ValueError(f"expected an object for {description}")
+    return value
+
+
+def output_preview(output):
+    output = object_value(output, "cell output")
+    kind = output.get("output_type")
+    if kind == "stream":
+        return fenced(multiline(output.get("text", "")))
+    if kind in ("display_data", "execute_result"):
+        data = object_value(output.get("data", {}), "output data")
+        if "text/plain" in data:
+            return fenced(multiline(data["text/plain"]))
+        if "text/markdown" in data:
+            return multiline(data["text/markdown"])
+        return fenced("[Output: " + (", ".join(sorted(data)) or "empty") + "]")
+    if kind == "error":
+        frames = output.get("traceback", [])
+        if not isinstance(frames, list) or not all(isinstance(frame, str) for frame in frames):
+            raise ValueError("expected a list of strings for traceback")
+        text = "\n".join(frames) if frames else f"{output.get('ename', 'Error')}: {output.get('evalue', '')}"
+        return fenced(text)
+    return fenced(f"[Unsupported output type: {kind}]")
+
+
+def preview(notebook):
+    notebook = object_value(notebook, "notebook")
+    if notebook.get("nbformat") != 4:
+        raise ValueError("only notebook format 4 is supported")
+    cells = notebook.get("cells")
+    if not isinstance(cells, list):
+        raise ValueError("expected a list of cells")
+    metadata = object_value(notebook.get("metadata", {}), "metadata")
+    info = object_value(metadata.get("language_info", {}), "language_info")
+    kernel = object_value(metadata.get("kernelspec", {}), "kernelspec")
+    language = info.get("name", kernel.get("language", "text"))
+    if not isinstance(language, str) or not re.fullmatch(r"[A-Za-z0-9_+.-]+", language):
+        language = "text"
+    sections = []
+    for index, cell in enumerate(cells, 1):
+        cell = object_value(cell, "cell")
+        kind = cell.get("cell_type")
+        source = multiline(cell.get("source", ""))
+        sections.append(f"## Cell {index}\n")
+        if kind == "markdown":
+            sections.append(source)
+        elif kind == "raw":
+            sections.append(fenced(source))
+        elif kind == "code":
+            sections.append(fenced(source, language))
+            outputs = cell.get("outputs", [])
+            if not isinstance(outputs, list):
+                raise ValueError("expected a list of outputs")
+            sections.extend(output_preview(output) for output in outputs)
+        else:
+            sections.append(fenced(f"[Unsupported cell type: {kind}]\n{source}"))
+    return "\n\n".join(section.rstrip("\n") for section in sections) + ("\n" if sections else "")
+
+
+def main():
+    try:
+        # Render fully before writing, so invalid input cannot leave a partial preview.
+        text = preview(json.load(sys.stdin.buffer))
+        sys.stdout.buffer.write(text.encode("utf-8"))
+    except BrokenPipeError:
+        # bat may intentionally stop reading after the requested line range.
+        return 0
+    except (ValueError, RecursionError) as error:
+        print(f"notebook-preview: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -538,6 +538,26 @@ impl App {
     }
 
     pub fn inputs(&self) -> Result<Vec<Input<'_>>> {
+        let command = self
+            .matches
+            .get_one::<crate::process::ProcessCommand>("process");
+        let new_stdin_input = |name| {
+            let input = new_stdin_input(name);
+            if let Some(command) = command {
+                input.with_reader(Box::new(command.reader(None)))
+            } else {
+                input
+            }
+        };
+        let new_file_input = |file, name| {
+            let input = new_file_input(file, name);
+            if let Some(command) = command {
+                input.with_reader(Box::new(command.reader(Some(file))))
+            } else {
+                input
+            }
+        };
+
         let filenames: Option<Vec<&Path>> = self
             .matches
             .get_many::<PathBuf>("file-name")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -151,6 +151,20 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("process")
+                .long("process")
+                .value_name("command")
+                .overrides_with("process")
+                .value_parser(crate::process::ProcessCommand::parse)
+                .help("Filter each input through a command before displaying it.")
+                .long_help("Run a separate command for each input, passing that input on its standard input. \
+                    Display the command's output with the original file name and syntax. Arguments use \
+                    shell-style quoting; shell operators are not interpreted. For example: \
+                    --process 'python -m json.tool' data.json. Standard error is inherited, and a failed \
+                    process makes bat fail. Line ranges and numbers apply to processed output. \
+                    Git change markers and LESSOPEN preprocessing are not applied to filtered inputs."),
+        )
+        .arg(
             Arg::new("file-name")
                 .long("file-name")
                 .action(ArgAction::Append)
@@ -175,6 +189,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                         .overrides_with("diff")
                         .action(ArgAction::SetTrue)
                         .conflicts_with("line-range")
+                        .conflicts_with("process")
                         .help("Only show lines that have been added/removed/modified.")
                         .long_help(
                             "Only show lines that have been added/removed/modified with respect \
@@ -647,6 +662,7 @@ pub fn build_app(interactive_output: bool) -> Command {
             .arg(
                 Arg::new("lessopen")
                     .long("lessopen")
+                    .conflicts_with("process")
                     .action(ArgAction::SetTrue)
                     .help("Enable the $LESSOPEN preprocessor"),
             )

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -8,13 +8,14 @@ mod completions;
 mod config;
 mod directories;
 mod input;
+mod process;
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::io;
 use std::io::{BufReader, Write};
 use std::path::Path;
-use std::process;
+use std::process as std_process;
 
 use bat::output::{OutputHandle, OutputType};
 use nu_ansi_term::Color::Green;
@@ -463,13 +464,13 @@ fn main() {
         Err(error) => {
             let stderr = std::io::stderr();
             default_error_handler(&error, &mut stderr.lock());
-            process::exit(1);
+            std_process::exit(1);
         }
         Ok(false) => {
-            process::exit(1);
+            std_process::exit(1);
         }
         Ok(true) => {
-            process::exit(0);
+            std_process::exit(0);
         }
     }
 }

--- a/src/bin/bat/process.rs
+++ b/src/bin/bat/process.rs
@@ -1,0 +1,134 @@
+//! Lazily run one filter per CLI input without buffering its complete output.
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use clircle::{Clircle, Identifier};
+
+#[derive(Clone)]
+pub struct ProcessCommand(Vec<String>);
+
+impl ProcessCommand {
+    pub fn parse(value: &str) -> Result<Self, String> {
+        let words = shell_words::split(value).map_err(|e| e.to_string())?;
+        if words.first().is_none_or(String::is_empty) {
+            return Err("The process command cannot be empty".into());
+        }
+        Ok(Self(words))
+    }
+
+    pub fn reader(&self, path: Option<&Path>) -> ProcessReader {
+        ProcessReader {
+            command: self.clone(),
+            path: path.map(Path::to_path_buf),
+            child: None,
+            finished: false,
+        }
+    }
+}
+
+pub struct ProcessReader {
+    command: ProcessCommand,
+    path: Option<PathBuf>,
+    child: Option<Child>,
+    finished: bool,
+}
+
+impl ProcessReader {
+    fn start(&mut self) -> io::Result<()> {
+        let stdout = if cfg!(windows) {
+            None
+        } else {
+            Identifier::stdout()
+        };
+        let input = if let Some(path) = &self.path {
+            let display = bat::sanitize_for_terminal(&path.to_string_lossy());
+            let mut file = File::open(path).map_err(|error| {
+                io::Error::new(
+                    error.kind(),
+                    format!("Input process source '{display}': {error}"),
+                )
+            })?;
+            if file.metadata()?.is_dir() {
+                return Err(io::Error::other(format!(
+                    "Input process source '{display}' is a directory"
+                )));
+            }
+            if let Some(stdout) = stdout {
+                let identity = Identifier::try_from(file).map_err(io::Error::other)?;
+                if stdout.surely_conflicts_with(&identity) {
+                    return Err(io::Error::other(
+                        "IO circle detected: the process input is also an output",
+                    ));
+                }
+                file = identity
+                    .into_inner()
+                    .ok_or_else(|| io::Error::other("Lost process input file"))?;
+            }
+            Stdio::from(file)
+        } else {
+            if let Some(stdout) = stdout {
+                let identity =
+                    Identifier::try_from(clircle::Stdio::Stdin).map_err(io::Error::other)?;
+                if stdout.surely_conflicts_with(&identity) {
+                    return Err(io::Error::other(
+                        "IO circle detected: process stdin is also an output",
+                    ));
+                }
+            }
+            Stdio::inherit()
+        };
+        self.child = Some(
+            Command::new(&self.command.0[0])
+                .args(&self.command.0[1..])
+                .stdin(input)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .map_err(|error| {
+                    io::Error::new(
+                        error.kind(),
+                        format!("Could not start input process: {error}"),
+                    )
+                })?,
+        );
+        Ok(())
+    }
+}
+
+impl Read for ProcessReader {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() || self.finished {
+            return Ok(0);
+        }
+        if self.child.is_none() {
+            self.start()?;
+        }
+        let child = self.child.as_mut().unwrap();
+        let count = child.stdout.as_mut().unwrap().read(buffer)?;
+        if count == 0 {
+            let status = child.wait()?;
+            self.finished = true;
+            self.child = None;
+            if !status.success() {
+                return Err(io::Error::other(format!("Input process failed: {status}")));
+            }
+        }
+        Ok(count)
+    }
+}
+
+impl Drop for ProcessReader {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            // A line range or a closed pager may stop reading before EOF.
+            // Do not leave a filter blocked on its output pipe in that case.
+            if !matches!(child.try_wait(), Ok(Some(_))) {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -97,6 +97,7 @@ pub struct Input<'a> {
     pub(crate) kind: InputKind<'a>,
     pub(crate) metadata: InputMetadata,
     pub(crate) description: InputDescription,
+    pub(crate) reader_override: Option<Box<dyn Read + 'a>>,
 }
 
 pub(crate) enum OpenedInputKind {
@@ -143,6 +144,7 @@ impl<'a> Input<'a> {
             description: kind.description(),
             metadata,
             kind,
+            reader_override: None,
         }
     }
 
@@ -152,6 +154,7 @@ impl<'a> Input<'a> {
             description: kind.description(),
             metadata: InputMetadata::default(),
             kind,
+            reader_override: None,
         }
     }
 
@@ -161,7 +164,23 @@ impl<'a> Input<'a> {
             description: kind.description(),
             metadata: InputMetadata::default(),
             kind,
+            reader_override: None,
         }
+    }
+
+    /// Replace the contents while retaining the input's name and source identity.
+    ///
+    /// The original source is not opened. Its size is cleared, and Git change
+    /// markers are disabled because replacement contents may have different lines.
+    pub fn with_reader(mut self, reader: Box<dyn Read + 'a>) -> Self {
+        self.reader_override = Some(reader);
+        self.metadata.size = None;
+        if self.metadata.user_provided_name.is_none() {
+            if let InputKind::OrdinaryFile(path) = &self.kind {
+                self.metadata.user_provided_name = Some(path.clone());
+            }
+        }
+        self
     }
 
     pub fn is_stdin(&self) -> bool {
@@ -195,6 +214,14 @@ impl<'a> Input<'a> {
         stdout_identifier: Option<&Identifier>,
     ) -> Result<OpenedInput<'a>> {
         let description = self.description().clone();
+        if let Some(reader) = self.reader_override {
+            return Ok(OpenedInput {
+                kind: OpenedInputKind::CustomReader,
+                metadata: self.metadata,
+                description,
+                reader: InputReader::try_new(BufReader::new(reader))?,
+            });
+        }
         match self.kind {
             InputKind::StdIn => {
                 if let Some(stdout) = stdout_identifier {

--- a/src/lessopen.rs
+++ b/src/lessopen.rs
@@ -127,6 +127,9 @@ impl LessOpenPreprocessor {
         mut stdin: R,
         stdout_identifier: Option<&Identifier>,
     ) -> Result<OpenedInput<'a>> {
+        if input.reader_override.is_some() {
+            return input.open(stdin, stdout_identifier);
+        }
         let (lessopen_stdout, path_str, kind) = match input.kind {
             InputKind::OrdinaryFile(ref path) => {
                 let path_str = match path.to_str() {

--- a/tests/examples/notebook-preview.ipynb
+++ b/tests/examples/notebook-preview.ipynb
@@ -1,0 +1,70 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Notebook café\n",
+        "Saved analysis"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print('hello')\n",
+        "# embedded ``` fence\n"
+      ],
+      "metadata": {},
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "hello ",
+            "world\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 1,
+          "data": {
+            "text/plain": [
+              "42\n"
+            ],
+            "text/html": "<b>42</b>"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "not-decoded"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "error",
+          "ename": "ValueError",
+          "evalue": "bad",
+          "traceback": [
+            "Traceback line 1",
+            "ValueError: bad"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "raw",
+      "source": "raw ``` fence",
+      "metadata": {}
+    }
+  ]
+}

--- a/tests/input_process.rs
+++ b/tests/input_process.rs
@@ -24,6 +24,7 @@ fn notebook_filter() -> String {
 
 #[test]
 #[cfg(unix)]
+#[ignore = "requires Python 3; the host CI job runs notebook previews explicitly"]
 fn notebook_preview_preserves_cells_outputs_and_embedded_fences() {
     let expected = "## Cell 1\n\n# Notebook café\nSaved analysis\n\n## Cell 2\n\n````python\nprint('hello')\n# embedded ``` fence\n````\n\n```text\nhello world\n```\n\n```text\n42\n```\n\n```text\n[Output: image/png]\n```\n\n```text\nTraceback line 1\nValueError: bad\n```\n\n## Cell 3\n\n````text\nraw ``` fence\n````\n";
     bat()
@@ -43,6 +44,7 @@ fn notebook_preview_preserves_cells_outputs_and_embedded_fences() {
 
 #[test]
 #[cfg(unix)]
+#[ignore = "requires Python 3; the host CI job runs notebook previews explicitly"]
 fn notebook_preview_handles_missing_metadata_and_invalid_inputs() {
     use predicates::prelude::*;
 

--- a/tests/input_process.rs
+++ b/tests/input_process.rs
@@ -1,0 +1,236 @@
+mod utils;
+
+#[cfg(unix)]
+use std::time::Duration;
+use utils::command::bat;
+
+fn child_bat(args: &str) -> String {
+    format!(
+        "{} --no-config --paging=never {args}",
+        shell_words::quote(env!("CARGO_BIN_EXE_bat"))
+    )
+}
+
+#[test]
+fn filters_run_per_file_and_retain_names_and_syntax() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = dir.path().join("first file.json");
+    let second = dir.path().join("second.json");
+    std::fs::write(&first, "{}\n").unwrap();
+    std::fs::write(&second, "[]\n").unwrap();
+    let output = bat()
+        .args([
+            "--decorations=always",
+            "--style=header",
+            "--color=always",
+            "--process",
+        ])
+        .arg(child_bat("--color=never --style=plain"))
+        .args([&first, &second])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains("first file.json"), "{text:?}");
+    assert!(text.contains("second.json"), "{text:?}");
+    assert!(text.contains("\x1b["), "{text:?}");
+    assert_eq!(std::fs::read_to_string(first).unwrap(), "{}\n");
+    let numbered = bat()
+        .args(["--color=never", "--style=plain", "--process"])
+        .arg(child_bat(
+            "--color=never --decorations=always --style=numbers",
+        ))
+        .args([&second, &second])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(numbered, b"   1 []\n   1 []\n");
+}
+
+#[test]
+fn stdin_and_explicit_names_are_filtered() {
+    bat()
+        .args(["--color=never", "--style=plain", "--process"])
+        .arg(child_bat(
+            "--color=never --decorations=always --style=numbers",
+        ))
+        .args(["-", "-"])
+        .write_stdin("one\ntwo\n")
+        .assert()
+        .success()
+        .stdout("   1 one\n   2 two\n");
+    let output = bat()
+        .args([
+            "--color=never",
+            "--style=header",
+            "--decorations=always",
+            "--file-name=logical.json",
+            "--process",
+        ])
+        .arg(child_bat("--color=never --style=plain"))
+        .write_stdin("{}\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(String::from_utf8(output).unwrap().contains("logical.json"));
+}
+
+#[test]
+fn invalid_commands_missing_files_and_directories_fail_without_content() {
+    for command in [
+        "",
+        "''",
+        "'unterminated",
+        "bat-no-such-process-command-2289",
+    ] {
+        bat()
+            .args(["--process", command])
+            .write_stdin("source\n")
+            .assert()
+            .failure()
+            .stdout("");
+    }
+    let dir = tempfile::tempdir().unwrap();
+    for input in [dir.path().to_path_buf(), dir.path().join("missing-file")] {
+        bat()
+            .arg("--process")
+            .arg(child_bat("--style=plain"))
+            .arg(input)
+            .assert()
+            .failure()
+            .stdout("");
+    }
+}
+
+#[test]
+fn replacing_contents_preserves_library_input_identity() {
+    let input = bat::input::Input::stdin().with_reader(Box::new(&b"replacement\n"[..]));
+    assert!(input.is_stdin());
+    assert_eq!(input.description().title(), "STDIN");
+    let input =
+        bat::input::Input::ordinary_file("nonexistent.json").with_reader(Box::new(&b"{}\n"[..]));
+    assert!(!input.is_stdin());
+    let mut output = String::new();
+    let config = bat::config::Config {
+        loop_through: true,
+        ..Default::default()
+    };
+    let assets = bat::assets::HighlightingAssets::from_binary();
+    assert!(bat::controller::Controller::new(&config, &assets)
+        .run(
+            vec![input],
+            Some(&mut bat::output::OutputHandle::FmtWrite(&mut output))
+        )
+        .unwrap());
+    assert_eq!(output, "{}\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn process_failures_and_stderr_are_reported() {
+    bat()
+        .args(["--process", "sh -c 'printf warning >&2; exit 7'"])
+        .write_stdin("source\n")
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicates::str::contains("warning"));
+    bat()
+        .args(["--process", "sh -c 'exit 0'"])
+        .write_stdin("source\n")
+        .assert()
+        .success()
+        .stdout("");
+    // The command is split into arguments, not evaluated by a shell.
+    bat()
+        .args([
+            "--style=plain",
+            "--color=never",
+            "--process",
+            "printf '%s' '$HOME; | literal'",
+        ])
+        .write_stdin("")
+        .assert()
+        .success()
+        .stdout("$HOME; | literal");
+}
+
+#[cfg(unix)]
+#[test]
+fn stopping_at_a_line_range_terminates_and_reaps_the_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let pid_path = dir.path().join("pid");
+    let script = format!(
+        "printf '%s' \"$$\" > {}; while :; do printf 'line\\n'; done",
+        shell_words::quote(pid_path.to_str().unwrap())
+    );
+    let command = format!("sh -c {}", shell_words::quote(&script));
+    bat()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "--process",
+            &command,
+            "--line-range=1:1",
+            "--style=plain",
+            "--color=never",
+        ])
+        .write_stdin("")
+        .assert()
+        .success()
+        .stdout("line\n");
+    let pid = std::fs::read_to_string(pid_path).unwrap();
+    let result = std::process::Command::new("kill")
+        .args(["-0", pid.trim()])
+        .stderr(std::process::Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!result.success(), "filter process {pid} was left running");
+}
+
+#[cfg(unix)]
+#[test]
+fn filters_detect_input_output_cycles() {
+    use std::fs::OpenOptions;
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("source");
+    std::fs::write(&file, "source\n").unwrap();
+    let output = utils::command::bat_raw_command()
+        .args(["--process", "cat"])
+        .arg(&file)
+        .stdout(OpenOptions::new().append(true).open(&file).unwrap())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8(output.stderr)
+        .unwrap()
+        .contains("IO circle detected"));
+    assert_eq!(std::fs::read_to_string(file).unwrap(), "source\n");
+}
+
+#[cfg(feature = "git")]
+#[test]
+fn process_and_diff_cannot_be_combined() {
+    bat()
+        .args(["--process", "cat", "--diff"])
+        .write_stdin("source\n")
+        .assert()
+        .failure()
+        .stdout("");
+}
+
+#[cfg(feature = "lessopen")]
+#[test]
+fn process_and_lessopen_cannot_be_combined() {
+    bat()
+        .args(["--process", "cat", "--lessopen"])
+        .write_stdin("source\n")
+        .assert()
+        .failure()
+        .stdout("");
+}

--- a/tests/input_process.rs
+++ b/tests/input_process.rs
@@ -11,6 +11,120 @@ fn child_bat(args: &str) -> String {
     )
 }
 
+#[cfg(unix)]
+fn notebook_filter() -> String {
+    format!(
+        "python3 {}",
+        shell_words::quote(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/examples/notebook-preview.py"
+        ))
+    )
+}
+
+#[test]
+#[cfg(unix)]
+fn notebook_preview_preserves_cells_outputs_and_embedded_fences() {
+    let expected = "## Cell 1\n\n# Notebook café\nSaved analysis\n\n## Cell 2\n\n````python\nprint('hello')\n# embedded ``` fence\n````\n\n```text\nhello world\n```\n\n```text\n42\n```\n\n```text\n[Output: image/png]\n```\n\n```text\nTraceback line 1\nValueError: bad\n```\n\n## Cell 3\n\n````text\nraw ``` fence\n````\n";
+    bat()
+        .args([
+            "--process",
+            &notebook_filter(),
+            "--language=markdown",
+            "--style=plain",
+            "--color=never",
+            "notebook-preview.ipynb",
+        ])
+        .assert()
+        .success()
+        .stdout(expected)
+        .stderr("");
+}
+
+#[test]
+#[cfg(unix)]
+fn notebook_preview_handles_missing_metadata_and_invalid_inputs() {
+    use predicates::prelude::*;
+
+    bat()
+        .args([
+            "--process",
+            &notebook_filter(),
+            "--language=markdown",
+            "--style=plain",
+            "--color=never",
+        ])
+        .write_stdin(r#"{"nbformat":4,"cells":[{"cell_type":"code","source":"x"}]}"#)
+        .assert()
+        .success()
+        .stdout("## Cell 1\n\n```text\nx\n```\n")
+        .stderr("");
+    for invalid in [
+        "{",
+        r#"{"nbformat":3,"cells":[]}"#,
+        r#"{"nbformat":4,"cells":{}}"#,
+        r#"{"nbformat":4,"cells":[{"cell_type":"markdown","source":"valid first cell"},{"cell_type":"code","source":[7]}]}"#,
+    ] {
+        bat()
+            .args([
+                "--process",
+                &notebook_filter(),
+                "--style=plain",
+                "--color=never",
+            ])
+            .write_stdin(invalid)
+            .assert()
+            .failure()
+            .stdout("")
+            .stderr(predicate::str::contains("notebook-preview:"));
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn binary_strings_filter_reads_bytes_without_executing_the_input() {
+    use predicates::prelude::*;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("binary input");
+    std::fs::write(
+        &file,
+        b"\x7fELF\0\x01\x02printable payload\0\xff\0second marker\0",
+    )
+    .unwrap();
+    bat()
+        .args([
+            "--process",
+            "strings -a",
+            "--language=txt",
+            "--decorations=always",
+            "--style=header",
+            "--terminal-width=200",
+            "--color=never",
+        ])
+        .arg(&file)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("binary input")
+                .and(predicate::str::contains("printable payload\n"))
+                .and(predicate::str::contains("second marker\n")),
+        )
+        .stderr("");
+    bat()
+        .args([
+            "--process",
+            "strings -a",
+            "--language=txt",
+            "--style=plain",
+            "--color=never",
+        ])
+        .write_stdin(b"\0stdin marker\0" as &[u8])
+        .assert()
+        .success()
+        .stdout("stdin marker\n");
+}
+
 #[test]
 fn filters_run_per_file_and_retain_names_and_syntax() {
     let dir = tempfile::tempdir().unwrap();
@@ -22,6 +136,7 @@ fn filters_run_per_file_and_retain_names_and_syntax() {
         .args([
             "--decorations=always",
             "--style=header",
+            "--terminal-width=200",
             "--color=always",
             "--process",
         ])
@@ -67,6 +182,7 @@ fn stdin_and_explicit_names_are_filtered() {
         .args([
             "--color=never",
             "--style=header",
+            "--terminal-width=200",
             "--decorations=always",
             "--file-name=logical.json",
             "--process",


### PR DESCRIPTION
Formatting input with a pipeline loses per-file identity and makes it awkward to display multiple formatted files together.

Add `--process <command>`, for example `bat --process "python -m json.tool" first.json second.json`. Each input starts its own filter only when read. File handles or stdin feed the filter directly, and stdout streams into bat without buffering the complete result. Original names and syntax selection are retained. Arguments use shell-style quoting without implicit shell evaluation.

Process stderr is inherited and a nonzero exit makes bat fail. Early termination closes and reaps the direct filter process; input/output cycles are rejected. Line ranges and highlights address processed output. Git markers are omitted, and `--diff`/`--lessopen` combinations are rejected. An Input::with_reader API preserves input identity while replacing its contents and clears its original size.

The included Python standard-library example converts version 4 Jupyter notebooks into Markdown with cells and saved textual outputs in order, including tracebacks and safe code fences. It never executes cells. A documented `strings -a` filter also previews binary contents while preserving source names.

Fixes #2289. Fixes #2191. Fixes #3007. Fixes #1554.

Validation: the full default suite passed (458 tests, five ignored). With LESSOPEN enabled, 158 library tests and nine process/library regressions passed. The regressions cover separate per-file invocation, names, stdin, repeated stdin, invalid commands, argument quoting, process failures, stderr, empty output, input/output cycles, early termination/reaping, and incompatible options. Eleven minimal-application tests and a library-only build passed. All-target/all-feature Clippy, formatting, Bash/Zsh syntax and whitespace checks passed. README, manual, help and four completions updated.

Follow-up validation: all 12 process/library tests passed with LESSOPEN, including notebook output, malformed input, binary strings and stdin. All-target/all-feature Clippy passed. The macOS CI failure came from long temporary paths wrapping inside a filename assertion; these tests now set an explicit width, and a long temporary-directory regression run passed.

The optional Python example is tested explicitly in the host code-quality job. Cross containers do not contain Python, so the two notebook tests are excluded from the generic Rust suite and run with `cargo test --test input_process notebook_preview -- --ignored` on the host. Both explicit notebook tests and all ten remaining LESSOPEN process tests passed locally; Clippy passed.