### PR TITLE
Use standard Debian architectures for musl packages

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -161,19 +161,19 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { target: aarch64-unknown-linux-musl  , os: ubuntu-latest , dpkg_arch: musl-linux-arm64, use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-latest , dpkg_arch: arm64           , use-cross: true }
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , dpkg_arch: arm64,            use-cross: true }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , dpkg_arch: armhf,            use-cross: true }
-          - { target: arm-unknown-linux-musleabihf, os: ubuntu-latest , dpkg_arch: musl-linux-armhf, use-cross: true }
+          - { target: arm-unknown-linux-musleabihf, os: ubuntu-latest , dpkg_arch: armhf           , use-cross: true }
           - { target: i686-pc-windows-msvc        , os: windows-2025  ,                                              }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-latest , dpkg_arch: i386,             use-cross: true }
-          - { target: i686-unknown-linux-musl     , os: ubuntu-latest , dpkg_arch: musl-linux-i686,  use-cross: true }
+          - { target: i686-unknown-linux-musl     , os: ubuntu-latest , dpkg_arch: i386          ,  use-cross: true }
           - { target: x86_64-apple-darwin         , os: macos-15-intel,                                              }
           - { target: aarch64-apple-darwin        , os: macos-latest  ,                                              }
           - { target: x86_64-pc-windows-msvc      , os: windows-2025  ,                                              }
           - { target: aarch64-pc-windows-msvc     , os: windows-11-arm,                                              }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest , dpkg_arch: amd64,            use-cross: true }
-          - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest , dpkg_arch: musl-linux-amd64, use-cross: true }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest , dpkg_arch: amd64           , use-cross: true }
     env:
       BUILD_CMD: cargo
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Other
 
-- Use standard Debian architectures for musl packages so installation does not require forcing the architecture, see #0 (@Matei02355)
+- Use standard Debian architectures for musl packages so installation does not require forcing the architecture, see #3972 (@Matei02355)
 
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Other
 
+- Use standard Debian architectures for musl packages so installation does not require forcing the architecture, see #0 (@Matei02355)
+
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)


### PR DESCRIPTION
The musl Debian packages set Architecture to values such as musl-linux-amd64. dpkg does not identify an amd64 Ubuntu system by that value, so installing the package requires --force-architecture.

Use amd64, i386, armhf, and arm64 in the musl matrix entries. The bat-musl package name continues to distinguish musl builds and keeps the existing conflict with the bat package. Generated filenames now use the same standard architecture values as the control metadata.

Validation: parsed the workflow; verified every Debian matrix architecture against dpkg-architecture's known architecture list; built and inspected a minimal Debian package for each of the four musl targets to confirm the resulting Architecture field. The release workflow builds the full packages.

Fixes #3173.