### PR TITLE
Replace deprecated serde_yaml with serde_yaml_ng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Other
 
+- Replace the deprecated `serde_yaml` dependency with `serde_yaml_ng`, preserving cache metadata compatibility, see #0 (@Matei02355)
+
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Other
 
-- Replace the deprecated `serde_yaml` dependency with `serde_yaml_ng`, preserving cache metadata compatibility, see #0 (@Matei02355)
+- Replace the deprecated `serde_yaml` dependency with `serde_yaml_ng`, preserving cache metadata compatibility, see #3989 (@Matei02355)
 
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_with",
- "serde_yaml",
+ "serde_yaml_ng",
  "serial_test",
  "shell-words",
  "syn",
@@ -2350,10 +2350,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ unicode-width = "0.2.2"
 globset = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
-serde_yaml = "0.9.28"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 semver = "1.0"
 path_abs = { version = "0.5", default-features = false }
 clircle = { version = "0.6.1", default-features = false }

--- a/tests/metadata_yaml.rs
+++ b/tests/metadata_yaml.rs
@@ -15,7 +15,16 @@ fn metadata_written_with_the_previous_serializer_remains_compatible() {
     assert!(metadata.is_compatible_with("0.26.9"));
     assert!(!metadata.is_compatible_with("0.27.0"));
     let serialized = serde_yaml::to_string(&metadata).unwrap();
-    let original: serde_yaml::Value = serde_yaml::from_str(LEGACY_METADATA).unwrap();
+    let mut original: serde_yaml::Value = serde_yaml::from_str(LEGACY_METADATA).unwrap();
+    // SystemTime has platform-dependent precision (100 ns on Windows).
+    // Reading an old cache must preserve the instant at that native precision.
+    let timestamp = std::time::UNIX_EPOCH + std::time::Duration::new(1700000000, 123456789);
+    original["creation_time"]["nanos_since_epoch"] = serde_yaml::Value::from(
+        timestamp
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos(),
+    );
     let restored: serde_yaml::Value = serde_yaml::from_str(&serialized).unwrap();
     assert_eq!(restored, original);
 }

--- a/tests/metadata_yaml.rs
+++ b/tests/metadata_yaml.rs
@@ -1,0 +1,66 @@
+use bat::assets_metadata::AssetsMetadata;
+use bat::error::Error;
+use std::fs;
+use tempfile::tempdir;
+
+const LEGACY_METADATA: &str = "bat_version: 0.26.1\ncreation_time:\n  secs_since_epoch: 1700000000\n  nanos_since_epoch: 123456789\n";
+
+#[test]
+fn metadata_written_with_the_previous_serializer_remains_compatible() {
+    let directory = tempdir().unwrap();
+    fs::write(directory.path().join("metadata.yaml"), LEGACY_METADATA).unwrap();
+    let metadata = AssetsMetadata::load_from_folder(directory.path())
+        .unwrap()
+        .unwrap();
+    assert!(metadata.is_compatible_with("0.26.9"));
+    assert!(!metadata.is_compatible_with("0.27.0"));
+    let serialized = serde_yaml::to_string(&metadata).unwrap();
+    let original: serde_yaml::Value = serde_yaml::from_str(LEGACY_METADATA).unwrap();
+    let restored: serde_yaml::Value = serde_yaml::from_str(&serialized).unwrap();
+    assert_eq!(restored, original);
+}
+
+#[test]
+fn null_values_and_unknown_fields_keep_the_metadata_contract() {
+    let directory = tempdir().unwrap();
+    fs::write(
+        directory.path().join("metadata.yaml"),
+        "bat_version: null\ncreation_time: null\nfuture_field: [one, two]\n",
+    )
+    .unwrap();
+    let metadata = AssetsMetadata::load_from_folder(directory.path())
+        .unwrap()
+        .unwrap();
+    assert_eq!(metadata, AssetsMetadata::default());
+    assert!(!metadata.is_compatible_with("0.26.1"));
+}
+
+#[test]
+fn malformed_yaml_remains_a_parse_error_even_when_cache_files_exist() {
+    let directory = tempdir().unwrap();
+    fs::write(
+        directory.path().join("metadata.yaml"),
+        "bat_version: [unterminated\n",
+    )
+    .unwrap();
+    fs::write(directory.path().join("syntaxes.bin"), b"cache placeholder").unwrap();
+    match AssetsMetadata::load_from_folder(directory.path()) {
+        Err(Error::SerdeYamlError(error)) => assert!(error.location().is_some()),
+        other => panic!("Malformed metadata was not rejected: {other:?}"),
+    }
+}
+
+#[test]
+fn yaml_aliases_and_json_metadata_remain_readable() {
+    let directory = tempdir().unwrap();
+    for text in [
+        "version: &version 0.26.1\nbat_version: *version\ncreation_time: null\n",
+        r#"{"bat_version":"0.26.1","creation_time":null}"#,
+    ] {
+        fs::write(directory.path().join("metadata.yaml"), text).unwrap();
+        let metadata = AssetsMetadata::load_from_folder(directory.path())
+            .unwrap()
+            .unwrap();
+        assert!(metadata.is_compatible_with("0.26.1"));
+    }
+}


### PR DESCRIPTION
The serde_yaml crate is deprecated. Switch the direct dependency to the published serde_yaml_ng 0.10.0 release through a Cargo dependency alias, keeping existing serialization call sites and the cache metadata format.

Add regression coverage for legacy timestamps and version compatibility, null values and unknown fields, YAML aliases and JSON input, and malformed YAML with an existing cache. The SerdeYamlError variant remains available and still reports parse locations; its wrapped error now comes from the replacement crate. Syntect's separate YAML parser is unchanged.

Validation: 477 tests passed with all features (7 ignored), Clippy with warnings denied and formatting passed, and the library builds without default features using regex-onig. Actual caches built with the old serializer were read by the updated binary and caches built with the updated binary were read by the old binary. The new lockfile checksum matches the published crates.io archive.

Fixes #3164.