### PR TITLE
Add automatic rebuilding for ordered custom asset sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Opt into automatic rebuilding of custom assets after source or version changes with `bat cache --build --automatic`, see #0 (@Matei02355)
+- Opt into automatic rebuilding of custom assets after source or version changes with `bat cache --build --automatic`, see #3979 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Opt into automatic rebuilding of custom assets after source or version changes with `bat cache --build --automatic`, see #0 (@Matei02355)
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Support combining system and user asset directories with repeated `cache --source`; automatic rebuilds track every source, see #3979 (@Matei02355)
+
 - Opt into automatic rebuilding of custom assets after source or version changes with `bat cache --build --automatic`, see #3979 (@Matei02355)
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ minimal-application = [
 git = ["gix"] # Support indicating git modifications
 paging = [ "shell-words", "grep-cli", "minus"] # Support applying a pager on the output
 lessopen = ["execute"] # Support $LESSOPEN preprocessor
-build-assets = ["syntect/yaml-load", "syntect/plist-load", "regex", "walkdir"]
+build-assets = ["syntect/yaml-load", "syntect/plist-load", "regex", "walkdir", "tempfile"]
 
 # You need to use one of these if you depend on bat as a library:
 regex-onig = ["syntect/regex-onig"] # Use the "oniguruma" regex engine
@@ -68,6 +68,7 @@ etcetera = { version = "0.11.0", optional = true }
 grep-cli = { version = "0.1.12", optional = true }
 regex = { version = "1.12.3", optional = true }
 walkdir = { version = "2.5", optional = true }
+tempfile = { version = "3.27.0", optional = true }
 bytesize = { version = "2.3.1" }
 encoding_rs = "0.8.35"
 execute = { version = "0.3.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -577,6 +577,19 @@ syntax:
    bat cache --build
    ```
 
+   To rebuild automatically after changing these source files or upgrading `bat`, use
+   `bat cache --build --automatic` instead. This opt-in mode records the source
+   directory and build options, then checks source contents on each invocation.
+   It follows source symlinks, so their targets must remain accessible. Keep the
+   source directory limited to your asset files to avoid unnecessary reads.
+
+   Rebuilds run locally, without downloading anything. A failed rebuild reports
+   an error and preserves the existing caches. Separate cache generations let
+   versions of `bat` coexist, while the explicit cache remains available to library
+   clients. `bat cache --clear` removes these generations. Run `bat cache --build`
+   without `--automatic` to return to manual updates, or use `--no-custom-assets`
+   to bypass custom assets for one invocation.
+
 3. Finally, use `bat --list-languages` to check if the new languages are available.
 
    If you ever want to go back to the default settings, call:

--- a/README.md
+++ b/README.md
@@ -602,6 +602,36 @@ syntax:
    consider opening a "syntax request" ticket after reading the policies and
    instructions [here](doc/assets.md): [Open Syntax Request](https://github.com/sharkdp/bat/issues/new?labels=syntax-request&template=syntax_request.md).
 
+### Combining system and user assets
+
+Packages can install syntax definitions and themes in a shared directory, for
+example `/usr/share/bat/syntaxes` and `/usr/share/bat/themes`. Each user can opt
+into these assets alongside their own without changing the shared files:
+
+```bash
+mkdir -p "$(bat --config-dir)"
+bat cache --build --automatic \
+  --source /usr/share/bat \
+  --source "$(bat --config-dir)"
+```
+
+Use the directory selected by your distribution or administrator in place of
+`/usr/share/bat`; bat does not create or scan that location by default. Repeat
+`--source` in order of increasing priority. Later themes replace earlier themes
+with the same name, and later syntax definitions take precedence for matching
+names, scopes and extensions. All syntax sources are linked together, so a user
+syntax can include a syntax provided by a system package. Integrated assets
+remain available unless `--blank` is specified.
+
+Automatic mode records every source and refreshes the user's cache after package
+updates, additions or removals. Package installation scripts only install source
+files in the shared location; they do not modify home directories or run bat for
+other users. Cache files are written only to the user's cache directory (or the
+explicit `--target`). Every configured source directory must remain readable;
+a removed package should leave the shared directory available, or the user can
+rebuild with an updated source list. Use `--no-custom-assets` to bypass unavailable
+sources. Without `--automatic`, rerun the same build command after changes.
+
 ### Adding new themes
 
 This works very similar to how we add new syntax definitions.

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -126,6 +126,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-c'                      , 'c'                     , [CompletionResultType]::ParameterName, 'Remove the cached syntax definitions and themes.')
             [CompletionResult]::new('--clear'                 , 'clear'                 , [CompletionResultType]::ParameterName, 'Remove the cached syntax definitions and themes.')
             [CompletionResult]::new('--blank'                 , 'blank'                 , [CompletionResultType]::ParameterName, 'Create completely new syntax and theme sets (instead of appending to the default sets).')
+            [CompletionResult]::new('--automatic', 'automatic', [CompletionResultType]::ParameterName, 'Automatically rebuild custom assets when sources or bat change.')
         #   [CompletionResult]::new('-h'                      , 'h'                     , [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('--help'                  , 'help'                  , [CompletionResultType]::ParameterName, 'Prints help information')
         #   [CompletionResult]::new('-V'                      , 'V'                     , [CompletionResultType]::ParameterName, 'Prints version information')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -71,6 +71,7 @@ _bat() {
 			--source
 			--target
 			--blank
+			--automatic
 			--help
 		" -- "$cur"))
 		return 0

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -257,7 +257,7 @@ complete -c $bat -l clear -f -d "Reset definitions to defaults" -n __bat_cache_n
 
 complete -c $bat -l blank -f -d "Create new data instead of appending" -n "__bat_cache_subcommand; and not __fish_seen_argument -l clear"
 
-complete -c $bat -l source -x -a "(__fish_complete_directories)" -d "Load syntaxes and themes from DIR" -n "__bat_cache_subcommand; and not __fish_seen_argument -l clear"
+complete -c $bat -l source -x -a "(__fish_complete_directories)" -d "Load assets from DIR; repeat for ordered sources" -n "__bat_cache_subcommand; and not __fish_seen_argument -l clear"
 
 complete -c $bat -l target -x -a "(__fish_complete_directories)" -d "Store cache in DIR" -n __bat_cache_subcommand
 

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -267,4 +267,7 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
+
+complete -c $bat -l automatic -f -d "Automatically rebuild custom assets" -n "__bat_cache_subcommand; and not __fish_seen_argument -l clear"
+
 # vim:ft=fish

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -13,6 +13,7 @@ _{{PROJECT_EXECUTABLE}}_cache_subcommand() {
         --source='[specify directory to load syntaxes and themes from]:directory:_files -/'
         --target='[specify directory to store the cached syntax and theme set in]:directory:_files -/'
         --blank'[create completely new syntax and theme sets]'
+        --automatic'[automatically rebuild custom assets when sources or bat change]'
         --acknowledgements'[build acknowledgements.bin]'
         '(: -)'{-h,--help}'[show help information]'
     )

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -10,7 +10,7 @@ _{{PROJECT_EXECUTABLE}}_cache_subcommand() {
     args=(
         '(-b --build -c --clear)'{-b,--build}'[initialize or update the syntax/theme cache]'
         '(-b --build -c --clear)'{-c,--clear}'[remove the cached syntax definitions and themes]'
-        --source='[specify directory to load syntaxes and themes from]:directory:_files -/'
+        '*--source=[load assets from a directory; later sources take precedence]:directory:_files -/'
         --target='[specify directory to store the cached syntax and theme set in]:directory:_files -/'
         --blank'[create completely new syntax and theme sets]'
         --automatic'[automatically rebuild custom assets when sources or bat change]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -376,6 +376,13 @@ The `\fBcache --clear\fR` command also removes automatic cache generations.
 .br
 If you ever want to remove the custom languages, you can clear the cache with `\fB{{PROJECT_EXECUTABLE}} cache --clear\fR`.
 
+.PP
+Repeat \fBcache --source\fR to combine ordered system and user asset directories.
+Later sources take precedence for theme names and syntax lookup.
+For example, \fBcache --build --automatic --source /usr/share/bat --source ~/.config/bat\fR
+tracks package assets alongside user assets, rebuilding only in the user's cache.
+Use the source paths selected by your distribution and configuration; shared sources are not discovered automatically.
+
 .SH "ADDING CUSTOM THEMES"
 Similarly to custom languages, {{PROJECT_EXECUTABLE}} supports Sublime Text \fB.tmTheme\fR themes.
 These can be installed to `\fB$({{PROJECT_EXECUTABLE}} --config-dir)/themes\fR`, and are added to the cache with

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -364,6 +364,15 @@ git clone https://github.com/tellnobody1/sublime-purescript-syntax
 .RE
 
 Once the cache is built, the new language will be visible in `\fB{{PROJECT_EXECUTABLE}} --list-languages\fR`.
+
+Use `\fB{{PROJECT_EXECUTABLE}} cache --build --automatic\fR` to opt into automatic updates.
+This records the source directory and build options and checks source contents on each invocation.
+When the sources or the version of {{PROJECT_EXECUTABLE}} change, the assets are rebuilt locally in a separate cache generation.
+Source files and symlink targets must remain accessible. Keep the source directory limited to asset files to avoid unnecessary reads.
+A failed rebuild reports an error and preserves existing caches.
+Run `\fB{{PROJECT_EXECUTABLE}} cache --build\fR` without `\fB--automatic\fR` to return to manual updates.
+The `\fB--no-custom-assets\fR` option bypasses custom assets for one invocation.
+The `\fBcache --clear\fR` command also removes automatic cache generations.
 .br
 If you ever want to remove the custom languages, you can clear the cache with `\fB{{PROJECT_EXECUTABLE}} cache --clear\fR`.
 

--- a/src/assets/build_assets.rs
+++ b/src/assets/build_assets.rs
@@ -16,13 +16,35 @@ pub fn build(
     target_dir: &Path,
     current_version: &str,
 ) -> Result<()> {
-    let theme_set = build_theme_set(source_dir, include_integrated_assets)?;
+    build_from_dirs(
+        &[source_dir],
+        include_integrated_assets,
+        include_acknowledgements,
+        target_dir,
+        current_version,
+    )
+}
 
-    let syntax_set_builder = build_syntax_set_builder(source_dir, include_integrated_assets)?;
+/// Build a shared cache from ordered source directories. Later sources override earlier
+/// themes and take precedence when resolving syntax names, extensions and scopes.
+/// Each source contains `syntaxes` and/or `themes`, just like the single-source builder.
+pub fn build_from_dirs(
+    source_dirs: &[&Path],
+    include_integrated_assets: bool,
+    include_acknowledgements: bool,
+    target_dir: &Path,
+    current_version: &str,
+) -> Result<()> {
+    if source_dirs.is_empty() {
+        return Err("At least one asset source directory is required".into());
+    }
+    let theme_set = build_theme_set(source_dirs, include_integrated_assets)?;
+
+    let syntax_set_builder = build_syntax_set_builder(source_dirs, include_integrated_assets)?;
 
     let syntax_set = syntax_set_builder.build();
 
-    let acknowledgements = build_acknowledgements(source_dir, include_acknowledgements)?;
+    let acknowledgements = build_acknowledgements(source_dirs, include_acknowledgements)?;
 
     print_unlinked_contexts(&syntax_set);
 
@@ -35,34 +57,35 @@ pub fn build(
     )
 }
 
-fn build_theme_set(source_dir: &Path, include_integrated_assets: bool) -> Result<LazyThemeSet> {
+fn build_theme_set(source_dirs: &[&Path], include_integrated_assets: bool) -> Result<LazyThemeSet> {
     let mut theme_set = if include_integrated_assets {
         crate::assets::get_integrated_themeset().try_into()?
     } else {
         ThemeSet::new()
     };
 
-    let theme_dir = source_dir.join("themes");
-    if theme_dir.exists() {
-        let res = theme_set.add_from_folder(&theme_dir);
-        if let Err(err) = res {
+    for source_dir in source_dirs {
+        let theme_dir = source_dir.join("themes");
+        if theme_dir.exists() {
+            let res = theme_set.add_from_folder(&theme_dir);
+            if let Err(err) = res {
+                println!(
+                    "Failed to load one or more themes from '{}' (reason: '{err}')",
+                    theme_dir.to_string_lossy(),
+                );
+            }
+        } else {
             println!(
-                "Failed to load one or more themes from '{}' (reason: '{err}')",
-                theme_dir.to_string_lossy(),
+                "No themes were found in '{}', using the default set",
+                theme_dir.to_string_lossy()
             );
         }
-    } else {
-        println!(
-            "No themes were found in '{}', using the default set",
-            theme_dir.to_string_lossy()
-        );
     }
-
     theme_set.try_into()
 }
 
 fn build_syntax_set_builder(
-    source_dir: &Path,
+    source_dirs: &[&Path],
     include_integrated_assets: bool,
 ) -> Result<SyntaxSetBuilder> {
     let mut syntax_set_builder = if !include_integrated_assets {
@@ -74,16 +97,17 @@ fn build_syntax_set_builder(
             .into_builder()
     };
 
-    let syntax_dir = source_dir.join("syntaxes");
-    if syntax_dir.exists() {
-        syntax_set_builder.add_from_folder(syntax_dir, true)?;
-    } else {
-        println!(
-            "No syntaxes were found in '{}', using the default set.",
-            syntax_dir.to_string_lossy()
-        );
+    for source_dir in source_dirs {
+        let syntax_dir = source_dir.join("syntaxes");
+        if syntax_dir.exists() {
+            syntax_set_builder.add_from_folder(syntax_dir, true)?;
+        } else {
+            println!(
+                "No syntaxes were found in '{}', using the default set.",
+                syntax_dir.to_string_lossy()
+            );
+        }
     }
-
     Ok(syntax_set_builder)
 }
 

--- a/src/assets/build_assets/acknowledgements.rs
+++ b/src/assets/build_assets/acknowledgements.rs
@@ -12,11 +12,11 @@ struct PathAndStem {
     relative_path: String,
 }
 
-/// Looks for LICENSE and NOTICE files in `source_dir`, does some rudimentary
+/// Looks for LICENSE and NOTICE files in `source_dirs`, does some rudimentary
 /// analysis, and compiles them together in a single string that is meant to be
 /// used in the output to `--acknowledgements`
 pub fn build_acknowledgements(
-    source_dir: &Path,
+    source_dirs: &[&Path],
     include_acknowledgements: bool,
 ) -> Result<Option<String>> {
     if !include_acknowledgements {
@@ -25,22 +25,23 @@ pub fn build_acknowledgements(
 
     let mut acknowledgements = format!("{}\n\n", include_str!("../../../NOTICE"));
 
-    // Sort entries so the order is stable over time
-    let entries = walkdir::WalkDir::new(source_dir).sort_by(|a, b| a.path().cmp(b.path()));
-    for path_and_stem in entries
-        .into_iter()
-        .flatten()
-        .flat_map(|entry| to_path_and_stem(source_dir, entry))
-    {
-        if let Some(license_text) = handle_file(&path_and_stem)? {
-            append_to_acknowledgements(
-                &mut acknowledgements,
-                &path_and_stem.relative_path,
-                &license_text,
-            )
+    for source_dir in source_dirs {
+        // Sort entries so the order is stable over time
+        let entries = walkdir::WalkDir::new(source_dir).sort_by(|a, b| a.path().cmp(b.path()));
+        for path_and_stem in entries
+            .into_iter()
+            .flatten()
+            .flat_map(|entry| to_path_and_stem(source_dir, entry))
+        {
+            if let Some(license_text) = handle_file(&path_and_stem)? {
+                append_to_acknowledgements(
+                    &mut acknowledgements,
+                    &path_and_stem.relative_path,
+                    &license_text,
+                )
+            }
         }
     }
-
     Ok(Some(acknowledgements))
 }
 

--- a/src/bin/bat/assets.rs
+++ b/src/bin/bat/assets.rs
@@ -13,12 +13,27 @@ pub fn clear_assets(cache_dir: &Path) {
     clear_asset(cache_dir.join("themes.bin"), "theme set cache");
     clear_asset(cache_dir.join("syntaxes.bin"), "syntax set cache");
     clear_asset(cache_dir.join("metadata.yaml"), "metadata file");
+    if cache_dir.join("automatic.yaml").exists() {
+        clear_asset(cache_dir.join("automatic.yaml"), "automatic asset recipe");
+    }
+    if let Err(error) = fs::remove_dir_all(cache_dir.join("automatic")) {
+        if error.kind() != io::ErrorKind::NotFound {
+            eprintln!("Could not clear automatic asset generations: {error}");
+        }
+    }
 }
 
 pub fn assets_from_cache_or_binary(
     use_custom_assets: bool,
     cache_dir: &Path,
 ) -> Result<HighlightingAssets> {
+    if !use_custom_assets {
+        return Ok(HighlightingAssets::from_binary());
+    }
+    #[cfg(feature = "build-assets")]
+    if let Some(assets) = crate::automatic_assets::load(cache_dir)? {
+        return Ok(assets);
+    }
     if let Some(metadata) = AssetsMetadata::load_from_folder(cache_dir)? {
         if !metadata.is_compatible_with(crate_version!()) {
             return Err(format!(

--- a/src/bin/bat/automatic_assets.rs
+++ b/src/bin/bat/automatic_assets.rs
@@ -19,6 +19,8 @@ const GENERATIONS: &str = "automatic";
 #[derive(Serialize, Deserialize)]
 pub(crate) struct Recipe {
     source_dir: PathBuf,
+    #[serde(default)]
+    preceding_source_dirs: Vec<PathBuf>,
     include_integrated_assets: bool,
     include_acknowledgements: bool,
     fingerprint: String,
@@ -26,82 +28,102 @@ pub(crate) struct Recipe {
 
 impl Recipe {
     pub(crate) fn new(
-        source_dir: &Path,
+        source_dirs: &[&Path],
         cache_dir: &Path,
         include_integrated_assets: bool,
         include_acknowledgements: bool,
     ) -> Result<Self> {
+        let mut sources: Vec<PathBuf> = source_dirs
+            .iter()
+            .map(|source| source.canonicalize())
+            .collect::<std::io::Result<_>>()?;
+        for source in &sources {
+            if !source.is_dir() {
+                return Err("The automatic asset sources must be directories".into());
+            }
+        }
+        let source_dir = sources
+            .pop()
+            .ok_or("At least one automatic asset source is required")?;
         let mut recipe = Self {
-            source_dir: source_dir.canonicalize()?,
+            source_dir,
+            preceding_source_dirs: sources,
             include_integrated_assets,
             include_acknowledgements,
             fingerprint: String::new(),
         };
-        if !recipe.source_dir.is_dir() {
-            return Err("The automatic asset source must be a directory".into());
-        }
         recipe.fingerprint = recipe.current_fingerprint(cache_dir)?;
         Ok(recipe)
+    }
+
+    fn source_dirs(&self) -> impl Iterator<Item = &Path> {
+        self.preceding_source_dirs
+            .iter()
+            .chain(std::iter::once(&self.source_dir))
+            .map(PathBuf::as_path)
     }
 
     fn current_fingerprint(&self, cache_dir: &Path) -> Result<String> {
         let mut hash = DefaultHasher::new();
         clap::crate_version!().hash(&mut hash);
-        self.source_dir.hash(&mut hash);
         self.include_integrated_assets.hash(&mut hash);
         self.include_acknowledgements.hash(&mut hash);
         let cache_dir = cache_dir.canonicalize().ok();
         let mut buffer = [0; 64 * 1024];
-        let entries = walkdir::WalkDir::new(&self.source_dir)
-            .follow_links(true)
-            .sort_by_file_name()
-            .into_iter()
-            .filter_entry(|entry| {
-                if entry.depth() == 0 {
-                    return true;
-                }
-                if entry.file_name() == ".git" {
-                    return false;
-                }
-                if let Some(cache_dir) = &cache_dir {
-                    if *cache_dir != self.source_dir && entry.path() == cache_dir {
+        for source_dir in self.source_dirs() {
+            source_dir.hash(&mut hash);
+            let entries = walkdir::WalkDir::new(source_dir)
+                .follow_links(true)
+                .sort_by_file_name()
+                .into_iter()
+                .filter_entry(|entry| {
+                    if entry.depth() == 0 {
+                        return true;
+                    }
+                    if entry.file_name() == ".git" {
                         return false;
                     }
+                    if let Some(cache_dir) = &cache_dir {
+                        if cache_dir != source_dir && entry.path() == cache_dir {
+                            return false;
+                        }
+                    }
+                    // A source can also be the cache target (as with assets/create.sh).
+                    if entry.depth() == 1 {
+                        return ![
+                            RECIPE,
+                            GENERATIONS,
+                            "metadata.yaml",
+                            "syntaxes.bin",
+                            "themes.bin",
+                            "acknowledgements.bin",
+                        ]
+                        .iter()
+                        .any(|name| entry.file_name() == *name);
+                    }
+                    true
+                });
+            for entry in entries {
+                let entry = entry.map_err(|error| {
+                    format!("Could not inspect automatic asset sources: {error}")
+                })?;
+                if !entry.file_type().is_file() {
+                    continue;
                 }
-                // A source can also be the cache target (as with assets/create.sh).
-                if entry.depth() == 1 {
-                    return ![
-                        RECIPE,
-                        GENERATIONS,
-                        "metadata.yaml",
-                        "syntaxes.bin",
-                        "themes.bin",
-                        "acknowledgements.bin",
-                    ]
-                    .iter()
-                    .any(|name| entry.file_name() == *name);
+                entry
+                    .path()
+                    .strip_prefix(source_dir)
+                    .map_err(|error| format!("Invalid asset source path: {error}"))?
+                    .hash(&mut hash);
+                let mut file = File::open(entry.path())?;
+                file.metadata()?.len().hash(&mut hash);
+                loop {
+                    let size = file.read(&mut buffer)?;
+                    if size == 0 {
+                        break;
+                    }
+                    hash.write(&buffer[..size]);
                 }
-                true
-            });
-        for entry in entries {
-            let entry = entry
-                .map_err(|error| format!("Could not inspect automatic asset sources: {error}"))?;
-            if !entry.file_type().is_file() {
-                continue;
-            }
-            entry
-                .path()
-                .strip_prefix(&self.source_dir)
-                .map_err(|error| format!("Invalid asset source path: {error}"))?
-                .hash(&mut hash);
-            let mut file = File::open(entry.path())?;
-            file.metadata()?.len().hash(&mut hash);
-            loop {
-                let size = file.read(&mut buffer)?;
-                if size == 0 {
-                    break;
-                }
-                hash.write(&buffer[..size]);
             }
         }
         Ok(format!("{:016x}", hash.finish()))
@@ -170,10 +192,11 @@ pub(crate) fn load(cache_dir: &Path) -> Result<Option<HighlightingAssets>> {
         .current_dir(stage.path())
         .arg("cache")
         .arg("--build")
-        .arg("--source")
-        .arg(&recipe.source_dir)
         .arg("--target")
         .arg(stage.path());
+    for source in recipe.source_dirs() {
+        command.arg("--source").arg(source);
+    }
     if !recipe.include_integrated_assets {
         command.arg("--blank");
     }
@@ -183,8 +206,8 @@ pub(crate) fn load(cache_dir: &Path) -> Result<Option<HighlightingAssets>> {
     let output = command.output()?;
     if !output.status.success() {
         return Err(format!(
-            "Could not automatically rebuild custom assets from '{}':\n{}{}",
-            recipe.source_dir.display(),
+            "Could not automatically rebuild custom assets from {:?}:\n{}{}",
+            recipe.source_dirs().collect::<Vec<_>>(),
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),
         )

--- a/src/bin/bat/automatic_assets.rs
+++ b/src/bin/bat/automatic_assets.rs
@@ -1,0 +1,224 @@
+//! Opt-in source-based caches. Explicit caches stay available to library clients;
+//! automatic rebuilds use separate, immutable generations for each input set.
+
+use std::collections::hash_map::DefaultHasher;
+use std::fs::{self, File};
+use std::hash::{Hash, Hasher};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use bat::assets::HighlightingAssets;
+use bat::assets_metadata::AssetsMetadata;
+use bat::error::*;
+use serde_derive::{Deserialize, Serialize};
+
+const RECIPE: &str = "automatic.yaml";
+const GENERATIONS: &str = "automatic";
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct Recipe {
+    source_dir: PathBuf,
+    include_integrated_assets: bool,
+    include_acknowledgements: bool,
+    fingerprint: String,
+}
+
+impl Recipe {
+    pub(crate) fn new(
+        source_dir: &Path,
+        cache_dir: &Path,
+        include_integrated_assets: bool,
+        include_acknowledgements: bool,
+    ) -> Result<Self> {
+        let mut recipe = Self {
+            source_dir: source_dir.canonicalize()?,
+            include_integrated_assets,
+            include_acknowledgements,
+            fingerprint: String::new(),
+        };
+        if !recipe.source_dir.is_dir() {
+            return Err("The automatic asset source must be a directory".into());
+        }
+        recipe.fingerprint = recipe.current_fingerprint(cache_dir)?;
+        Ok(recipe)
+    }
+
+    fn current_fingerprint(&self, cache_dir: &Path) -> Result<String> {
+        let mut hash = DefaultHasher::new();
+        clap::crate_version!().hash(&mut hash);
+        self.source_dir.hash(&mut hash);
+        self.include_integrated_assets.hash(&mut hash);
+        self.include_acknowledgements.hash(&mut hash);
+        let cache_dir = cache_dir.canonicalize().ok();
+        let mut buffer = [0; 64 * 1024];
+        let entries = walkdir::WalkDir::new(&self.source_dir)
+            .follow_links(true)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_entry(|entry| {
+                if entry.depth() == 0 {
+                    return true;
+                }
+                if entry.file_name() == ".git" {
+                    return false;
+                }
+                if let Some(cache_dir) = &cache_dir {
+                    if *cache_dir != self.source_dir && entry.path() == cache_dir {
+                        return false;
+                    }
+                }
+                // A source can also be the cache target (as with assets/create.sh).
+                if entry.depth() == 1 {
+                    return ![
+                        RECIPE,
+                        GENERATIONS,
+                        "metadata.yaml",
+                        "syntaxes.bin",
+                        "themes.bin",
+                        "acknowledgements.bin",
+                    ]
+                    .iter()
+                    .any(|name| entry.file_name() == *name);
+                }
+                true
+            });
+        for entry in entries {
+            let entry = entry
+                .map_err(|error| format!("Could not inspect automatic asset sources: {error}"))?;
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            entry
+                .path()
+                .strip_prefix(&self.source_dir)
+                .map_err(|error| format!("Invalid asset source path: {error}"))?
+                .hash(&mut hash);
+            let mut file = File::open(entry.path())?;
+            file.metadata()?.len().hash(&mut hash);
+            loop {
+                let size = file.read(&mut buffer)?;
+                if size == 0 {
+                    break;
+                }
+                hash.write(&buffer[..size]);
+            }
+        }
+        Ok(format!("{:016x}", hash.finish()))
+    }
+}
+
+pub(crate) fn save_recipe(recipe: Option<&Recipe>, cache_dir: &Path) -> Result<()> {
+    let path = cache_dir.join(RECIPE);
+    if let Some(recipe) = recipe {
+        if recipe.current_fingerprint(cache_dir)? != recipe.fingerprint {
+            return Err(
+                "Asset sources changed during the build; run bat cache --build --automatic again"
+                    .into(),
+            );
+        }
+        let mut file = tempfile::NamedTempFile::new_in(cache_dir)?;
+        serde_yaml::to_writer(file.as_file_mut(), recipe)?;
+        file.persist(path).map_err(|error| error.error)?;
+    } else if let Err(error) = fs::remove_file(path) {
+        if error.kind() != io::ErrorKind::NotFound {
+            return Err(error.into());
+        }
+    }
+    Ok(())
+}
+
+fn read_assets(path: &Path) -> Result<HighlightingAssets> {
+    if !AssetsMetadata::load_from_folder(path)?
+        .is_some_and(|metadata| metadata.is_compatible_with(clap::crate_version!()))
+    {
+        return Err("Incompatible automatic asset cache".into());
+    }
+    let assets = HighlightingAssets::from_cache(path)?;
+    // A generation is usable only when both cache files can be read.
+    assets.get_syntax_set()?;
+    Ok(assets)
+}
+
+pub(crate) fn load(cache_dir: &Path) -> Result<Option<HighlightingAssets>> {
+    let file = match File::open(cache_dir.join(RECIPE)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let recipe: Recipe = serde_yaml::from_reader(file)?;
+    let fingerprint = recipe.current_fingerprint(cache_dir)?;
+    if fingerprint == recipe.fingerprint {
+        if let Ok(assets) = read_assets(cache_dir) {
+            return Ok(Some(assets));
+        }
+    }
+    let generations = cache_dir.join(GENERATIONS);
+    fs::create_dir_all(&generations)?;
+    let target = generations.join(&fingerprint);
+    if let Ok(assets) = read_assets(&target) {
+        return Ok(Some(assets));
+    }
+
+    let stage = tempfile::Builder::new()
+        .prefix("building-")
+        .tempdir_in(&generations)?;
+    let mut command = Command::new(std::env::current_exe()?);
+    // Run in an empty directory so a user file named `cache` cannot hide the
+    // subcommand. Capture progress messages so they cannot enter file output.
+    command
+        .current_dir(stage.path())
+        .arg("cache")
+        .arg("--build")
+        .arg("--source")
+        .arg(&recipe.source_dir)
+        .arg("--target")
+        .arg(stage.path());
+    if !recipe.include_integrated_assets {
+        command.arg("--blank");
+    }
+    if recipe.include_acknowledgements {
+        command.arg("--acknowledgements");
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "Could not automatically rebuild custom assets from '{}':\n{}{}",
+            recipe.source_dir.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        )
+        .into());
+    }
+    read_assets(stage.path())?;
+    if recipe.current_fingerprint(cache_dir)? != fingerprint {
+        return Err("Asset sources changed during the automatic build; retry the command".into());
+    }
+    // Move a corrupt generation aside before replacement. Its contents remain
+    // isolated until the replacement is published, then the temporary directory
+    // cleans them up. A concurrent successful publisher wins.
+    let quarantine = tempfile::Builder::new()
+        .prefix("replacing-")
+        .tempdir_in(&generations)?;
+    if target.exists() {
+        if let Ok(assets) = read_assets(&target) {
+            return Ok(Some(assets));
+        }
+        match fs::rename(&target, quarantine.path().join("old")) {
+            Ok(()) => (),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => (),
+            Err(error) => return Err(error.into()),
+        }
+    }
+    match fs::rename(stage.path(), &target) {
+        Ok(()) => (),
+        Err(error) => {
+            // Another process may have published the same generation.
+            if let Ok(assets) = read_assets(&target) {
+                return Ok(Some(assets));
+            }
+            return Err(error.into());
+        }
+    }
+    Ok(Some(read_assets(&target)?))
+}

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -775,6 +775,13 @@ pub fn build_app(interactive_output: bool) -> Command {
                         ),
                 )
                 .arg(
+                    Arg::new("automatic")
+                        .long("automatic")
+                        .action(ArgAction::SetTrue)
+                        .requires("build")
+                        .help("Rebuild these custom assets automatically when their sources or bat change."),
+                )
+                .arg(
                     Arg::new("clear")
                         .long("clear")
                         .short('c')

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -792,9 +792,10 @@ pub fn build_app(interactive_output: bool) -> Command {
                 .arg(
                     Arg::new("source")
                         .long("source")
+                        .action(ArgAction::Append)
                         .requires("build")
                         .value_name("dir")
-                        .help("Use a different directory to load syntaxes and themes from."),
+                        .help("Load syntaxes and themes from this directory. Repeat for multiple sources; later sources take precedence."),
                 )
                 .arg(
                     Arg::new("target")

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -49,15 +49,25 @@ const THEME_PREVIEW_DATA: &[u8] = include_bytes!("../../../assets/theme_preview.
 
 #[cfg(feature = "build-assets")]
 fn build_assets(matches: &clap::ArgMatches, config_dir: &Path, cache_dir: &Path) -> Result<()> {
-    let source_dir = matches
-        .get_one::<String>("source")
-        .map(Path::new)
-        .unwrap_or_else(|| config_dir);
+    let source_dirs: Vec<&Path> = match matches.get_many::<String>("source") {
+        Some(sources) => {
+            let sources: Vec<_> = sources.map(Path::new).collect();
+            for source in &sources {
+                if !source.is_dir() {
+                    return Err(
+                        format!("Asset source '{}' is not a directory", source.display()).into(),
+                    );
+                }
+            }
+            sources
+        }
+        None => vec![config_dir],
+    };
 
     let automatic = matches.get_flag("automatic");
     let recipe = if automatic {
         Some(automatic_assets::Recipe::new(
-            source_dir,
+            &source_dirs,
             cache_dir,
             !matches.get_flag("blank"),
             matches.get_flag("acknowledgements"),
@@ -66,8 +76,8 @@ fn build_assets(matches: &clap::ArgMatches, config_dir: &Path, cache_dir: &Path)
         None
     };
 
-    bat::assets::build(
-        source_dir,
+    bat::assets::build_from_dirs(
+        &source_dirs,
         !matches.get_flag("blank"),
         matches.get_flag("acknowledgements"),
         cache_dir,

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -29,6 +29,9 @@ use crate::{
 use crate::config::system_config_file;
 
 use assets::{assets_from_cache_or_binary, clear_assets};
+
+#[cfg(feature = "build-assets")]
+mod automatic_assets;
 use directories::PROJECT_DIRS;
 use globset::GlobMatcher;
 
@@ -51,13 +54,26 @@ fn build_assets(matches: &clap::ArgMatches, config_dir: &Path, cache_dir: &Path)
         .map(Path::new)
         .unwrap_or_else(|| config_dir);
 
+    let automatic = matches.get_flag("automatic");
+    let recipe = if automatic {
+        Some(automatic_assets::Recipe::new(
+            source_dir,
+            cache_dir,
+            !matches.get_flag("blank"),
+            matches.get_flag("acknowledgements"),
+        )?)
+    } else {
+        None
+    };
+
     bat::assets::build(
         source_dir,
         !matches.get_flag("blank"),
         matches.get_flag("acknowledgements"),
         cache_dir,
         clap::crate_version!(),
-    )
+    )?;
+    automatic_assets::save_recipe(recipe.as_ref(), cache_dir)
 }
 
 fn run_cache_subcommand(

--- a/tests/asset_sources.rs
+++ b/tests/asset_sources.rs
@@ -1,0 +1,325 @@
+#![cfg(feature = "build-assets")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use bat::assets::HighlightingAssets;
+use predicates::prelude::*;
+use tempfile::{tempdir, TempDir};
+
+mod utils;
+use utils::command::{bat, bat_with_config};
+
+struct Sources {
+    system: TempDir,
+    user: TempDir,
+    cache: TempDir,
+}
+
+fn syntax(root: &Path, filename: &str, name: &str, scope: &str, rules: &str) -> PathBuf {
+    fs::create_dir_all(root.join("syntaxes")).unwrap();
+    let path = root.join("syntaxes").join(filename);
+    fs::write(
+        &path,
+        format!("name: {name}\nfile_extensions: [layered]\nscope: {scope}\ncontexts:\n  main:\n{rules}\n"),
+    )
+    .unwrap();
+    path
+}
+
+fn theme(root: &Path, color: &str) {
+    fs::create_dir_all(root.join("themes")).unwrap();
+    fs::write(root.join("themes/Layered.tmTheme"), format!(
+        "<?xml version=\"1.0\"?><plist version=\"1.0\"><dict><key>settings</key><array><dict><key>settings</key><dict><key>foreground</key><string>{color}</string></dict></dict><dict><key>scope</key><string>keyword.control, constant.numeric</string><key>settings</key><dict><key>foreground</key><string>#00ff00</string></dict></dict></array></dict></plist>"
+    )).unwrap();
+}
+
+impl Sources {
+    fn new() -> Self {
+        Self {
+            system: tempdir().unwrap(),
+            user: tempdir().unwrap(),
+            cache: tempdir().unwrap(),
+        }
+    }
+
+    fn build(&self, automatic: bool, reversed: bool) {
+        let sources = if reversed {
+            [self.user.path(), self.system.path()]
+        } else {
+            [self.system.path(), self.user.path()]
+        };
+        let mut command = bat_with_config();
+        command
+            .current_dir(self.cache.path())
+            .args(["cache", "--build", "--blank", "--target"])
+            .arg(self.cache.path());
+        for source in sources {
+            command.arg("--source").arg(source);
+        }
+        if automatic {
+            command.arg("--automatic");
+        }
+        command.assert().success();
+    }
+
+    fn names(&self) -> assert_cmd::Command {
+        let mut command = bat();
+        command.env("BAT_CACHE_PATH", self.cache.path()).args([
+            "--list-languages",
+            "--color=never",
+            "--paging=never",
+        ]);
+        command
+    }
+}
+
+#[test]
+fn later_sources_override_themes_and_syntax_names_extensions_and_scopes() {
+    let sources = Sources::new();
+    syntax(
+        sources.system.path(),
+        "shared.sublime-syntax",
+        "Shared",
+        "source.shared",
+        "    - match: system\n      scope: keyword.control",
+    );
+    syntax(
+        sources.user.path(),
+        "shared.sublime-syntax",
+        "Shared",
+        "source.shared",
+        "    - match: user\n      scope: keyword.control",
+    );
+    theme(sources.system.path(), "#112233");
+    theme(sources.user.path(), "#abcdef");
+    for (reversed, expected, keyword) in [
+        (false, (0xab, 0xcd, 0xef), "user"),
+        (true, (0x11, 0x22, 0x33), "system"),
+    ] {
+        sources.build(false, reversed);
+        let assets = HighlightingAssets::from_cache(sources.cache.path()).unwrap();
+        let theme = assets.get_theme("Layered");
+        let color = theme.settings.foreground.unwrap();
+        assert_eq!((color.r, color.g, color.b), expected);
+        let syntaxes = assets.get_syntax_set().unwrap();
+        for syntax in [
+            syntaxes.find_syntax_by_name("Shared").unwrap(),
+            syntaxes.find_syntax_by_extension("layered").unwrap(),
+            syntaxes
+                .find_syntax_by_scope("source.shared".parse().unwrap())
+                .unwrap(),
+        ] {
+            let mut highlighter = syntect::easy::HighlightLines::new(syntax, theme);
+            let highlighted = highlighter.highlight_line(keyword, syntaxes).unwrap();
+            let color = highlighted[0].0.foreground;
+            assert_eq!((color.r, color.g, color.b), (0, 255, 0));
+        }
+    }
+}
+
+#[test]
+fn user_syntaxes_can_include_system_syntaxes_in_a_single_linked_set() {
+    let sources = Sources::new();
+    syntax(
+        sources.system.path(),
+        "base.sublime-syntax",
+        "System Base",
+        "source.system-base",
+        "    - match: base\n      scope: constant.numeric",
+    );
+    syntax(
+        sources.user.path(),
+        "wrapper.sublime-syntax",
+        "User Wrapper",
+        "source.user-wrapper",
+        "    - include: scope:source.system-base",
+    );
+    theme(sources.user.path(), "#abcdef");
+    sources.build(false, false);
+    let assets = HighlightingAssets::from_cache(sources.cache.path()).unwrap();
+    let syntaxes = assets.get_syntax_set().unwrap();
+    assert!(syntaxes.find_unlinked_contexts().is_empty());
+    let mut highlighter = syntect::easy::HighlightLines::new(
+        syntaxes.find_syntax_by_name("User Wrapper").unwrap(),
+        assets.get_theme("Layered"),
+    );
+    let highlighted = highlighter.highlight_line("base", syntaxes).unwrap();
+    let color = highlighted[0].0.foreground;
+    assert_eq!((color.r, color.g, color.b), (0, 255, 0));
+}
+
+#[test]
+fn package_updates_and_removals_rebuild_only_the_user_cache() {
+    let sources = Sources::new();
+    let system_file = syntax(
+        sources.system.path(),
+        "package.sublime-syntax",
+        "Package One",
+        "source.package",
+        "    - match: package\n      scope: keyword.control",
+    );
+    syntax(
+        sources.user.path(),
+        "custom.sublime-syntax",
+        "User Custom",
+        "source.user-custom",
+        "    - match: user\n      scope: keyword.control",
+    );
+    sources.build(true, false);
+    sources.names().assert().success().stdout(
+        predicate::str::contains("Package One").and(predicate::str::contains("User Custom")),
+    );
+    syntax(
+        sources.system.path(),
+        "package.sublime-syntax",
+        "Package Two",
+        "source.package",
+        "    - match: package\n      scope: keyword.control",
+    );
+    sources.names().assert().success().stdout(
+        predicate::str::contains("Package Two").and(predicate::str::contains("Package One").not()),
+    );
+    fs::remove_file(system_file).unwrap();
+    sources.names().assert().success().stdout(
+        predicate::str::contains("User Custom").and(predicate::str::contains("Package Two").not()),
+    );
+    for source in [sources.system.path(), sources.user.path()] {
+        assert!(!source.join("syntaxes.bin").exists());
+        assert!(!source.join("themes.bin").exists());
+        assert!(!source.join("automatic.yaml").exists());
+        assert!(!source.join("automatic").exists());
+    }
+}
+
+#[test]
+fn missing_explicit_source_fails_before_replacing_the_cache() {
+    let sources = Sources::new();
+    syntax(
+        sources.user.path(),
+        "custom.sublime-syntax",
+        "User Custom",
+        "source.user-custom",
+        "    - match: user\n      scope: keyword.control",
+    );
+    sources.build(false, false);
+    let old = fs::read(sources.cache.path().join("syntaxes.bin")).unwrap();
+    bat_with_config()
+        .current_dir(sources.cache.path())
+        .args(["cache", "--build", "--source"])
+        .arg(sources.system.path())
+        .arg("--source")
+        .arg(sources.user.path().join("missing"))
+        .arg("--target")
+        .arg(sources.cache.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("is not a directory"));
+    assert_eq!(
+        fs::read(sources.cache.path().join("syntaxes.bin")).unwrap(),
+        old
+    );
+}
+
+#[test]
+fn acknowledgements_collect_notices_from_all_sources_once() {
+    let sources = Sources::new();
+    fs::write(
+        sources.system.path().join("NOTICE"),
+        "System package notice\n",
+    )
+    .unwrap();
+    fs::write(sources.user.path().join("NOTICE"), "User package notice\n").unwrap();
+    bat::assets::build_from_dirs(
+        &[sources.system.path(), sources.user.path()],
+        false,
+        true,
+        sources.cache.path(),
+        env!("CARGO_PKG_VERSION"),
+    )
+    .unwrap();
+    let data = fs::read(sources.cache.path().join("acknowledgements.bin")).unwrap();
+    let notices: String = syntect::dumps::from_binary(&data);
+    assert_eq!(notices.matches("System package notice").count(), 1);
+    assert_eq!(notices.matches("User package notice").count(), 1);
+}
+
+#[test]
+fn single_source_recipes_without_the_new_list_remain_readable() {
+    let sources = Sources::new();
+    syntax(
+        sources.user.path(),
+        "custom.sublime-syntax",
+        "Original",
+        "source.user-custom",
+        "    - match: user\n      scope: keyword.control",
+    );
+    bat_with_config()
+        .current_dir(sources.cache.path())
+        .args(["cache", "--build", "--blank", "--automatic", "--source"])
+        .arg(sources.user.path())
+        .arg("--target")
+        .arg(sources.cache.path())
+        .assert()
+        .success();
+    let path = sources.cache.path().join("automatic.yaml");
+    let mut recipe: serde_yaml::Value = serde_yaml::from_slice(&fs::read(&path).unwrap()).unwrap();
+    recipe
+        .as_mapping_mut()
+        .unwrap()
+        .remove(serde_yaml::Value::String("preceding_source_dirs".into()));
+    fs::write(path, serde_yaml::to_string(&recipe).unwrap()).unwrap();
+    syntax(
+        sources.user.path(),
+        "custom.sublime-syntax",
+        "Updated",
+        "source.user-custom",
+        "    - match: user\n      scope: keyword.control",
+    );
+    sources.names().assert().success().stdout(
+        predicate::str::contains("Updated").and(predicate::str::contains("Original").not()),
+    );
+}
+
+#[test]
+fn shared_sources_can_be_combined_when_user_source_is_also_the_cache() {
+    let sources = Sources::new();
+    syntax(
+        sources.system.path(),
+        "package.sublime-syntax",
+        "Original Package",
+        "source.package",
+        "    - match: package\n      scope: keyword.control",
+    );
+    bat_with_config()
+        .current_dir(sources.cache.path())
+        .args(["cache", "--build", "--blank", "--automatic", "--source"])
+        .arg(sources.system.path())
+        .arg("--source")
+        .arg(sources.user.path())
+        .arg("--target")
+        .arg(sources.user.path())
+        .assert()
+        .success();
+    syntax(
+        sources.system.path(),
+        "package.sublime-syntax",
+        "Updated Package",
+        "source.package",
+        "    - match: package\n      scope: keyword.control",
+    );
+    for _ in 0..2 {
+        bat()
+            .env("BAT_CACHE_PATH", sources.user.path())
+            .args(["--list-languages", "--color=never", "--paging=never"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Updated Package"));
+        assert_eq!(
+            fs::read_dir(sources.user.path().join("automatic"))
+                .unwrap()
+                .count(),
+            1
+        );
+    }
+}

--- a/tests/automatic_assets.rs
+++ b/tests/automatic_assets.rs
@@ -1,0 +1,282 @@
+#![cfg(feature = "build-assets")]
+
+use std::fs;
+use std::process::Command;
+
+use assert_cmd::assert::OutputAssertExt;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+mod utils;
+use utils::command::{bat, bat_raw_command, bat_with_config};
+
+struct Assets {
+    source: TempDir,
+    cache: TempDir,
+}
+
+impl Assets {
+    fn new() -> Self {
+        let assets = Self {
+            source: tempfile::tempdir().unwrap(),
+            cache: tempfile::tempdir().unwrap(),
+        };
+        fs::create_dir(assets.source.path().join("syntaxes")).unwrap();
+        assets.syntax("One");
+        assets
+    }
+
+    fn syntax(&self, name: &str) {
+        fs::write(
+            self.source.path().join("syntaxes/custom.sublime-syntax"),
+            format!(
+                "name: Automatic {name}\nfile_extensions: [autocustom]\nscope: source.autocustom\ncontexts:\n  main:\n    - match: custom\n      scope: keyword.control\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn build(&self, automatic: bool) {
+        let mut command = bat_with_config();
+        command
+            .current_dir(self.source.path())
+            .args(["cache", "--build"])
+            .arg("--source")
+            .arg(self.source.path())
+            .arg("--target")
+            .arg(self.cache.path());
+        if automatic {
+            command.arg("--automatic");
+        }
+        command.assert().success();
+    }
+
+    fn command(&self) -> Command {
+        let mut command = bat_raw_command();
+        command
+            .env("BAT_CACHE_PATH", self.cache.path())
+            .args(["--list-languages", "--color=never"]);
+        command
+    }
+
+    fn names(&self, expected: &str, absent: &str) {
+        self.command()
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(expected).and(predicate::str::contains(absent).not()))
+            .stderr("");
+    }
+
+    fn generations(&self) -> Vec<std::path::PathBuf> {
+        let root = self.cache.path().join("automatic");
+        if !root.exists() {
+            return vec![];
+        }
+        fs::read_dir(root)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect()
+    }
+}
+
+#[test]
+fn source_content_changes_rebuild_without_touching_the_explicit_cache() {
+    let assets = Assets::new();
+    assets.build(true);
+    assets.names("Automatic One", "Automatic Two");
+    assert!(assets.generations().is_empty());
+    let explicit = fs::read(assets.cache.path().join("syntaxes.bin")).unwrap();
+    let source = assets.source.path().join("syntaxes/custom.sublime-syntax");
+    let modified = source.metadata().unwrap().modified().unwrap();
+    assets.syntax("Two");
+    fs::File::options()
+        .write(true)
+        .open(&source)
+        .unwrap()
+        .set_times(fs::FileTimes::new().set_modified(modified))
+        .unwrap();
+    assets.names("Automatic Two", "Automatic One");
+    let generations = assets.generations();
+    assert_eq!(generations.len(), 1);
+    let generated = generations[0].join("syntaxes.bin");
+    let generated_time = generated.metadata().unwrap().modified().unwrap();
+    assets.names("Automatic Two", "Automatic One");
+    assert_eq!(
+        generated.metadata().unwrap().modified().unwrap(),
+        generated_time
+    );
+    assert_eq!(
+        fs::read(assets.cache.path().join("syntaxes.bin")).unwrap(),
+        explicit
+    );
+}
+
+#[test]
+fn incompatible_metadata_rebuilds_in_a_separate_generation() {
+    let assets = Assets::new();
+    assets.build(true);
+    fs::write(
+        assets.cache.path().join("metadata.yaml"),
+        "bat_version: 0.1.0\n",
+    )
+    .unwrap();
+    assets.names("Automatic One", "Writing syntax set");
+    assert_eq!(assets.generations().len(), 1);
+    assert_eq!(
+        fs::read_to_string(assets.cache.path().join("metadata.yaml")).unwrap(),
+        "bat_version: 0.1.0\n"
+    );
+}
+
+#[test]
+fn malformed_sources_fail_without_replacing_good_caches() {
+    let assets = Assets::new();
+    assets.build(true);
+    let original = fs::read(assets.cache.path().join("syntaxes.bin")).unwrap();
+    fs::write(
+        assets.source.path().join("syntaxes/custom.sublime-syntax"),
+        "contexts: [",
+    )
+    .unwrap();
+    assets
+        .command()
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains("Could not automatically rebuild"));
+    assert_eq!(
+        fs::read(assets.cache.path().join("syntaxes.bin")).unwrap(),
+        original
+    );
+    assert!(assets.generations().is_empty());
+    assets.syntax("Two");
+    assets.names("Automatic Two", "Automatic One");
+}
+
+#[test]
+fn additions_and_removals_invalidate_the_cache() {
+    let assets = Assets::new();
+    assets.build(true);
+    fs::rename(
+        assets.source.path().join("syntaxes/custom.sublime-syntax"),
+        assets.source.path().join("syntaxes/renamed.sublime-syntax"),
+    )
+    .unwrap();
+    assets.names("Automatic One", "Automatic Two");
+    assert_eq!(assets.generations().len(), 1);
+    fs::remove_file(assets.source.path().join("syntaxes/renamed.sublime-syntax")).unwrap();
+    assets.names("Rust", "Automatic One");
+    assert_eq!(assets.generations().len(), 2);
+}
+
+#[test]
+fn concurrent_builds_publish_one_complete_generation() {
+    let assets = Assets::new();
+    assets.build(true);
+    assets.syntax("Two");
+    let children: Vec<_> = (0..3)
+        .map(|_| {
+            assets
+                .command()
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .unwrap()
+        })
+        .collect();
+    for child in children {
+        let output = child.wait_with_output().unwrap();
+        output
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Automatic Two"))
+            .stderr("");
+    }
+    assert_eq!(assets.generations().len(), 1);
+}
+
+#[test]
+fn corrupt_automatic_generation_is_repaired() {
+    let assets = Assets::new();
+    assets.build(true);
+    assets.syntax("Two");
+    assets.names("Automatic Two", "Automatic One");
+    let generation = assets.generations().pop().unwrap();
+    fs::write(generation.join("syntaxes.bin"), "broken").unwrap();
+    assets.names("Automatic Two", "Automatic One");
+    assert_eq!(assets.generations(), vec![generation]);
+}
+
+#[test]
+fn manual_build_disables_automatic_mode_and_clear_removes_generations() {
+    let assets = Assets::new();
+    assets.build(true);
+    assets.syntax("Two");
+    assets.names("Automatic Two", "Automatic One");
+    assets.build(false);
+    assert!(!assets.cache.path().join("automatic.yaml").exists());
+    assets.syntax("Three");
+    assets.names("Automatic Two", "Automatic Three");
+    bat_with_config()
+        .current_dir(assets.source.path())
+        .args(["cache", "--clear"])
+        .env("BAT_CACHE_PATH", assets.cache.path())
+        .assert()
+        .success();
+    assert!(assets.generations().is_empty());
+    assert!(!assets.cache.path().join("syntaxes.bin").exists());
+}
+
+#[test]
+fn source_and_target_may_match_and_cache_filename_does_not_hide_rebuild() {
+    let assets = Assets::new();
+    bat_with_config()
+        .current_dir(assets.cache.path())
+        .args(["cache", "--build", "--automatic", "--blank"])
+        .arg("--source")
+        .arg(assets.source.path())
+        .arg("--target")
+        .arg(assets.source.path())
+        .assert()
+        .success();
+    fs::write(assets.source.path().join("cache"), "a file named cache").unwrap();
+    assets.syntax("Two");
+    bat()
+        .current_dir(assets.source.path())
+        .env("BAT_CACHE_PATH", assets.source.path())
+        .args(["--list-languages", "--color=never"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Automatic Two").and(predicate::str::contains("Rust").not()),
+        )
+        .stderr("");
+}
+
+#[test]
+fn unavailable_sources_can_be_bypassed_with_no_custom_assets() {
+    let assets = Assets::new();
+    assets.build(true);
+    fs::remove_dir_all(assets.source.path()).unwrap();
+    assets.command().assert().failure();
+    assets
+        .command()
+        .arg("--no-custom-assets")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Automatic One").not());
+}
+
+#[cfg(unix)]
+#[test]
+fn linked_source_content_is_tracked() {
+    let assets = Assets::new();
+    let linked = tempfile::tempdir().unwrap();
+    let source = assets.source.path().join("syntaxes/custom.sublime-syntax");
+    let destination = linked.path().join("linked.sublime-syntax");
+    fs::rename(&source, &destination).unwrap();
+    std::os::unix::fs::symlink(&destination, &source).unwrap();
+    assets.build(true);
+    assets.syntax("Two");
+    assets.names("Automatic Two", "Automatic One");
+}


### PR DESCRIPTION
Custom caches currently require a manual rebuild after a version mismatch or source change. Add `bat cache --build --automatic` to record source directories and build options and rebuild when their contents or bat's version change.

Repeat `--source` to combine system package assets with user assets. Later sources take precedence for theme names and syntax lookup. Link the syntax definitions together so user grammars can include system grammars, and collect acknowledgements from every source. Package scripts only install shared source files; each user's opt-in automatic cache refreshes after package updates, additions and removals. Shared paths are explicit and are never written by the builder. Preserve the public single-directory build API and add build_from_dirs for library callers.

Automatic mode follows source symlinks and uses content fingerprints. Rebuilds run locally with captured progress output and publish complete cache generations atomically. The explicit cache remains available to library clients; separate generations allow different bat versions to coexist. Failed builds preserve existing caches, concurrent builders reuse the same complete generation, and corrupt generations can be repaired. Single-source recipes remain readable.

Manual mode remains the default. A build without --automatic disables automatic updates. --no-custom-assets bypasses the mode, and cache --clear removes its recipe and generations. Document source-read costs, source availability and system/user setup, and update completions.

Validation: 490 tests passed with all features, including 17 new process/library regressions; seven platform/manual tests were ignored. Coverage includes source ordering, syntax/theme collisions, cross-source context linking, package updates/removals, acknowledgements, old recipes, unchanged timestamps, version incompatibility, malformed sources, concurrent builds, corruption repair, opt-out/clear, coincident source and target directories, missing sources and symlinks. All-target/all-feature Clippy, the minimal regex-onig library build, formatting and rendered Bash/Zsh completion syntax checks passed.

Fixes #2085 and #2559.