### PR TITLE
Support right-side sidebar decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Features
 
+- Add the `sidebar-right` style modifier and `PrettyPrinter::sidebar_right()` for right-side decorations, see #0 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add the `sidebar-right` style modifier and `PrettyPrinter::sidebar_right()` for right-side decorations, see #0 (@Matei02355)
+- Add the `sidebar-right` style modifier and `PrettyPrinter::sidebar_right()` for right-side decorations, see #3985 (@Matei02355)
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -640,6 +640,18 @@ syntax, use (this mapping is already built in):
 --map-syntax='/etc/apache2/**/*.conf:Apache Conf'
 ```
 
+### Placing the sidebar on the right
+
+Use `bat --style=default,sidebar-right file` to put line numbers and Git markers
+to the right of the content. `--style=+sidebar-right` adds this placement to your
+configured style, and `--style=-sidebar-right` restores the left side. The modifier
+changes placement without enabling decorations by itself.
+
+Wrapped continuation rows retain an empty sidebar. With wrapping disabled, content
+wider than the available area places its sidebar after the complete line. Moving
+the sidebar does not remove it from a multiline terminal selection; use plain
+output when copying undecorated text.
+
 ### Using a different pager
 
 `bat` uses the pager that is specified in the `PAGER` environment variable. If this variable is not

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -5,7 +5,7 @@ using namespace System.Management.Automation.Language
 Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
-    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
+    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip', 'sidebar-right')
     $ArrayCompletion = @('bash', 'fish', 'zsh', 'ps1')
     $ArrayWhen       = @('auto', 'never', 'always')
     $ArrayYesNo      = @('never', 'always')
@@ -152,7 +152,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
             [CompletionResult]::new('--theme'                 , 'theme'                 , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting.')
             [CompletionResult]::new('--theme-dark'            , 'themedark'             , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for dark backgrounds.')
             [CompletionResult]::new('--theme-light'           , 'themelight'            , [CompletionResultType]::ParameterName, 'Set the color theme for syntax highlighting for light backgrounds.')
-            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).')
+            [CompletionResult]::new('--style'                 , 'style'                 , [CompletionResultType]::ParameterName, 'Comma-separated list of style elements to display (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip, sidebar-right).')
         #   [CompletionResult]::new('-r'                      , 'r'                     , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
             [CompletionResult]::new('--line-range'            , 'line-range'            , [CompletionResultType]::ParameterName, 'Only print the lines from N to M.')
         #   [CompletionResult]::new('-A'                      , 'A'                     , [CompletionResultType]::ParameterName, 'Show non-printable characters (space, tab, newline, ..).')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -179,6 +179,7 @@ _bat() {
 			grid
 			rule
 			numbers
+			sidebar-right
 			snip
 		)
 		# shellcheck disable=SC2016

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -84,6 +84,7 @@ function __bat_style_opts
         "header-filesize,filesize above content" \
         "grid,lines b/w sidebar/header/content" \
         "numbers,line numbers in sidebar" \
+        "sidebar-right,sidebar decorations on the right" \
         "rule,separate files" \
         "snip,separate ranges"
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -56,7 +56,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
-            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+            default auto full plain changes header header-filename header-filesize grid rule numbers snip sidebar-right'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
         '(* -)'{-L,--list-languages}'[display all supported languages]'
         '(-u --unbuffered)'--unbuffered'[enable unbuffered input reading for streaming use cases]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -243,7 +243,12 @@ By default, the following components are enabled:
 changes, grid, header\-filename, numbers, snip
 .IP
 Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
-rule, numbers, snip.
+rule, numbers, snip, sidebar-right.
+.PP
+The sidebar-right modifier moves the selected line numbers, Git markers and grid
+to the right of the content. For example, '--style=default,sidebar-right' uses the
+default decorations on the right. It does not enable decorations by itself.
+With wrapping disabled, overlong content places its sidebar after the complete line.
 .HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...
 .IP

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -201,7 +201,7 @@ Options:
           Possible values:
           
             * default: enables recommended style components (default).
-            * full: enables all available components.
+            * full: enables all decorations.
             * auto: same as 'default', unless the output is piped.
             * plain: disables all available components.
             * changes: show Git modification markers.
@@ -213,6 +213,7 @@ Options:
             * rule: horizontal lines to delimit files.
             * numbers: show line numbers in the side bar.
             * snip: draw separation lines between distinct line ranges.
+            * sidebar-right: place the selected sidebar decorations on the right.
 
   -r, --line-range <N:M>
           Only print the specified range of lines for each file. For example:

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -57,7 +57,7 @@ Options:
           Squeeze consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
-          header, header-filename, header-filesize, grid, rule, numbers, snip).
+          header, header-filename, header-filesize, grid, rule, numbers, snip, sidebar-right).
   -r, --line-range <N:M>
           Only print the lines from N to M.
   -L, --list-languages

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -630,7 +630,21 @@ impl App {
     fn style_components(&self) -> Result<StyleComponents> {
         let matches = &self.matches;
         let mut styled_components = match self.forced_style_components() {
-            Some(forced_components) => forced_components,
+            Some(mut forced_components) => {
+                // Number/plain shortcuts choose decorations; sidebar-right only
+                // changes their placement and does not enable another decoration.
+                if let Some(styles) = matches.get_many::<String>("style") {
+                    let lists = styles
+                        .map(|style| StyleComponentList::from_str(style))
+                        .collect::<Result<Vec<_>>>()?;
+                    if StyleComponentList::to_components(lists, self.interactive_output, false)
+                        .sidebar_right()
+                    {
+                        forced_components.insert(StyleComponent::SidebarRight);
+                    }
+                }
+                forced_components
+            }
 
             // Parse the `--style` arguments and merge them.
             None if matches.contains_id("style") => {

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -534,7 +534,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).",
+                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip, sidebar-right).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -554,7 +554,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                         changes, grid, header-filename, numbers, snip\n\n\
                      Possible values:\n\n  \
                      * default: enables recommended style components (default).\n  \
-                     * full: enables all available components.\n  \
+                     * full: enables all decorations.\n  \
                      * auto: same as 'default', unless the output is piped.\n  \
                      * plain: disables all available components.\n  \
                      * changes: show Git modification markers.\n  \
@@ -565,7 +565,8 @@ pub fn build_app(interactive_output: bool) -> Command {
                        and the header from the content.\n  \
                      * rule: horizontal lines to delimit files.\n  \
                      * numbers: show line numbers in the side bar.\n  \
-                     * snip: draw separation lines between distinct line ranges.",
+                     * snip: draw separation lines between distinct line ranges.\n  \
+                     * sidebar-right: place the selected sidebar decorations on the right.",
                 ),
         )
         .arg(

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -26,6 +26,7 @@ struct ActiveStyleComponents {
     grid: bool,
     rule: bool,
     line_numbers: bool,
+    sidebar_right: bool,
     snip: bool,
 }
 
@@ -148,6 +149,12 @@ impl<'a> PrettyPrinter<'a> {
     /// Whether to show line numbers
     pub fn line_numbers(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.line_numbers = yes;
+        self
+    }
+
+    /// Whether to place the selected sidebar decorations on the right.
+    pub fn sidebar_right(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.sidebar_right = yes;
         self
     }
 
@@ -318,6 +325,11 @@ impl<'a> PrettyPrinter<'a> {
             self.config
                 .style_components
                 .insert(StyleComponent::LineNumbers);
+        }
+        if self.active_style_components.sidebar_right {
+            self.config
+                .style_components
+                .insert(StyleComponent::SidebarRight);
         }
         if self.active_style_components.snip {
             self.config.style_components.insert(StyleComponent::Snip);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -367,7 +367,12 @@ impl<'a> InteractivePrinter<'a> {
             self.print_horizontal_line_term(handle, self.colors.grid)?;
         } else {
             let hline = "─".repeat(self.config.term_width - (self.panel_width + 1));
-            let hline = format!("{}{grid_char}{hline}", "─".repeat(self.panel_width));
+            let panel = "─".repeat(self.panel_width);
+            let hline = if self.right_sidebar() {
+                format!("{hline}{grid_char}{panel}")
+            } else {
+                format!("{panel}{grid_char}{hline}")
+            };
             writeln!(handle, "{}", self.colors.grid.paint(hline))?;
         }
 
@@ -384,7 +389,13 @@ impl<'a> InteractivePrinter<'a> {
             "{text_truncated}{}",
             " ".repeat(self.panel_width - 1 - text_truncated.len())
         );
-        if self.config.style_components.grid() {
+        if self.right_sidebar() {
+            if self.config.style_components.grid() {
+                format!(" │ {text_filled}")
+            } else {
+                format!(" {text_filled}")
+            }
+        } else if self.config.style_components.grid() {
             format!("{text_filled} │ ")
         } else {
             text_filled
@@ -419,8 +430,55 @@ impl<'a> InteractivePrinter<'a> {
         handle: &mut OutputHandle,
         content: &str,
     ) -> Result<()> {
-        self.print_header_component_indent(handle)?;
-        writeln!(handle, "{content}")
+        if self.right_sidebar() {
+            let available = self.config.term_width - self.get_header_component_indent_length();
+            write!(
+                handle,
+                "{content}{}",
+                " ".repeat(available.saturating_sub(console::measure_text_width(content)))
+            )?;
+            if self.config.style_components.grid() {
+                write!(handle, "{}", self.colors.grid.paint(" │"))?;
+            }
+            writeln!(handle, "{}", " ".repeat(self.panel_width))
+        } else {
+            self.print_header_component_indent(handle)?;
+            writeln!(handle, "{content}")
+        }
+    }
+
+    fn right_sidebar(&self) -> bool {
+        self.panel_width > 0 && self.config.style_components.sidebar_right()
+    }
+
+    fn right_panel(&self, line_number: usize, continuation: bool) -> String {
+        let mut panel = String::new();
+        for decoration in self.decorations.iter().rev() {
+            panel.push(' ');
+            panel.push_str(&decoration.generate(line_number, continuation, self).text);
+        }
+        panel
+    }
+
+    fn print_right_panel(
+        &self,
+        handle: &mut OutputHandle,
+        panel: &str,
+        cursor: usize,
+        width: usize,
+        background: Option<Color>,
+    ) -> Result<()> {
+        let padding = " ".repeat(width.saturating_sub(cursor));
+        let style = Style {
+            background: background.and_then(|color| to_ansi_color(color, self.config.true_color)),
+            ..Default::default()
+        };
+        write!(
+            handle,
+            "{}{}{panel}",
+            self.ansi_style.to_reset_sequence(),
+            style.paint(padding)
+        )
     }
 
     fn print_header_multiline_component(
@@ -637,9 +695,17 @@ impl Printer for InteractivePrinter<'_> {
         writeln!(
             handle,
             "{}",
-            self.colors
-                .grid
-                .paint(format!("{panel}{snip_left}{title}{snip_right}"))
+            self.colors.grid.paint(if self.right_sidebar() {
+                let snip = format!("{snip_left}{title}{snip_right}");
+                let padding = self
+                    .config
+                    .term_width
+                    .saturating_sub(panel_count)
+                    .saturating_sub(console::measure_text_width(&snip));
+                format!("{snip}{}{panel}", " ".repeat(padding))
+            } else {
+                format!("{panel}{snip_left}{title}{snip_right}")
+            })
         )?;
 
         Ok(())
@@ -719,6 +785,9 @@ impl Printer for InteractivePrinter<'_> {
         let mut cursor_max: usize = self.config.term_width;
         let mut cursor_total: usize = 0;
         let mut panel_wrap: Option<String> = None;
+        let right_sidebar = self.right_sidebar();
+        let mut right_panel = String::new();
+        let mut panel_written = false;
 
         // Line highlighting
         let highlight_this_line = self
@@ -751,8 +820,13 @@ impl Printer for InteractivePrinter<'_> {
                 .map(|d| d.generate(display_line_number, false, self));
 
             for deco in decorations {
-                write!(handle, "{} ", deco.text)?;
+                if !right_sidebar {
+                    write!(handle, "{} ", deco.text)?;
+                }
                 cursor_max -= deco.width + 1;
+            }
+            if right_sidebar {
+                right_panel = self.right_panel(display_line_number, false);
             }
         }
 
@@ -770,6 +844,9 @@ impl Printer for InteractivePrinter<'_> {
                         EscapeSequence::Text(text) => {
                             let text = self.preprocess(text, &mut cursor_total);
                             let text_trimmed = text.trim_end_matches(['\r', '\n']);
+                            if right_sidebar {
+                                cursor += text_trimmed.chars().map(char_width).sum::<usize>();
+                            }
 
                             write!(
                                 handle,
@@ -787,7 +864,16 @@ impl Printer for InteractivePrinter<'_> {
 
                             // Pad the rest of the line.
                             if text.len() != text_trimmed.len() {
-                                if let Some(background_color) = background_color {
+                                if right_sidebar {
+                                    self.print_right_panel(
+                                        handle,
+                                        &right_panel,
+                                        cursor,
+                                        cursor_max,
+                                        background_color,
+                                    )?;
+                                    panel_written = true;
+                                } else if let Some(background_color) = background_color {
                                     let ansi_style = Style {
                                         background: to_ansi_color(background_color, true_color),
                                         ..Default::default()
@@ -813,6 +899,9 @@ impl Printer for InteractivePrinter<'_> {
                 }
             }
 
+            if right_sidebar && !panel_written {
+                self.print_right_panel(handle, &right_panel, cursor, cursor_max, background_color)?;
+            }
             if !self.config.style_components.plain() && line.bytes().next_back() != Some(b'\n') {
                 writeln!(handle)?;
             }
@@ -854,7 +943,9 @@ impl Printer for InteractivePrinter<'_> {
                                 if current_width > max_width {
                                     // Generate wrap padding if not already generated.
                                     if panel_wrap.is_none() {
-                                        panel_wrap = if self.panel_width > 0 {
+                                        panel_wrap = if right_sidebar {
+                                            Some(self.right_panel(line_number, true))
+                                        } else if self.panel_width > 0 {
                                             Some(format!(
                                                 "{} ",
                                                 self.decorations
@@ -893,7 +984,7 @@ impl Printer for InteractivePrinter<'_> {
                                     // It wraps.
                                     write!(
                                         handle,
-                                        "{}{}\n{}",
+                                        "{}{}",
                                         as_terminal_escaped(
                                             style,
                                             &format!(
@@ -906,9 +997,26 @@ impl Printer for InteractivePrinter<'_> {
                                             self.config.use_italic_text,
                                             background_color
                                         ),
-                                        self.ansi_style.to_reset_sequence(),
-                                        panel_wrap.clone().unwrap()
+                                        self.ansi_style.to_reset_sequence()
                                     )?;
+                                    if right_sidebar {
+                                        let emitted_width = cursor
+                                            + line_buf[..emit_end]
+                                                .chars()
+                                                .map(char_width)
+                                                .sum::<usize>();
+                                        self.print_right_panel(
+                                            handle,
+                                            &right_panel,
+                                            emitted_width,
+                                            cursor_max,
+                                            background_color,
+                                        )?;
+                                        right_panel = panel_wrap.clone().unwrap();
+                                        writeln!(handle)?;
+                                    } else {
+                                        write!(handle, "\n{}", panel_wrap.as_deref().unwrap())?;
+                                    }
 
                                     cursor = 0;
                                     max_width = cursor_max;
@@ -956,7 +1064,9 @@ impl Printer for InteractivePrinter<'_> {
                 }
             }
 
-            if let Some(background_color) = background_color {
+            if right_sidebar {
+                self.print_right_panel(handle, &right_panel, cursor, cursor_max, background_color)?;
+            } else if let Some(background_color) = background_color {
                 let ansi_style = Style {
                     background: to_ansi_color(background_color, self.config.true_color),
                     ..Default::default()

--- a/src/style.rs
+++ b/src/style.rs
@@ -15,6 +15,7 @@ pub enum StyleComponent {
     HeaderFilename,
     HeaderFilesize,
     LineNumbers,
+    SidebarRight,
     Snip,
     Full,
     Default,
@@ -39,6 +40,7 @@ impl StyleComponent {
             StyleComponent::HeaderFilename => &[StyleComponent::HeaderFilename],
             StyleComponent::HeaderFilesize => &[StyleComponent::HeaderFilesize],
             StyleComponent::LineNumbers => &[StyleComponent::LineNumbers],
+            StyleComponent::SidebarRight => &[StyleComponent::SidebarRight],
             StyleComponent::Snip => &[StyleComponent::Snip],
             StyleComponent::Full => &[
                 #[cfg(feature = "git")]
@@ -76,6 +78,7 @@ impl FromStr for StyleComponent {
             "header-filename" => Ok(StyleComponent::HeaderFilename),
             "header-filesize" => Ok(StyleComponent::HeaderFilesize),
             "numbers" => Ok(StyleComponent::LineNumbers),
+            "sidebar-right" => Ok(StyleComponent::SidebarRight),
             "snip" => Ok(StyleComponent::Snip),
             "full" => Ok(StyleComponent::Full),
             "default" => Ok(StyleComponent::Default),
@@ -127,7 +130,13 @@ impl StyleComponents {
     }
 
     pub fn plain(&self) -> bool {
-        self.0.iter().all(|c| c == &StyleComponent::Plain)
+        self.0
+            .iter()
+            .all(|c| matches!(c, StyleComponent::Plain | StyleComponent::SidebarRight))
+    }
+
+    pub fn sidebar_right(&self) -> bool {
+        self.0.contains(&StyleComponent::SidebarRight)
     }
 
     pub fn insert(&mut self, component: StyleComponent) {

--- a/tests/right_sidebar.rs
+++ b/tests/right_sidebar.rs
@@ -1,0 +1,209 @@
+use bat::{PrettyPrinter, WrappingMode};
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+mod utils;
+use utils::command::bat;
+
+fn render(arguments: &[&str], input: &str) -> String {
+    let output = bat()
+        .args([
+            "--color=never",
+            "--decorations=always",
+            "--paging=never",
+            "--terminal-width=20",
+            "--style=numbers,grid,sidebar-right",
+        ])
+        .args(arguments)
+        .write_stdin(input)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(output).unwrap()
+}
+
+fn rows(output: &str) -> Vec<&str> {
+    output.lines().filter(|line| line.contains('│')).collect()
+}
+
+#[test]
+fn numbers_grid_and_horizontal_rules_move_together() {
+    assert_eq!(
+        render(&[], "short\nnext\n"),
+        concat!(
+            "──────────────┬─────\n",
+            "short         │    1\n",
+            "next          │    2\n",
+            "──────────────┴─────\n",
+        )
+    );
+}
+
+#[test]
+fn character_and_word_wrap_keep_the_number_on_the_first_row() {
+    let output = render(&["--wrap=character"], &("界".repeat(10) + "\n"));
+    assert_eq!(
+        rows(&output),
+        ["界界界界界界  │    1", "界界界界      │     "]
+    );
+    for line in rows(&output) {
+        assert_eq!(console::measure_text_width(line), 20);
+    }
+    let output = render(&["--wrap=word"], "alpha beta gamma delta\n");
+    assert_eq!(
+        rows(&output),
+        ["alpha beta    │    1", "gamma delta   │     "]
+    );
+}
+
+#[test]
+fn unwrapped_unicode_line_endings_and_long_content_are_preserved() {
+    let output = render(&["--wrap=never"], "界界\r\nlast");
+    assert!(output.contains("界界          │    1\r\n"));
+    assert!(output.contains("last          │    2\n"));
+    for line in rows(&output) {
+        assert_eq!(console::measure_text_width(line), 20);
+    }
+    let text = "x".repeat(30);
+    let output = render(&["--wrap=never"], &(text.clone() + "\n"));
+    assert_eq!(rows(&output), [format!("{text} │    1")]);
+}
+
+#[test]
+fn tabs_blank_numbers_and_ansi_highlights_remain_aligned() {
+    let output = render(
+        &["--tabs=4", "--number-nonblank", "--wrap=never"],
+        "a\tb\n\n",
+    );
+    assert_eq!(output, format!("{:<19}1\n{}\n", "a   b", " ".repeat(20)));
+    for wrap in ["never", "character", "word"] {
+        let output = render(
+            &[
+                "--wrap",
+                wrap,
+                "--color=always",
+                "--theme=Monokai Extended",
+                "--highlight-line=1",
+            ],
+            "\x1b[31mred\x1b[0m text\n",
+        );
+        let plain = console::strip_ansi_codes(&output);
+        assert_eq!(rows(&plain), ["red text      │    1"]);
+        assert!(
+            output.contains("48;"),
+            "missing highlighted background: {output:?}"
+        );
+    }
+}
+
+#[test]
+fn headers_and_snips_follow_the_right_grid() {
+    let output = render(
+        &[
+            "--style=full,sidebar-right",
+            "--file-name=notes.txt",
+            "--line-range=1:1",
+            "--line-range=3:3",
+        ],
+        "first\nskip\nlast\n",
+    );
+    for row in rows(&output) {
+        assert_eq!(console::measure_text_width(row), 20, "{row:?}");
+        assert_eq!(
+            console::measure_text_width(row.split_once('│').unwrap().0),
+            14,
+            "{row:?}"
+        );
+    }
+    let snip = output.lines().find(|line| line.contains("8<")).unwrap();
+    assert!(snip.find("8<").unwrap() < snip.find("...").unwrap());
+}
+
+#[test]
+fn placement_is_opt_in_and_does_not_enable_decorations() {
+    assert_eq!(
+        render(&["--style=plain,sidebar-right"], "unchanged"),
+        render(&["--style=plain"], "unchanged")
+    );
+    let left = render(&["--style=-sidebar-right"], "text\n");
+    assert!(left.contains("   1 │ text\n"));
+    let narrow = render(&["--terminal-width=5"], "small\n");
+    assert!(!narrow.contains('│'));
+    assert!(narrow.contains("small\n"));
+}
+
+#[test]
+fn library_callers_can_place_and_reset_the_sidebar() {
+    for right in [true, false] {
+        let mut output = String::new();
+        PrettyPrinter::new()
+            .input_from_bytes(b"text\n")
+            .colored_output(false)
+            .line_numbers(true)
+            .grid(true)
+            .term_width(20)
+            .wrapping_mode(WrappingMode::Character)
+            .sidebar_right(!right)
+            .sidebar_right(right)
+            .print_with_writer(Some(&mut output))
+            .unwrap();
+        assert!(output.contains(if right {
+            "text          │    1"
+        } else {
+            "   1 │ text"
+        }));
+    }
+}
+
+#[cfg(feature = "git")]
+#[test]
+fn git_change_markers_remain_between_the_grid_and_numbers() {
+    let directory = tempdir().unwrap();
+    let git = |args: &[&str]| {
+        let output = Command::new("git")
+            .current_dir(directory.path())
+            .args([
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "core.autocrlf=false",
+            ])
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    git(&["init", "--quiet"]);
+    let path = directory.path().join("example.txt");
+    fs::write(&path, "old\n").unwrap();
+    git(&["add", "example.txt"]);
+    git(&["commit", "--quiet", "-m", "Initial"]);
+    fs::write(&path, "new\n").unwrap();
+    let result = bat()
+        .args([
+            "--paging=never",
+            "--color=never",
+            "--decorations=always",
+            "--terminal-width=24",
+            "--style=numbers,changes,grid,sidebar-right",
+        ])
+        .arg(path)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(result).unwrap();
+    assert_eq!(rows(&output), ["new             │ ~    1"]);
+}


### PR DESCRIPTION
Add the opt-in `sidebar-right` style modifier to move the selected line numbers, Git markers and grid to the right of the content. For example, `--style=default,sidebar-right` uses the usual decorations on the right; `--style=+sidebar-right` preserves the configured decoration selection. Library callers can use `PrettyPrinter::sidebar_right()`.

Render the sidebar after each physical row, padding shorter rows to the available width. Continuation rows leave the number and Git marker blank. Mirror header/footer grid junctions and align headers and snip separators with the relocated grid. Number/plain shortcuts retain the placement modifier without enabling other decorations. Defaults keep the existing left-side layout.

With wrapping disabled, overlong content keeps its complete text and appends the sidebar after it. Moving decorations does not remove them from a multiline terminal selection; the README explains using plain output for that use case. Help, manual and four shell completions are updated.

Fixes #2245.

Validation: 481 tests passed with all features, including eight new process/library regressions; seven platform/manual tests were ignored. Coverage includes character/word/no wrapping, wide Unicode, CRLF and missing final newlines, tabs, nonblank numbering, ANSI colors and highlighted backgrounds, narrow terminals, headers, snips, Git changes, plain output and resetting the library option. All-target/all-feature Clippy, formatting, Bash/Zsh parsing and the minimal regex-onig library build passed.