### PR TITLE
Publish stable download aliases for release assets

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -318,6 +318,11 @@ jobs:
         esac;
         popd >/dev/null
 
+        # Keep the versioned archive and add a stable name for /releases/latest/download.
+        PKG_ALIAS="${{ needs.crate_metadata.outputs.name }}-${{ matrix.job.target }}${PKG_suffix}"
+        cp "${PKG_STAGING}/${PKG_NAME}" "${PKG_STAGING}/${PKG_ALIAS}"
+        echo "PKG_ALIAS_PATH=${PKG_STAGING}/${PKG_ALIAS}" >> $GITHUB_OUTPUT
+
         # Let subsequent steps know where to find the compressed package
         echo "PKG_PATH=${PKG_STAGING}/${PKG_NAME}" >> $GITHUB_OUTPUT
 
@@ -421,18 +426,26 @@ jobs:
         # build dpkg
         fakeroot dpkg-deb --build "${DPKG_DIR}" "${DPKG_PATH}"
 
+        DPKG_ALIAS_PATH="${DPKG_STAGING}/${DPKG_BASENAME}_${DPKG_ARCH}.deb"
+        cp "${DPKG_PATH}" "${DPKG_ALIAS_PATH}"
+        echo "DPKG_ALIAS_PATH=${DPKG_ALIAS_PATH}" >> $GITHUB_OUTPUT
+
     - name: "Artifact upload: tarball"
       uses: actions/upload-artifact@master
       with:
         name: ${{ steps.package.outputs.PKG_NAME }}
-        path: ${{ steps.package.outputs.PKG_PATH }}
+        path: |
+          ${{ steps.package.outputs.PKG_PATH }}
+          ${{ steps.package.outputs.PKG_ALIAS_PATH }}
 
     - name: "Artifact upload: Debian package"
       uses: actions/upload-artifact@master
       if: steps.debian-package.outputs.DPKG_NAME
       with:
         name: ${{ steps.debian-package.outputs.DPKG_NAME }}
-        path: ${{ steps.debian-package.outputs.DPKG_PATH }}
+        path: |
+          ${{ steps.debian-package.outputs.DPKG_PATH }}
+          ${{ steps.debian-package.outputs.DPKG_ALIAS_PATH }}
 
     - name: Check for release
       id: is-release
@@ -447,7 +460,9 @@ jobs:
       with:
         files: |
           ${{ steps.package.outputs.PKG_PATH }}
+          ${{ steps.package.outputs.PKG_ALIAS_PATH }}
           ${{ steps.debian-package.outputs.DPKG_PATH }}
+          ${{ steps.debian-package.outputs.DPKG_ALIAS_PATH }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -460,5 +475,5 @@ jobs:
       - uses: vedantmgoyal9/winget-releaser@19e706d4c9121098010096f9c495a70a7518b30f
         with:
           identifier: sharkdp.bat
-          installers-regex: '-pc-windows-msvc\.zip$'
+          installers-regex: '^bat-v.+-pc-windows-msvc\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Other
 
-- Publish versionless release download aliases alongside existing archives and Debian packages, see #0 (@Matei02355)
+- Publish versionless release download aliases alongside existing archives and Debian packages, see #3973 (@Matei02355)
 
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Other
 
+- Publish versionless release download aliases alongside existing archives and Debian packages, see #0 (@Matei02355)
+
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/README.md
+++ b/README.md
@@ -287,6 +287,19 @@ the most recent release of `bat`, download the latest `.deb` package from the
 sudo dpkg -i bat_0.18.3_amd64.deb  # adapt version number and architecture
 ```
 
+Releases also include versionless aliases for automated downloads. For example,
+the following always downloads the latest release's amd64 Debian package:
+
+```bash
+curl -fLO https://github.com/sharkdp/bat/releases/latest/download/bat_amd64.deb
+sudo dpkg -i bat_amd64.deb
+```
+
+Archive aliases use `bat-<target>.tar.gz` (or `.zip` on Windows), for example
+`bat-x86_64-unknown-linux-gnu.tar.gz`. They contain the same versioned directory
+as the original archive. Versioned release assets remain available for pinned
+downloads.
+
 ### On Alpine Linux
 
 You can install [the `bat` package](https://pkgs.alpinelinux.org/packages?name=bat)


### PR DESCRIPTION
The /releases/latest/download endpoint still requires callers to know the version embedded in each asset filename. Publish versionless copies alongside the existing versioned archives and Debian packages so automation can use a stable download URL.

Archive aliases use bat-<target>.tar.gz or .zip; Debian aliases omit only the version. Both names are uploaded as workflow artifacts and release assets. The archive contents remain identical. Narrow the Winget installer matcher to versioned archives so aliases do not create duplicate installers, and document the stable download URLs.

Validation: parsed the workflow and executed the actual alias-generation shell fragments against fixtures for all 13 archive targets across two release versions and all 8 Debian variants. Verified byte-identical copies, stable names without collisions, and Winget selecting only versioned Windows installers. Diff checks passed.

Fixes #2417.