### PR TITLE
Use native command lookup for pagers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)
 
+## Other
+
+- Use Rust's native executable lookup for pagers and remove the obsolete `grep-cli` workaround; retain Windows `.com` pager support as a fallback, see #0 (@Matei02355)
+
 ## Features
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Other
 
-- Use Rust's native executable lookup for pagers and remove the obsolete `grep-cli` workaround; retain Windows `.com` pager support as a fallback, see #0 (@Matei02355)
+- Use Rust's native executable lookup for pagers and remove the obsolete `grep-cli` workaround; retain Windows `.com` pager support as a fallback, see #3986 (@Matei02355)
 
 ## Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,6 @@ dependencies = [
  "flate2",
  "gix",
  "globset",
- "grep-cli",
  "indexmap",
  "itertools",
  "minus",
@@ -1616,20 +1615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "grep-cli"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf32d263c5d5cc2a23ce587097f5ddafdb188492ba2e6fb638eaccdc22453631"
-dependencies = [
- "bstr",
- "globset",
- "libc",
- "log",
- "termcolor",
- "winapi-util",
-]
-
-[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,15 +2528,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ minimal-application = [
     "wild",
 ]
 git = ["gix"] # Support indicating git modifications
-paging = [ "shell-words", "grep-cli", "minus"] # Support applying a pager on the output
+paging = [ "shell-words", "minus"] # Support applying a pager on the output
 lessopen = ["execute"] # Support $LESSOPEN preprocessor
 build-assets = ["syntect/yaml-load", "syntect/plist-load", "regex", "walkdir"]
 
@@ -65,7 +65,6 @@ path_abs = { version = "0.5", default-features = false }
 clircle = { version = "0.6.1", default-features = false }
 bugreport = { version = "0.6.0", optional = true }
 etcetera = { version = "0.11.0", optional = true }
-grep-cli = { version = "0.1.12", optional = true }
 regex = { version = "1.12.3", optional = true }
 walkdir = { version = "2.5", optional = true }
 bytesize = { version = "2.3.1" }

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -362,13 +362,9 @@ fn invoke_bugreport(app: &App, cache_dir: &Path) {
         .info(CompileTimeInformation::default());
 
     #[cfg(feature = "paging")]
-    if let Ok(resolved_path) = grep_cli::resolve_binary(pager) {
-        report = report.info(CommandOutput::new(
-            "Less version",
-            resolved_path,
-            &["--version"],
-        ))
-    };
+    {
+        report = report.info(CommandOutput::new("Less version", pager, &["--version"]));
+    }
 
     report.print::<Markdown>();
 }

--- a/src/less.rs
+++ b/src/less.rs
@@ -10,9 +10,10 @@ pub enum LessVersion {
 }
 
 pub fn retrieve_less_version(less_path: &dyn AsRef<OsStr>) -> Option<LessVersion> {
-    let resolved_path = grep_cli::resolve_binary(less_path.as_ref()).ok()?;
-
-    let cmd = Command::new(resolved_path).arg("--version").output().ok()?;
+    let cmd = crate::pager::run_command(less_path.as_ref(), |program| {
+        Command::new(program).arg("--version").output()
+    })
+    .ok()?;
     if cmd.status.success() {
         parse_less_version(&cmd.stdout)
     } else {
@@ -128,4 +129,16 @@ fn test_parse_less_version_invalid_utf_8() {
 
     assert_eq!(None, parse_less_version(output));
     assert_eq!(None, parse_less_version_busybox(output));
+}
+
+#[cfg(all(test, windows))]
+#[test]
+fn version_query_accepts_an_explicit_batch_path_with_spaces() {
+    let root = tempfile::tempdir().unwrap();
+    let program = root.path().join("less version.cmd");
+    std::fs::write(&program, "@echo off\r\necho less 590 ^(test pager^)\r\n").unwrap();
+    assert_eq!(
+        retrieve_less_version(&program),
+        Some(LessVersion::Less(590))
+    );
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -114,89 +114,78 @@ impl OutputType {
             return Ok(OutputType::BuiltinPager(BuiltinPager::new()));
         }
 
-        let resolved_path = match grep_cli::resolve_binary(&pager.bin) {
-            Ok(path) => path,
-            Err(_) => {
-                crate::bat_warning!(
-                    "Pager '{}' not found, outputting to stdout instead",
-                    pager.bin
-                );
-                return Ok(OutputType::stdout());
-            }
-        };
-
-        let mut p = Command::new(resolved_path);
         let args = pager.args;
 
-        if pager.kind == PagerKind::Less {
-            // less needs to be called with the '-R' option in order to properly interpret the
-            // ANSI color sequences printed by bat. If someone has set PAGER="less -F", we
-            // therefore need to overwrite the arguments and add '-R'.
-            //
-            // We only do this for PAGER (as it is not specific to 'bat'), not for BAT_PAGER
-            // or bats '--pager' command line option.
-            let replace_arguments_to_less = pager.source == PagerSource::EnvVarPager;
-
-            if args.is_empty() || replace_arguments_to_less {
-                p.arg("-R"); // Short version of --RAW-CONTROL-CHARS for maximum compatibility
-                if single_screen_action == SingleScreenAction::Quit {
-                    p.arg("-F"); // Short version of --quit-if-one-screen for compatibility
-                }
-
-                if wrapping_mode == WrappingMode::NoWrapping(true) {
-                    p.arg("-S"); // Short version of --chop-long-lines for compatibility
-                }
-
-                let less_version = retrieve_less_version(&pager.bin);
-
-                // Ensures that 'less' quits together with 'bat'
-                // The BusyBox version of less does not support -K
-                if less_version != Some(LessVersion::BusyBox) {
-                    p.arg("-K"); // Short version of '--quit-on-intr'
-                }
-
-                // Passing '--no-init' fixes a bug with '--quit-if-one-screen' in older
-                // versions of 'less'. Unfortunately, it also breaks mouse-wheel support.
+        let child = pager::run_command(pager.bin.as_ref(), |program| {
+            let mut p = Command::new(program);
+            if pager.kind == PagerKind::Less {
+                // less needs to be called with the '-R' option in order to properly interpret the
+                // ANSI color sequences printed by bat. If someone has set PAGER="less -F", we
+                // therefore need to overwrite the arguments and add '-R'.
                 //
-                // See: http://www.greenwoodsoftware.com/less/news.530.html
-                //
-                // For newer versions (530 or 558 on Windows), we omit '--no-init' as it
-                // is not needed anymore.
-                if single_screen_action == SingleScreenAction::Quit {
-                    match less_version {
-                        None => {
-                            p.arg("--no-init");
-                        }
-                        Some(LessVersion::Less(version))
-                            if (version < 530 || (cfg!(windows) && version < 558)) =>
-                        {
-                            p.arg("--no-init");
-                        }
-                        _ => {}
+                // We only do this for PAGER (as it is not specific to 'bat'), not for BAT_PAGER
+                // or bats '--pager' command line option.
+                let replace_arguments_to_less = pager.source == PagerSource::EnvVarPager;
+
+                if args.is_empty() || replace_arguments_to_less {
+                    p.arg("-R"); // Short version of --RAW-CONTROL-CHARS for maximum compatibility
+                    if single_screen_action == SingleScreenAction::Quit {
+                        p.arg("-F"); // Short version of --quit-if-one-screen for compatibility
                     }
+
+                    if wrapping_mode == WrappingMode::NoWrapping(true) {
+                        p.arg("-S"); // Short version of --chop-long-lines for compatibility
+                    }
+
+                    let less_version = retrieve_less_version(&pager.bin);
+
+                    // Ensures that 'less' quits together with 'bat'
+                    // The BusyBox version of less does not support -K
+                    if less_version != Some(LessVersion::BusyBox) {
+                        p.arg("-K"); // Short version of '--quit-on-intr'
+                    }
+
+                    // Passing '--no-init' fixes a bug with '--quit-if-one-screen' in older
+                    // versions of 'less'. Unfortunately, it also breaks mouse-wheel support.
+                    //
+                    // See: http://www.greenwoodsoftware.com/less/news.530.html
+                    //
+                    // For newer versions (530 or 558 on Windows), we omit '--no-init' as it
+                    // is not needed anymore.
+                    if single_screen_action == SingleScreenAction::Quit {
+                        match less_version {
+                            None => {
+                                p.arg("--no-init");
+                            }
+                            Some(LessVersion::Less(version))
+                                if (version < 530 || (cfg!(windows) && version < 558)) =>
+                            {
+                                p.arg("--no-init");
+                            }
+                            _ => {}
+                        }
+                    }
+                } else {
+                    p.args(&args);
                 }
+                p.env("LESSCHARSET", "UTF-8");
+
+                #[cfg(feature = "lessopen")]
+                // Ensures that 'less' does not preprocess input again if '$LESSOPEN' is set.
+                p.arg("--no-lessopen");
             } else {
-                p.args(args);
-            }
-            p.env("LESSCHARSET", "UTF-8");
+                p.args(&args);
+            };
 
-            #[cfg(feature = "lessopen")]
-            // Ensures that 'less' does not preprocess input again if '$LESSOPEN' is set.
-            p.arg("--no-lessopen");
-        } else {
-            p.args(args);
-        };
-
-        Ok(p.stdin(Stdio::piped())
-            .spawn()
-            .map(OutputType::Pager)
-            .unwrap_or_else(|_| {
-                crate::bat_warning!(
-                    "Pager '{}' not found, outputting to stdout instead",
-                    &pager.bin
-                );
-                OutputType::stdout()
-            }))
+            p.stdin(Stdio::piped()).spawn()
+        });
+        Ok(child.map(OutputType::Pager).unwrap_or_else(|_| {
+            crate::bat_warning!(
+                "Pager '{}' not found, outputting to stdout instead",
+                &pager.bin
+            );
+            OutputType::stdout()
+        }))
     }
 
     pub(crate) fn stdout() -> Self {

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -1,5 +1,30 @@
 use shell_words::ParseError;
 use std::env;
+use std::ffi::OsStr;
+use std::io;
+
+/// Run a pager with Rust's executable lookup, without implicitly searching the working directory.
+/// Windows Command appends `.exe`, but not `.com` (used by e.g. `more.com`), so retry that
+/// extension only when the native lookup cannot find an extensionless program. Explicit
+/// extensions retain their meaning, and other launch errors must not execute another program.
+/// The closure constructs the complete command on each attempt, including its arguments,
+/// environment and standard streams.
+pub(crate) fn run_command<T>(
+    program: &OsStr,
+    mut run: impl FnMut(&OsStr) -> io::Result<T>,
+) -> io::Result<T> {
+    let result = run(program);
+    #[cfg(windows)]
+    if matches!(&result, Err(error) if error.kind() == io::ErrorKind::NotFound)
+        && !program.is_empty()
+        && std::path::Path::new(program).extension().is_none()
+    {
+        let mut com_program = program.to_os_string();
+        com_program.push(".com");
+        return run(&com_program);
+    }
+    result
+}
 
 /// If we use a pager, this enum tells us from where we were told to use it.
 #[derive(Debug, PartialEq)]
@@ -134,5 +159,23 @@ pub(crate) fn get_pager(config_pager: Option<&str>) -> Result<Option<Pager>, Par
             }))
         }
         None => Ok(None),
+    }
+}
+
+#[cfg(all(test, windows))]
+mod command_tests {
+    use super::run_command;
+    use std::ffi::OsStr;
+    use std::io;
+
+    #[test]
+    fn launch_errors_do_not_try_another_program() {
+        let mut attempts = 0;
+        let result: io::Result<()> = run_command(OsStr::new("pager"), |_| {
+            attempts += 1;
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        });
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(attempts, 1);
     }
 }

