### PR TITLE
Support optional TOML configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Accept optional TOML configuration files while preserving existing config-file precedence, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Accept optional TOML configuration files while preserving existing config-file precedence, see #0 (@Matei02355)
+- Accept optional TOML configuration files while preserving existing config-file precedence, see #3971 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ minimal-application = [
     "paging",
     "regex-onig",
     "wild",
+    "toml",
 ]
 git = ["gix"] # Support indicating git modifications
 paging = [ "shell-words", "grep-cli", "minus"] # Support applying a pager on the output
@@ -41,6 +42,7 @@ regex-onig = ["syntect/regex-onig"] # Use the "oniguruma" regex engine
 regex-fancy = ["syntect/regex-fancy"] # Use the rust-only "fancy-regex" engine
 
 [dependencies]
+toml = { version = "1.1.1", features = ["preserve_order"], optional = true }
 nu-ansi-term = "0.50.3"
 ansi_colours = "^1.2"
 bincode = "1.0"

--- a/README.md
+++ b/README.md
@@ -771,9 +771,32 @@ file is present, the content of the user configuration will simply be appended t
 
 ### Format
 
-The configuration file is a simple list of command line arguments. Use `bat --help` to see a full list of possible options and values. In addition, you can add comments by prepending a line with the `#` character.
+The extensionless `config` file is a simple list of command line arguments. Use `bat --help` to see a full list of possible options and values. In addition, you can add comments by prepending a line with the `#` character.
 
