### PR TITLE
Keep the input filename in pager prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Features
 
+- Show the single input's filename in less and built-in pager prompts, see #0 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Show the single input's filename in less and built-in pager prompts, see #0 (@Matei02355)
+- Show the single input's filename in less and built-in pager prompts, see #3984 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -664,6 +664,16 @@ Instead of using environment variables, you can also use `bat`'s [configuration 
 
 ### Using `less` as a pager
 
+When displaying one file, `bat` includes its name in the `less` prompt, including
+the `-m`, `-M` and `=` views. This also works for input named with `--file-name`.
+The built-in pager shows the same name in its footer. For multiple inputs, the
+normal pager prompt is used because a single filename would be misleading.
+Control characters in names are displayed visibly.
+
+Custom `less -P` prompts still take precedence. If `LESS` might contain a custom
+prompt, `bat` leaves the prompts alone. This filename feature requires standard
+`less`; it is not enabled for BusyBox or other pagers.
+
 When using `less` as a pager, `bat` will automatically pass extra options along to `less`
 to improve the experience. Specifically, `-R`/`--RAW-CONTROL-CHARS`, `-F`/`--quit-if-one-screen`,
 `-K`/`--quit-on-intr` and under certain conditions, `-X`/`--no-init` and/or `-S`/`--chop-long-lines`.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -76,10 +76,21 @@ impl Controller<'_> {
 
             let wrapping_mode = self.config.wrapping_mode;
 
-            output_type_opt = Some(OutputType::from_mode(
+            let filename = match inputs.as_slice() {
+                [input]
+                    if matches!(input.kind, InputKind::OrdinaryFile(_))
+                        || input.metadata.user_provided_name.is_some()
+                        || input.description.title() != &input.description.name =>
+                {
+                    Some(input.description.title().as_str())
+                }
+                _ => None,
+            };
+            output_type_opt = Some(OutputType::from_mode_with_filename(
                 paging_mode,
                 wrapping_mode,
                 self.config.pager,
+                filename,
             )?);
         }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,6 +14,31 @@ use crate::paging::PagingMode;
 use crate::wrapping::WrappingMode;
 
 #[cfg(feature = "paging")]
+fn prompt_filename(filename: &str) -> String {
+    crate::preprocessor::sanitize_for_terminal(filename).replace('\t', "^I")
+}
+
+#[cfg(feature = "paging")]
+fn less_filename_prompts(filename: &str) -> [String; 4] {
+    let mut escaped = String::new();
+    for character in prompt_filename(filename).chars() {
+        if matches!(character, '?' | ':' | '.' | '%' | '\\') {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    // If the user opens another file with :e, less knows its real name.
+    let name = format!("?f%f:{escaped}.");
+    let detail = " ?ltlines %lt-%lb?L/%L.. ?e(END).%t";
+    [
+        format!("s{name} ?e(END).%t"),
+        format!("m{name}{detail}"),
+        format!("M{name}{detail}"),
+        format!("={name}{detail}"),
+    ]
+}
+
+#[cfg(feature = "paging")]
 pub struct BuiltinPager {
     pager: minus::Pager,
     handle: Option<JoinHandle<Result<()>>>,
@@ -21,8 +46,13 @@ pub struct BuiltinPager {
 
 #[cfg(feature = "paging")]
 impl BuiltinPager {
-    fn new() -> Self {
+    fn new(filename: Option<&str>) -> Self {
         let pager = minus::Pager::new();
+        if let Some(filename) = filename {
+            pager
+                .set_prompt(prompt_filename(filename))
+                .expect("failed to set prompt on newly created pager");
+        }
 
         let mut input_register = minus::input::HashedEventRegister::default();
         input_register.add_key_events(&["home"], |_, _| {
@@ -78,11 +108,23 @@ impl OutputType {
         wrapping_mode: WrappingMode,
         pager: Option<&str>,
     ) -> Result<Self> {
+        Self::from_mode_with_filename(paging_mode, wrapping_mode, pager, None)
+    }
+
+    #[cfg(feature = "paging")]
+    pub(crate) fn from_mode_with_filename(
+        paging_mode: PagingMode,
+        wrapping_mode: WrappingMode,
+        pager: Option<&str>,
+        filename: Option<&str>,
+    ) -> Result<Self> {
         use self::PagingMode::*;
         Ok(match paging_mode {
-            Always => OutputType::try_pager(SingleScreenAction::Nothing, wrapping_mode, pager)?,
+            Always => {
+                OutputType::try_pager(SingleScreenAction::Nothing, wrapping_mode, pager, filename)?
+            }
             QuitIfOneScreen => {
-                OutputType::try_pager(SingleScreenAction::Quit, wrapping_mode, pager)?
+                OutputType::try_pager(SingleScreenAction::Quit, wrapping_mode, pager, filename)?
             }
             _ => OutputType::stdout(),
         })
@@ -94,6 +136,7 @@ impl OutputType {
         single_screen_action: SingleScreenAction,
         wrapping_mode: WrappingMode,
         pager_from_config: Option<&str>,
+        filename: Option<&str>,
     ) -> Result<Self> {
         use crate::pager::{self, PagerKind, PagerSource};
         use std::process::{Command, Stdio};
@@ -111,7 +154,7 @@ impl OutputType {
         }
 
         if pager.kind == PagerKind::Builtin {
-            return Ok(OutputType::BuiltinPager(BuiltinPager::new()));
+            return Ok(OutputType::BuiltinPager(BuiltinPager::new(filename)));
         }
 
         let resolved_path = match grep_cli::resolve_binary(&pager.bin) {
@@ -129,6 +172,26 @@ impl OutputType {
         let args = pager.args;
 
         if pager.kind == PagerKind::Less {
+            let less_version = if filename.is_some()
+                || args.is_empty()
+                || pager.source == PagerSource::EnvVarPager
+            {
+                retrieve_less_version(&pager.bin)
+            } else {
+                None
+            };
+            let less_options = std::env::var("LESS").unwrap_or_default();
+            if let (Some(filename), Some(LessVersion::Less(_))) = (filename, &less_version) {
+                // LESS is a separate option language, not shell words. Be conservative
+                // when it might contain a user prompt; do not replace that prompt.
+                if !less_options.contains('P') && !less_options.contains("prompt") {
+                    for prompt in less_filename_prompts(filename) {
+                        // Keep the value in a separate argument. In a combined -Pvalue
+                        // option, less treats '$' inside a filename as an option separator.
+                        p.arg("-P").arg(prompt);
+                    }
+                }
+            }
             // less needs to be called with the '-R' option in order to properly interpret the
             // ANSI color sequences printed by bat. If someone has set PAGER="less -F", we
             // therefore need to overwrite the arguments and add '-R'.
@@ -146,8 +209,6 @@ impl OutputType {
                 if wrapping_mode == WrappingMode::NoWrapping(true) {
                     p.arg("-S"); // Short version of --chop-long-lines for compatibility
                 }
-
-                let less_version = retrieve_less_version(&pager.bin);
 
                 // Ensures that 'less' quits together with 'bat'
                 // The BusyBox version of less does not support -K

--- a/tests/pager_filename.rs
+++ b/tests/pager_filename.rs
@@ -1,0 +1,167 @@
+#![cfg(all(unix, feature = "paging"))]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use tempfile::{tempdir, TempDir};
+
+mod utils;
+use utils::command::bat;
+
+struct Pager {
+    directory: TempDir,
+    arguments: PathBuf,
+}
+
+impl Pager {
+    fn new(name: &str, busybox: bool) -> Self {
+        let directory = tempdir().unwrap();
+        let script = directory.path().join(name);
+        let version = if busybox {
+            "printf 'BusyBox v1.35.0\n' >&2; exit 1"
+        } else {
+            "printf 'less 590\n'; exit 0"
+        };
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = --version ]; then {version}; fi\nprintf '%s\\n' \"$@\" > \"$BAT_TEST_PAGER_ARGS\"\ncat\n"
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o700)).unwrap();
+        let arguments = directory.path().join("arguments");
+        Self {
+            directory,
+            arguments,
+        }
+    }
+
+    fn command(&self, name: &str, options: &[&str]) -> assert_cmd::Command {
+        let binary = self.directory.path().join(name);
+        let pager = shell_words::join(
+            std::iter::once(binary.to_str().unwrap()).chain(options.iter().copied()),
+        );
+        let mut command = bat();
+        command
+            .args(["--paging=always", "--style=plain", "--pager", &pager])
+            .env_remove("LESS")
+            .env("BAT_TEST_PAGER_ARGS", &self.arguments);
+        command
+    }
+
+    fn args(&self) -> Vec<String> {
+        fs::read_to_string(&self.arguments)
+            .unwrap()
+            .lines()
+            .filter(|argument| *argument != "--no-lessopen")
+            .map(str::to_owned)
+            .collect()
+    }
+}
+
+#[test]
+fn less_receives_literal_filename_for_all_prompt_views() {
+    let pager = Pager::new("less", false);
+    pager
+        .command("less", &["-RFM"])
+        .args(["--file-name", "file?.:%\\$ name\n\t\x1b.txt", "test.txt"])
+        .assert()
+        .success()
+        .stdout("hello world\n");
+    let args = pager.args();
+    let values: Vec<_> = args
+        .windows(2)
+        .filter(|pair| pair[0] == "-P")
+        .map(|pair| &pair[1])
+        .collect();
+    assert_eq!(values.len(), 4);
+    for (value, selector) in values.iter().zip(['s', 'm', 'M', '=']) {
+        assert!(value.starts_with(selector));
+        assert!(
+            value.contains(r"file\?\.\:\%\\$ name^J^I^[\.txt"),
+            "{value:?}"
+        );
+        assert!(!value.contains('\x1b'));
+    }
+    assert_eq!(args.last().unwrap(), "-RFM");
+}
+
+#[test]
+fn less_uses_named_stdin_but_not_anonymous_or_multiple_inputs() {
+    let pager = Pager::new("less", false);
+    pager
+        .command("less", &["-R"])
+        .args(["--file-name", "named.txt"])
+        .write_stdin("input\n")
+        .assert()
+        .success()
+        .stdout("input\n");
+    assert!(pager.args().iter().any(|arg| arg.contains(r"named\.txt")));
+    pager
+        .command("less", &["-R"])
+        .write_stdin("input\n")
+        .assert()
+        .success()
+        .stdout("input\n");
+    assert_eq!(pager.args(), ["-R"]);
+    pager
+        .command("less", &["-R"])
+        .args(["test.txt", "test.txt"])
+        .assert()
+        .success()
+        .stdout("hello world\nhello world\n");
+    assert_eq!(pager.args(), ["-R"]);
+}
+
+#[test]
+fn explicit_less_prompt_follows_generated_defaults() {
+    let pager = Pager::new("less", false);
+    pager
+        .command("less", &["-R", "-P", "Mcustom prompt"])
+        .arg("test.txt")
+        .assert()
+        .success();
+    assert!(pager
+        .args()
+        .ends_with(&["-R".into(), "-P".into(), "Mcustom prompt".into()]));
+}
+
+#[test]
+fn less_environment_prompt_is_preserved() {
+    let pager = Pager::new("less", false);
+    for options in ["-R -PMcustom", "RMPcustom", "--prompt=custom"] {
+        pager
+            .command("less", &["-R"])
+            .env("LESS", options)
+            .arg("test.txt")
+            .assert()
+            .success();
+        assert_eq!(pager.args(), ["-R"]);
+    }
+}
+
+#[test]
+fn busybox_and_other_pagers_receive_no_prompt_options() {
+    for (name, busybox) in [("less", true), ("other-pager", false)] {
+        let pager = Pager::new(name, busybox);
+        pager
+            .command(name, &["-R"])
+            .arg("test.txt")
+            .assert()
+            .success();
+        assert_eq!(pager.args(), ["-R"]);
+    }
+}
+
+#[test]
+fn unpaged_output_does_not_launch_the_pager() {
+    let pager = Pager::new("less", false);
+    pager
+        .command("less", &["-R"])
+        .args(["--paging=never", "test.txt"])
+        .assert()
+        .success()
+        .stdout("hello world\n");
+    assert!(!Path::new(&pager.arguments).exists());
+}


### PR DESCRIPTION
When bat sends highlighted input over a pipe, less cannot determine its original filename. Long files therefore lose their visible identity once the header scrolls away.

Pass a single input's display name to the pager. Standard less shows it in the short, medium, long and `=` prompts, while the built-in pager uses it as its footer. Named stdin and library input titles work too. Multiple inputs retain the normal prompt. If the user opens a different file inside less, its actual name is displayed.

Escape less prompt metacharacters and display control characters visibly. Pass prompt values as separate arguments so a dollar sign in a filename cannot introduce more less options. Explicit command-line prompts take precedence; potentially customized prompts in LESS are left alone. BusyBox and unknown pagers receive no filename options. The existing public OutputType::from_mode API remains available unchanged.

Fixes #1855.

Validation: 479 tests passed with all features and a single test thread, including six new process regressions; seven platform/manual tests were ignored. All-target/all-feature Clippy, formatting and the minimal regex-onig library build passed. Real PTY sessions with less 590 verified short/medium/long/`=` views and an explicit custom prompt; a real built-in pager session also displayed the sanitized filename and exited normally. These checks included spaces, punctuation, backslashes, dollar signs, newline, tab and ESC in the display name. An initial parallel run hit an unrelated LESSOPEN test; its focused rerun and the complete serial suite passed.