### PR TITLE
Add reproducible profile-guided builds and benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Other
 
+- Add an optional profile-guided build script with output verification and reproducible benchmarks, see #0 (@Matei02355)
+
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Other
 
-- Add an optional profile-guided build script with output verification and reproducible benchmarks, see #0 (@Matei02355)
+- Add an optional profile-guided build script with output verification and reproducible benchmarks, see #3983 (@Matei02355)
 
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536

--- a/README.md
+++ b/README.md
@@ -901,6 +901,9 @@ bash assets/create.sh
 cargo install --path . --locked --force
 ```
 
+For an optional profile-guided release build and local performance comparisons,
+see the [PGO build guide](doc/pgo.md).
+
 If you want to build an application that uses `bat`'s pretty-printing
 features as a library, check out the [API documentation](https://docs.rs/bat/).
 Note that you have to use either `regex-onig` or `regex-fancy` as a feature

--- a/doc/pgo.md
+++ b/doc/pgo.md
@@ -1,0 +1,50 @@
+# Profile-guided builds
+
+Profile-guided optimization (PGO) uses measurements from representative runs to
+guide compiler decisions. The resulting binary still accepts ordinary bat inputs
+and options. Performance depends on the training files and how the binary is used;
+measure the workloads that matter to you.
+
+The optional [build script](../scripts/build-pgo.py) follows the
+[Rust compiler's PGO workflow](https://doc.rust-lang.org/rustc/profile-guided-optimization.html).
+It requires Python 3, a Rust toolchain, and the matching LLVM tools:
+
+```sh
+rustup component add llvm-tools-preview
+python3 scripts/build-pgo.py --benchmark src/printer.rs Cargo.toml README.md
+```
+
+Without filenames, the script uses those three repository files. Supply examples
+of the languages and file sizes you normally read. Each file is used in both
+highlighted and plain modes. `--training-runs` controls repetition; its default is
+three. `--offline` uses Cargo's cached dependencies.
+
+The script builds for the compiler's native host target with bat's normal release
+settings and default features. It preserves additional compiler flags supplied via
+`RUSTFLAGS` or `CARGO_ENCODED_RUSTFLAGS`. An explicit target keeps instrumentation
+out of Cargo's build scripts. Compiler arguments use absolute, individually encoded
+profile paths, including when the work directory contains spaces.
+
+Each invocation creates its own directory under `target/pgo`, or under the path
+given by `--work-dir`. The directory contains build logs, raw profiles, merged
+profile data, and the optimized executable. Existing runs are retained. The final
+output prints the executable and `report.json` paths.
+
+Training records output hashes. The optimized binary must reproduce those hashes
+before the script reports success. Keep the inputs and their Git status unchanged
+throughout a run, because the highlighted workload includes Git decorations.
+Configuration files and custom assets are
+disabled for consistent training and comparison; the generated executable retains
+its normal configuration and custom-asset support.
+
+`--benchmark` also builds an ordinary release and checks its output against the
+training output. It warms both binaries, alternates their execution order, and
+records individual timings and medians for each file and display mode. Use
+`--benchmark-runs` to change the default ten repetitions. A reported ratio greater
+than one means the optimized binary was faster in that measurement. Small timing
+differences can be noise, especially for short files.
+
+The report records the compiler version, target, flags, input paths, output hashes,
+and raw benchmark results so a measurement can be reproduced. Rebuild and retrain
+after changing the compiler, source, release settings, or representative workload.
+The script enables LLVM's missing-profile warnings in the optimized build log.

--- a/scripts/build-pgo.py
+++ b/scripts/build-pgo.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Build bat with profile-guided optimization using representative input files."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MODES = {
+    "highlighted": ["--color=always", "--decorations=always", "--style=full"],
+    "plain": ["--color=never", "--decorations=never", "--style=plain"],
+}
+
+
+def positive(value):
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return number
+
+
+def run(command, **kwargs):
+    return subprocess.run(command, check=True, **kwargs)
+
+
+def tool_output(command):
+    return subprocess.check_output(command, cwd=ROOT, text=True).strip()
+
+
+def compiler_flags():
+    # Match Cargo's whitespace splitting for RUSTFLAGS, while preserving the
+    # encoded form exactly. Generated paths remain single compiler arguments.
+    encoded = os.environ.get("CARGO_ENCODED_RUSTFLAGS")
+    if encoded is not None:
+        flags = encoded.split("\x1f") if encoded else []
+    else:
+        flags = os.environ.get("RUSTFLAGS", "").split()
+    if any("profile-generate" in flag or "profile-use" in flag for flag in flags):
+        raise ValueError("remove existing PGO flags before starting a new training run")
+    return flags
+
+
+def build(stage, flags, args, host, directory):
+    env = os.environ.copy()
+    env.pop("RUSTFLAGS", None)
+    env["CARGO_ENCODED_RUSTFLAGS"] = "\x1f".join(flags)
+    env["CARGO_TARGET_DIR"] = str(directory / "cargo")
+    env["CARGO_INCREMENTAL"] = "0"
+    command = ["cargo", "build", "--locked", "--release", "--bin", "bat", "--target", host]
+    if args.offline:
+        command.append("--offline")
+    print(f"Building {stage}; log: {directory / (stage + '.log')}", flush=True)
+    with (directory / (stage + ".log")).open("wb") as log:
+        run(command, cwd=ROOT, env=env, stdout=log, stderr=subprocess.STDOUT)
+    suffix = ".exe" if os.name == "nt" else ""
+    binary = directory / ("bat-" + stage + suffix)
+    shutil.copy2(directory / "cargo" / host / "release" / ("bat" + suffix), binary)
+    return binary
+
+
+def display_environment(profiles=None):
+    env = {key: value for key, value in os.environ.items() if not key.startswith("BAT_")}
+    for key in ("NO_COLOR", "PAGER", "LESSOPEN", "LESSCLOSE", "LLVM_PROFILE_FILE"):
+        env.pop(key, None)
+    env["COLORTERM"] = "truecolor"
+    if profiles is not None:
+        env["LLVM_PROFILE_FILE"] = str(profiles / "%p-%m.profraw")
+    return env
+
+
+def display_command(binary, mode, source):
+    return [str(binary), "--no-config", "--no-custom-assets", "--paging=never",
+            "--theme=Monokai Extended", "--terminal-width=100", *MODES[mode], "--", str(source)]
+
+
+def digest(binary, mode, source, env):
+    # Hash incrementally so output checks also work for large training files.
+    with subprocess.Popen(display_command(binary, mode, source), stdout=subprocess.PIPE,
+                          env=env, cwd=ROOT) as child:
+        result = hashlib.sha256()
+        while True:
+            block = child.stdout.read(65536)
+            if not block:
+                break
+            result.update(block)
+        if child.wait() != 0:
+            raise subprocess.CalledProcessError(child.returncode, child.args)
+    return result.hexdigest()
+
+
+def benchmark(baseline, optimized, files, count):
+    env = display_environment()
+    results = []
+    for source in files:
+        for mode in MODES:
+            samples = {"baseline": [], "optimized": []}
+            binaries = {"baseline": baseline, "optimized": optimized}
+            for binary in binaries.values():
+                run(display_command(binary, mode, source), env=env, cwd=ROOT,
+                    stdout=subprocess.DEVNULL)
+            for iteration in range(count):
+                order = ["baseline", "optimized"] if iteration % 2 == 0 else ["optimized", "baseline"]
+                for label in order:
+                    start = time.perf_counter()
+                    run(display_command(binaries[label], mode, source), env=env, cwd=ROOT,
+                        stdout=subprocess.DEVNULL)
+                    samples[label].append(time.perf_counter() - start)
+            medians = {label: statistics.median(values) for label, values in samples.items()}
+            ratio = medians["baseline"] / medians["optimized"]
+            results.append({"file": str(source), "mode": mode, "seconds": samples,
+                            "median_seconds": medians, "speedup": ratio})
+            print(f"{source.name} ({mode}): {ratio:.3f}x baseline/optimized", flush=True)
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="*", type=Path, help="representative files for training")
+    parser.add_argument("--work-dir", type=Path, default=ROOT / "target" / "pgo")
+    parser.add_argument("--training-runs", type=positive, default=3)
+    parser.add_argument("--benchmark", action="store_true", help="also build and measure an ordinary release")
+    parser.add_argument("--benchmark-runs", type=positive, default=10)
+    parser.add_argument("--offline", action="store_true", help="use Cargo's cached dependencies")
+    args = parser.parse_args()
+    files = [path.resolve() for path in (args.files or [ROOT / "src/printer.rs", ROOT / "Cargo.toml", ROOT / "README.md"])]
+    for path in files:
+        if not path.is_file():
+            parser.error(f"input is not a regular file: {path}")
+    rustc = os.environ.get("RUSTC", "rustc")
+    version = tool_output([rustc, "-vV"])
+    host = next(line.split(": ", 1)[1] for line in version.splitlines() if line.startswith("host: "))
+    sysroot = Path(tool_output([rustc, "--print", "sysroot"]))
+    profdata = sysroot / "lib" / "rustlib" / host / "bin" / ("llvm-profdata.exe" if os.name == "nt" else "llvm-profdata")
+    if not profdata.is_file():
+        parser.error("llvm-profdata is missing; install it with: rustup component add llvm-tools-preview")
+    flags = compiler_flags()
+    work = args.work_dir.resolve()
+    work.mkdir(parents=True, exist_ok=True)
+    # Each run owns fresh profile data; existing profiles and binaries are kept.
+    directory = Path(tempfile.mkdtemp(prefix="run-", dir=work))
+    profiles = directory / "profiles"
+    profiles.mkdir()
+    print(f"Run directory: {directory}", flush=True)
+    baseline = build("baseline", flags, args, host, directory) if args.benchmark else None
+    instrumented = build("instrumented", flags + [f"-Cprofile-generate={profiles}"], args, host, directory)
+    expected = {}
+    env = display_environment(profiles)
+    print("Training and recording output hashes", flush=True)
+    for iteration in range(args.training_runs):
+        for source in files:
+            for mode in MODES:
+                value = digest(instrumented, mode, source, env)
+                key = (str(source), mode)
+                if key in expected and expected[key] != value:
+                    raise ValueError(f"input or output changed during training: {source}")
+                expected[key] = value
+    if not list(profiles.glob("*.profraw")):
+        raise ValueError("training produced no raw profiles")
+    merged = directory / "merged.profdata"
+    run([str(profdata), "merge", "-o", str(merged), str(profiles)], cwd=ROOT)
+    optimized = build("optimized", flags + [f"-Cprofile-use={merged}", "-Cllvm-args=-pgo-warn-missing-function"],
+                      args, host, directory)
+    for source in files:
+        for mode in MODES:
+            for binary in [optimized] + ([baseline] if baseline else []):
+                if digest(binary, mode, source, display_environment()) != expected[(str(source), mode)]:
+                    raise ValueError(f"output differs for {source} in {mode} mode")
+    report = {"rustc": version, "host": host, "compiler_flags": flags,
+              "files": [str(path) for path in files], "training_runs": args.training_runs,
+              "optimized_binary": str(optimized), "profile": str(merged),
+              "output_hashes": [{"file": path, "mode": mode, "sha256": value}
+                                for (path, mode), value in expected.items()],
+              "benchmarks": benchmark(baseline, optimized, files, args.benchmark_runs) if baseline else []}
+    report_path = directory / "report.json"
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"Optimized binary: {optimized}\nReport: {report_path}", flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"build-pgo: {error}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Provide an optional native-host PGO build workflow so developers can train and measure bat on their own files.

The Python 3 script builds with the matching toolchain's LLVM tools, gathers fresh profiles, merges them, and rebuilds with profile-use. It preserves compiler flags, isolates each run, supports paths containing spaces, and verifies output hashes before reporting success. An optional baseline build measures alternating, warmed runs and records raw timings, medians, compiler details and output hashes in JSON. Documentation explains setup, reproducibility and workload-dependent results. Normal release builds remain unchanged; BOLT and release-binary training are outside this change.

Addresses #2701.

Validation: completed all three release builds with Rust 1.91.1 / LLVM 21.1.2 on x86_64 Linux, offline, in a work directory containing spaces. Used two training repetitions and ten benchmark repetitions. Baseline, instrumented and optimized output hashes matched for all six training file/mode combinations. Separate large JSON and Python files not used for training also produced identical baseline/optimized output in both modes.

Measured medians (milliseconds; this machine/run only):

| Input | Mode | Baseline | PGO | Baseline/PGO |
| --- | --- | ---: | ---: | ---: |
| src/printer.rs | highlighted | 47.450 | 44.364 | 1.070 |
| Cargo.toml | highlighted | 10.259 | 8.891 | 1.154 |
| README.md | highlighted | 93.237 | 86.983 | 1.072 |
| src/printer.rs | plain | 2.076 | 1.936 | 1.072 |
| Cargo.toml | plain | 1.705 | 1.594 | 1.070 |
| README.md | plain | 2.174 | 2.252 | 0.965 |
| JSON holdout | highlighted | 1100.787 | 982.980 | 1.120 |
| Python holdout | highlighted | 1052.670 | 990.963 | 1.062 |
| JSON holdout | plain | 15.375 | 14.838 | 1.036 |
| Python holdout | plain | 7.780 | 7.436 | 1.046 |

Small timing differences can be noise; the plain README case regressed slightly. The holdout JSON contains 10,000 indented objects with id/name/enabled/values fields; Python repeats a three-line function 15,000 times. Compiler-flag inheritance and invalid inputs were also checked.