--- a/tests/pager_resolution.rs
+++ b/tests/pager_resolution.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "paging")]
+
+mod utils;
+use utils::command::bat;
+
+#[test]
+fn missing_pager_falls_back_to_stdout() {
+    bat()
+        .args([
+            "--style=plain",
+            "--wrap=never",
+            "--paging=always",
+            "--pager=bat-test-missing-pager-2027",
+        ])
+        .write_stdin("input\n")
+        .assert()
+        .success()
+        .stdout("input\n")
+        .stderr(predicates::str::contains("outputting to stdout instead"));
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::bat;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn install_command(path: &Path) {
+        let system_root = std::env::var_os("SystemRoot").expect("Windows system directory");
+        fs::copy(Path::new(&system_root).join("System32/cmd.exe"), path).unwrap();
+    }
+
+    fn command(pager: &str, path: &Path, cwd: &Path) -> assert_cmd::Command {
+        let mut command = bat();
+        command
+            .current_dir(cwd)
+            .env("PATH", path)
+            .args([
+                "--style=plain",
+                "--wrap=never",
+                "--paging=always",
+                "--pager",
+            ])
+            .arg(format!("\"{pager}\" /D /C echo pager-launched"))
+            .write_stdin("input\n");
+        command
+    }
+
+    #[test]
+    fn working_directory_is_not_an_implicit_pager_search_path() {
+        let root = tempdir().unwrap();
+        let path = root.path().join("empty-path");
+        fs::create_dir(&path).unwrap();
+        for extension in ["exe", "com"] {
+            install_command(&root.path().join(format!("bat-test-pager.{extension}")));
+        }
+        command("bat-test-pager", &path, root.path())
+            .assert()
+            .success()
+            .stdout("input\n")
+            .stderr(predicates::str::contains("outputting to stdout instead"));
+    }
+
+    #[test]
+    fn path_resolves_native_and_com_pagers() {
+        for extension in ["exe", "com"] {
+            let root = tempdir().unwrap();
+            let path = root.path().join("binary directory with spaces");
+            fs::create_dir(&path).unwrap();
+            install_command(&path.join(format!("bat-test-pager.{extension}")));
+            command("bat-test-pager", &path, root.path())
+                .assert()
+                .success()
+                .stdout("pager-launched\r\n");
+        }
+    }
+
+    #[test]
+    fn explicit_relative_and_absolute_paths_remain_available() {
+        let root = tempdir().unwrap();
+        let path = root.path().join("binary directory with spaces");
+        fs::create_dir(&path).unwrap();
+        for extension in ["exe", "com"] {
+            let relative = format!(".\\binary directory with spaces\\bat-test-pager.{extension}");
+            let absolute = path.join(format!("bat-test-pager.{extension}"));
+            install_command(&absolute);
+            for program in [relative.as_str(), absolute.to_str().unwrap()] {
+                command(program, root.path(), root.path())
+                    .assert()
+                    .success()
+                    .stdout("pager-launched\r\n");
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_extension_does_not_fall_back_to_com() {
+        let root = tempdir().unwrap();
+        let path = root.path().join("bin");
+        fs::create_dir(&path).unwrap();
+        install_command(&path.join("bat-test-pager.com"));
+        command("bat-test-pager.exe", &path, root.path())
+            .assert()
+            .success()
+            .stdout("input\n")
+            .stderr(predicates::str::contains("outputting to stdout instead"));
+    }
+}


### PR DESCRIPTION
Rust 1.58 removed implicit working-directory searches when launching Windows programs. The project's existing rust-version = 1.88 already enforces a sufficiently recent compiler, so retire the grep-cli executable-resolution workaround and its dependency.

Construct pager and version-query commands with std::process::Command. Keep the existing stdout fallback when launching a pager fails. On Windows, native lookup appends .exe but does not try .com, so retry an extensionless program with .com only after NotFound; this preserves bare more/custom COM pager support. Explicit extensions and non-NotFound launch errors never trigger that retry. Native executable lookup now takes precedence, with COM programs as a fallback. Diagnostics also use native command lookup.

Fixes #2027.

Validation: 474 tests passed locally with all features; seven platform/manual tests were ignored. All-target/all-feature Clippy, formatting and the minimal regex-onig library build passed. New Windows CI tests exercise a malicious pager in the working directory, PATH lookup for EXE and COM programs, explicit relative/absolute paths containing spaces, explicit-extension failures, version queries through a batch path, and rejection of retries after other launch errors. Windows-specific tests require the Windows CI runners and have not been executed locally.

Rust behavior: https://blog.rust-lang.org/2022/01/13/Rust-1.58.0/