### PR TITLE
Run Windows test matrix directly in PowerShell

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -243,15 +243,17 @@ jobs:
         unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--lib --bin ${{ needs.crate_metadata.outputs.name }}" ;; esac;
         echo "CARGO_TEST_OPTIONS=${CARGO_TEST_OPTIONS}" >> $GITHUB_OUTPUT
 
-    - name: Run tests
+    - name: Run tests (Unix)
+      if: runner.os != 'Windows'
       shell: bash
+      run: $BUILD_CMD test --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
+
+    - name: Run tests (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
       run: |
-        if [[ ${{ matrix.job.os }} = windows-* ]]
-        then
-          powershell.exe -command "$BUILD_CMD test --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}"
-        else
-          $BUILD_CMD test --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
-        fi
+        & $env:BUILD_CMD test --locked --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
+        exit $LASTEXITCODE
 
     - name: Run bat
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Other
 
+- Run Windows tests directly in PowerShell so Git Bash does not mask missing native commands, see #0 (@Matei02355)
+
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Other
 
-- Run Windows tests directly in PowerShell so Git Bash does not mask missing native commands, see #0 (@Matei02355)
+- Run Windows tests directly in PowerShell so Git Bash does not mask missing native commands, see #3970 (@Matei02355)
 
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536


### PR DESCRIPTION
Windows tests are launched from Git Bash, which starts powershell.exe with its inherited PATH. This can expose Unix tools such as echo.exe to tests that fail in a normal PowerShell session, masking the problem reported in #2664.

Split the test step by runner OS and run Windows targets directly with the native pwsh shell. Invoke the selected build command with PowerShell's call operator and explicitly return the native command's exit code. Unix targets retain their Bash invocation, and target-specific test options remain unchanged.

Validation: parsed the workflow YAML and checked the diff. Native Windows behavior is exercised by this PR's Windows matrix jobs.

Fixes #2664.