-Example configuration file:
+Alternatively, create `config.toml` in the same configuration directory. It is used
+when the extensionless `config` file is absent, for both user and system
+configuration. `BAT_CONFIG_PATH` always selects the exact file; a `.toml`
+extension selects TOML parsing. Existing configuration files keep their priority.
+
+TOML keys use the long option names without `--`. Strings and integers supply
+option values, arrays repeat an option, and `true` enables a flag. `false` omits
+that flag from the file; it does not undo a flag from another configuration source.
+Counted flags such as `plain` also accept an integer (`plain = 2` means `-pp`).
+Options are applied in file order. Environment settings and command-line options
+keep their usual precedence over file settings.
+
+```toml
+theme = "TwoDark"
+style = "numbers,changes"
+tabs = 4
+paging = "never"
+map-syntax = ["*.ino:C++", ".ignore:Git Ignore"]
+```
+
+To generate a commented TOML template at a chosen location, set `BAT_CONFIG_PATH`
+to a `.toml` file before running `bat --generate-config-file`.
+
+Example extensionless `config` file:
 ```bash
 # Set the theme to "TwoDark"
 --theme="TwoDark"

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -323,6 +323,14 @@ is dependent on your operating system. To get the default path for your system, 
 Alternatively, you can use the BAT_CONFIG_PATH environment variable to point {{PROJECT_EXECUTABLE}} to a non-default
 location of the configuration file.
 
+If the extensionless config file is absent, config.toml in the same directory is
+used instead. This applies to both system and user configuration. An explicit
+BAT_CONFIG_PATH selects that exact file; the .toml extension selects TOML parsing.
+TOML keys are long option names without the leading dashes. Strings and integers
+supply values, arrays repeat options, and true enables a flag. False omits a flag
+from that file and does not cancel settings from other sources. Counted flags
+also accept integers, for example plain = 2 is equivalent to -pp.
+
 To generate a default configuration file, call:
 
 \fB{{PROJECT_EXECUTABLE}} --generate-config-file\fR

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -237,7 +237,7 @@ impl App {
         let mut args = if help_requested {
             config_args.unwrap_or_default()
         } else {
-            config_args.map_err(|_| "Could not parse configuration file")?
+            config_args?
         };
 
         // Selected env vars supersede config vars

--- a/src/bin/bat/config.rs
+++ b/src/bin/bat/config.rs
@@ -17,16 +17,29 @@ pub fn system_config_file() -> PathBuf {
     let mut path = PathBuf::from(folder);
 
     path.push("bat");
-    path.push("config");
-
-    path
+    config_in_directory(&path)
 }
 
 pub fn config_file() -> PathBuf {
     env::var("BAT_CONFIG_PATH")
         .ok()
         .map(PathBuf::from)
-        .unwrap_or_else(|| PROJECT_DIRS.config_dir().join("config"))
+        .unwrap_or_else(|| config_in_directory(PROJECT_DIRS.config_dir()))
+}
+
+fn config_in_directory(directory: &Path) -> PathBuf {
+    let legacy = directory.join("config");
+    let toml = directory.join("config.toml");
+    if !legacy.exists() && toml.is_file() {
+        toml
+    } else {
+        legacy
+    }
+}
+
+fn is_toml(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("toml"))
 }
 
 pub fn generate_config_file() -> bat::error::Result<()> {
@@ -86,6 +99,18 @@ pub fn generate_config_file() -> bat::error::Result<()> {
 #--map-syntax ".ignore:Git Ignore"
 "#;
 
+    let default_config = if is_toml(&config_file) {
+        "# Options use their long command-line names.\n\
+         # String and integer values are passed as option values.\n\
+         # Arrays repeat an option; true enables a flag and false omits it.\n\n\
+         # theme = \"TwoDark\"\n\
+         # italic-text = \"always\"\n\
+         # paging = \"never\"\n\
+         # map-syntax = [\"*.ino:C++\", \".ignore:Git Ignore\"]\n"
+    } else {
+        default_config
+    };
+
     fs::write(&config_file, default_config).map_err(|e| {
         format!(
             "Failed to create config file at '{}': {e}",
@@ -101,26 +126,86 @@ pub fn generate_config_file() -> bat::error::Result<()> {
     Ok(())
 }
 
-pub fn get_args_from_config_file() -> Result<Vec<OsString>, shell_words::ParseError> {
-    let mut config = String::new();
-
+pub fn get_args_from_config_file() -> bat::error::Result<Vec<OsString>> {
     let system_config = system_config_file();
     let user_config = config_file();
 
-    if let Ok(c) = fs::read_to_string(&system_config) {
-        config.push_str(&c);
-        config.push('\n');
-    }
+    let mut args = read_config(&system_config)?;
 
     // Skip the user config if it resolves to the same file as the system config,
     // which can happen when BAT_CONFIG_DIR is set to e.g. "/etc/bat". See #3589.
     if !same_file(&system_config, &user_config) {
-        if let Ok(c) = fs::read_to_string(&user_config) {
-            config.push_str(&c);
+        args.extend(read_config(&user_config)?);
+    }
+    Ok(args)
+}
+
+fn read_config(path: &Path) -> bat::error::Result<Vec<OsString>> {
+    let Ok(content) = fs::read_to_string(path) else {
+        return Ok(Vec::new());
+    };
+    let result = if is_toml(path) {
+        get_args_from_toml(&content)
+    } else {
+        get_args_from_str(&content).map_err(|error| error.to_string())
+    };
+    result.map_err(|error| {
+        format!(
+            "Could not parse configuration file '{}': {error}",
+            path.display()
+        )
+        .into()
+    })
+}
+
+fn get_args_from_toml(content: &str) -> Result<Vec<OsString>, String> {
+    let table: toml::Table = toml::from_str(content).map_err(|error| format!("{error}"))?;
+    let command = crate::clap_app::build_app(false);
+    let mut args = Vec::new();
+    for (key, value) in table {
+        let option = command
+            .get_arguments()
+            .find(|arg| arg.get_long() == Some(key.as_str()))
+            .ok_or_else(|| format!("Unknown option '{key}'"))?;
+        match option.get_action() {
+            clap::ArgAction::SetTrue => match value {
+                toml::Value::Boolean(true) => args.push(format!("--{key}").into()),
+                toml::Value::Boolean(false) => {}
+                _ => return Err(format!("Option '{key}' requires a boolean")),
+            },
+            clap::ArgAction::Count => {
+                let count = match value {
+                    toml::Value::Boolean(enabled) => u8::from(enabled),
+                    toml::Value::Integer(count) => u8::try_from(count)
+                        .map_err(|_| format!("Option '{key}' requires a count from 0 to 255"))?,
+                    _ => return Err(format!("Option '{key}' requires a boolean or count")),
+                };
+                args.extend(std::iter::repeat_n(
+                    OsString::from(format!("--{key}")),
+                    count.into(),
+                ));
+            }
+            _ => {
+                let values = match value {
+                    toml::Value::Array(values) => values,
+                    value => vec![value],
+                };
+                for value in values {
+                    let value = match value {
+                        toml::Value::String(value) => value,
+                        toml::Value::Integer(value) => value.to_string(),
+                        _ => {
+                            return Err(format!(
+                            "Option '{key}' requires a string, integer, or array of these values"
+                        ))
+                        }
+                    };
+                    args.push(format!("--{key}={value}").into());
+                }
+            }
         }
     }
-
-    get_args_from_str(&config)
+    Ok(args)
 }
 
 fn same_file(a: &Path, b: &Path) -> bool {
@@ -130,8 +215,10 @@ fn same_file(a: &Path, b: &Path) -> bool {
     }
 }
 
-pub fn get_args_from_env_opts_var() -> Option<Result<Vec<OsString>, shell_words::ParseError>> {
-    env::var("BAT_OPTS").ok().map(|s| get_args_from_str(&s))
+pub fn get_args_from_env_opts_var() -> Option<bat::error::Result<Vec<OsString>>> {
+    env::var("BAT_OPTS").ok().map(|s| {
+        get_args_from_str(&s).map_err(|error| format!("Could not parse BAT_OPTS: {error}").into())
+    })
 }
 
 fn get_args_from_str(content: &str) -> Result<Vec<OsString>, shell_words::ParseError> {

--- a/tests/toml_config.rs
+++ b/tests/toml_config.rs
@@ -1,0 +1,185 @@
+mod utils;
+
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+use utils::command::bat_with_config as unformatted_bat;
+
+fn bat_with_config() -> assert_cmd::Command {
+    let mut command = unformatted_bat();
+    command.arg("--decorations=always");
+    command
+}
+
+fn configuration(content: &str) -> TempDir {
+    let directory = tempfile::tempdir().unwrap();
+    fs::write(directory.path().join("config.toml"), content).unwrap();
+    directory
+}
+
+#[test]
+fn toml_config_and_environment_and_cli_precedence() {
+    let directory = configuration("style = 'plain'\npaging = 'never'\ntabs = 2\n");
+    for (env, cli, expected) in [
+        (None, None, 2),
+        (Some("4"), None, 4),
+        (Some("4"), Some("6"), 6),
+    ] {
+        let mut command = bat_with_config();
+        command.env("BAT_CONFIG_DIR", directory.path());
+        if let Some(value) = env {
+            command.env("BAT_TABS", value);
+        }
+        if let Some(value) = cli {
+            command.args(["--tabs", value]);
+        }
+        command
+            .write_stdin("\ttext\n")
+            .assert()
+            .success()
+            .stdout(format!("{}text\n", " ".repeat(expected)));
+    }
+}
+
+#[test]
+fn legacy_config_takes_precedence_over_toml_fallback() {
+    let directory = configuration("style = 'plain'\ntabs = 2\n");
+    bat_with_config()
+        .env("BAT_CONFIG_DIR", directory.path())
+        .arg("--config-file")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("config.toml"));
+    fs::write(directory.path().join("config"), "--style=plain\n--tabs=3\n").unwrap();
+    bat_with_config()
+        .env("BAT_CONFIG_DIR", directory.path())
+        .write_stdin("\tx\n")
+        .assert()
+        .success()
+        .stdout("   x\n");
+    bat_with_config()
+        .env("BAT_CONFIG_DIR", directory.path())
+        .env("BAT_CONFIG_PATH", directory.path().join("config.toml"))
+        .write_stdin("\tx\n")
+        .assert()
+        .success()
+        .stdout("  x\n");
+}
+
+#[test]
+fn toml_values_are_literal_and_arrays_repeat_mappings() {
+    let directory = configuration("style = 'plain'\ncolor = 'always'\ntheme = 'ansi'\nmap-syntax = ['*.one:JSON', '*.two:JSON']\nfile-name = 'name with # spaces.one'\n");
+    let expected = bat_with_config()
+        .args([
+            "--no-config",
+            "--style=plain",
+            "--color=always",
+            "--theme=ansi",
+            "--language=JSON",
+        ])
+        .write_stdin("{\"value\": 1}\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    for filename in [None, Some("other file.two")] {
+        let mut command = bat_with_config();
+        command.env("BAT_CONFIG_DIR", directory.path());
+        if let Some(filename) = filename {
+            command.args(["--file-name", filename]);
+        }
+        command
+            .write_stdin("{\"value\": 1}\n")
+            .assert()
+            .success()
+            .stdout(expected.clone());
+    }
+}
+
+#[test]
+fn flags_and_count_options_work_in_toml() {
+    let directory = configuration("number = true\nplain = 2\nshow-all = false\n");
+    bat_with_config()
+        .env("BAT_CONFIG_DIR", directory.path())
+        .write_stdin("one\ntwo\n")
+        .assert()
+        .success()
+        .stdout("one\ntwo\n");
+    fs::write(
+        directory.path().join("config.toml"),
+        "plain = true\nnumber = true\n",
+    )
+    .unwrap();
+    bat_with_config()
+        .env("BAT_CONFIG_DIR", directory.path())
+        .args(["--decorations=always"])
+        .write_stdin("one\ntwo\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 one").and(predicate::str::contains("2 two")));
+}
+
+#[test]
+fn invalid_toml_reports_the_source_and_setting_but_help_still_works() {
+    for (content, message) in [
+        ("tabs = [", "TOML"),
+        ("unknown-setting = 1", "unknown-setting"),
+        ("show-all = 'yes'", "requires a boolean"),
+        ("plain = -1", "count from 0 to 255"),
+        ("tabs = { nested = 2 }", "requires a string"),
+    ] {
+        let directory = configuration(content);
+        bat_with_config()
+            .env("BAT_CONFIG_DIR", directory.path())
+            .write_stdin("text\n")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("config.toml").and(predicate::str::contains(message)));
+        bat_with_config()
+            .env("BAT_CONFIG_DIR", directory.path())
+            .arg("--help")
+            .assert()
+            .success();
+    }
+}
+
+#[test]
+fn bat_opts_and_no_config_bypass_toml() {
+    let directory = configuration("invalid = true");
+    bat_with_config()
+        .env("BAT_CONFIG_DIR", directory.path())
+        .env("BAT_OPTS", "--style=plain --tabs=3")
+        .write_stdin("\tx\n")
+        .assert()
+        .success()
+        .stdout("   x\n");
+    bat_with_config()
+        .env("BAT_CONFIG_DIR", directory.path())
+        .args(["--no-config", "--style=plain", "--tabs=4"])
+        .write_stdin("\tx\n")
+        .assert()
+        .success()
+        .stdout("    x\n");
+}
+
+#[test]
+fn generated_toml_is_valid_and_readable() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = directory.path().join("custom.TOML");
+    bat_with_config()
+        .env("BAT_CONFIG_PATH", &config)
+        .arg("--generate-config-file")
+        .assert()
+        .success();
+    let content = fs::read_to_string(&config).unwrap();
+    content.parse::<toml::Table>().unwrap();
+    assert!(content.contains("# map-syntax = ["));
+    bat_with_config()
+        .env("BAT_CONFIG_PATH", &config)
+        .args(["--style=plain", "--paging=never"])
+        .write_stdin("hello\n")
+        .assert()
+        .success()
+        .stdout("hello\n");
+}


### PR DESCRIPTION
The extensionless configuration format cannot be recognized reliably by editors. Add config.toml as an optional fallback in system and user configuration directories, with the existing config file retaining priority. BAT_CONFIG_PATH still selects an exact file and a .toml extension selects TOML parsing.

Keys use existing long option names. Strings and integers supply values, arrays repeat options, booleans enable or omit flags, and counted flags accept integers. Parsing preserves file order and literal values without shell splitting. Existing environment and command-line precedence remains intact. TOML errors identify the source file and setting, help remains available with invalid configuration, and --generate-config-file emits a TOML template for a .toml destination.

Validation: all 458 tests passed, including seven new process tests for precedence, legacy fallback, explicit paths, mappings and literal values, booleans and counts, invalid settings, bypasses, and template generation. All-target/all-feature Clippy, formatting, minimal-application, and library-only checks passed.

Fixes #3203.