### PR TITLE
Add optional Git blame annotations for working-tree files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add opt-in Git blame annotations with configurable commit metadata and support for working-tree edits and renames, see #0 (@Matei02355). Closes #1536 and #2810
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add opt-in Git blame annotations with configurable commit metadata and support for working-tree edits and renames, see #0 (@Matei02355). Closes #1536 and #2810
+- Add opt-in Git blame annotations with configurable commit metadata and support for working-tree edits and renames, see #3991 (@Matei02355). Closes #1536 and #2810
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ checksum = "bb3790fd8981cba7949f1ba924ef865d902df731627bc5998d14164063892fce"
 dependencies = [
  "gix-actor",
  "gix-attributes",
+ "gix-blame",
  "gix-command",
  "gix-commitgraph",
  "gix-config",
@@ -948,6 +949,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd1d118d0f5d88b96e6f6e13b566475fef4797ead4a02c26fed36c1375066f7"
 dependencies = [
  "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06d20ff0e88ada2dd852b3852727b664ec9baefdf653d1d4e722e858c52cd17"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ itertools = "0.14.0"
 version = "0.86"
 optional = true
 default-features = false
-features = ["sha1", "blob-diff"]
+features = ["sha1", "blob-diff", "blame"]
 
 [dependencies.syntect]
 version = "5.3.0"

--- a/README.md
+++ b/README.md
@@ -152,6 +152,34 @@ highlighting:
 git show v0.6.0:src/main.rs | bat -l rs
 ```
 
+#### Git blame
+
+Use `bat --blame file.rs` to show each line's commit and author before the line
+numbers. Attribution follows renames and accounts for staged and unstaged edits;
+new or changed lines show `00000000 Not Committed Yet`. It uses the current
+checkout's history, including linked worktrees.
+
+The sidebar is optional and is excluded from the `default` and `full` styles.
+`--blame` enables it even when piping output; `--decorations=never` suppresses it.
+For a custom layout, use `--style=blame,numbers` (and `--decorations=always` when
+piping). The library exposes `PrettyPrinter::git_blame` and `blame_format`.
+
+```sh
+bat --blame --blame-format='%h %an %as' file.rs
+```
+
+The format supports `%h` (8-digit hash), `%H` (full hash), `%an` / `%ae` (author
+name / email), `%as` / `%at` (author date / Unix time), `%cn` / `%ce` (committer
+name / email), `%cs` / `%ct` (committer date / Unix time), `%s` (subject), and `%%`.
+Dates retain the commit's timezone. Missing metadata for uncommitted lines is
+empty. Annotations are sanitized and shortened to at most 32 terminal columns.
+
+Blame requires the `git` build feature and ordinary UTF-8 files. Standard input,
+preprocessed or unbuffered inputs, binary files, and files outside Git repositories have no
+blame sidebar. Narrow terminals may hide it to leave room for the source.
+Computing history adds work before the first line is printed, so enable it only
+when attribution is needed.
+
 #### `git diff`
 
 You can combine `bat` with `git diff` to view lines around code changes with proper syntax
@@ -514,7 +542,7 @@ The available pre-defined styles are:
 | Style | Description |
 |-------|-------------|
 | `default` | Enables the recommended style components listed above. |
-| `full` | Enables all available components. |
+| `full` | Enables all components except opt-in Git blame. |
 | `auto` | Same as `default`, unless the output is piped. |
 | `plain` | Disables all available components. |
 
@@ -523,6 +551,7 @@ The available individual components are:
 | Component | Description |
 |-----------|-------------|
 | `changes` | Show Git modification markers. |
+| `blame` | Show Git commit attribution (requires Git support). |
 | `header` | Alias for `header-filename`. |
 | `header-filename` | Show filenames before the content. |
 | `header-filesize` | Show file sizes before the content. |

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -5,7 +5,7 @@ using namespace System.Management.Automation.Language
 Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 
-    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
+    $ArrayStyle      = @('default', 'auto', 'full', 'plain', 'changes', 'blame', 'header', 'header-filename', 'header-filesize', 'grid', 'rule', 'numbers', 'snip')
     $ArrayCompletion = @('bash', 'fish', 'zsh', 'ps1')
     $ArrayWhen       = @('auto', 'never', 'always')
     $ArrayYesNo      = @('never', 'always')
@@ -58,6 +58,9 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         '*;--theme' {
             Get-MyThemes |
             ForEach-Object {[System.Management.Automation.CompletionResult]::new($_, $_, [CompletionResultType]::ParameterName, $_)}
+            break
+        }
+        '*;--blame-format' {
             break
         }
         '*;--binary' {
@@ -138,6 +141,8 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
             [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
             [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
+            [CompletionResult]::new('--blame', 'blame', [CompletionResultType]::ParameterName, 'Show Git commit attribution.')
+            [CompletionResult]::new('--blame-format', 'blame-format', [CompletionResultType]::ParameterName, 'Format the Git attribution sidebar.')
             [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')
             [CompletionResult]::new('--tabs'                  , 'tabs'                  , [CompletionResultType]::ParameterName, 'Set the tab width to T spaces.')
             [CompletionResult]::new('--wrap'                  , 'wrap'                  , [CompletionResultType]::ParameterName, 'Specify the text-wrapping mode (*auto*, never, character, word).')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -89,6 +89,7 @@ _bat() {
 		;;
 	-H | --highlight-line | \
 	--diff-context | \
+	--blame-format | \
 	--tabs | \
 	--terminal-width | \
 	-m | --map-syntax | \
@@ -173,6 +174,7 @@ _bat() {
 			auto
 			plain
 			changes
+			blame
 			header
 			header-filename
 			header-filesize
@@ -203,6 +205,8 @@ _bat() {
 			--language
 			--highlight-line
 			--file-name
+			--blame
+			--blame-format
 			--diff
 			--diff-context
 			--tabs

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -79,6 +79,7 @@ function __bat_style_opts
         "full,all components" \
         "plain,no components" \
         "changes,Git change markers" \
+        "blame,Git commit attribution" \
         "header,alias for header-filename" \
         "header-filename,filename above content" \
         "header-filesize,filesize above content" \
@@ -161,6 +162,9 @@ complete -c $bat -l decorations -x -a "$decorations_opts" -d "When to use --styl
 
 complete -c $bat -l diagnostic -d "Print diagnostic info for bug reports" -n __fish_is_first_arg
 complete -c $bat -l quiet-empty -d "Do not produce any output when the input is empty" -n __fish_is_first_arg
+
+complete -c $bat -l blame -d "Show Git commit attribution" -n __bat_no_excl_args
+complete -c $bat -l blame-format -x -d "Format the Git attribution sidebar" -n __bat_no_excl_args
 
 complete -c $bat -s d -l diff -d "Only show lines with Git changes" -n __bat_no_excl_args
 

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -32,6 +32,8 @@ _{{PROJECT_EXECUTABLE}}_main() {
         \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
         \*--file-name='[specify the name to display for a file]:name:_files'
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'
+        --blame'[show Git commit attribution]'
+        --blame-format='[format the Git attribution sidebar]:format'
         --diff-context='[specify lines of context around added/removed/modified lines when using `--diff`]:lines'
         --tabs='[set the tab width]:tab width [4]'
         --wrap='[specify the text-wrapping mode]:mode [auto]:(auto never character word)'
@@ -56,7 +58,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         --strip-ansi='[specify when to strip ANSI escape sequences]:when:(auto never always)'
         --sanitize='[specify when to sanitize untrusted input for safe display]:when:(auto never always)'
         --style='[comma-separated list of style elements to display]: : _values "style [default]"
-            default auto full plain changes header header-filename header-filesize grid rule numbers snip'
+            default auto full plain changes blame header header-filename header-filesize grid rule numbers snip'
         \*{-r+,--line-range=}'[only print the specified line range]:start\:end'
         '(* -)'{-L,--list-languages}'[display all supported languages]'
         '(-u --unbuffered)'--unbuffered'[enable unbuffered input reading for streaming use cases]'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -88,6 +88,24 @@ highlights lines 30 to 40
 .IP
 Specify the name to display for a file. Useful when piping data to {{PROJECT_EXECUTABLE}} from STDIN when {{PROJECT_EXECUTABLE}} does not otherwise know the filename. Note that the provided file name is also used for syntax detection.
 .HP
+\fB\-\-blame\fR
+.IP
+Show Git commit attribution before line numbers. Follows renames and marks staged
+or unstaged changes as uncommitted. Requires Git support and ordinary UTF-8 files;
+standard input, preprocessed or unbuffered inputs, and binary files have no blame sidebar.
+This is opt-in, is excluded from default and full styles, and can also be selected
+with the blame style component. It enables decorations when piping unless
+\&'\-\-decorations=never' is set. Computing history can delay the first output line.
+.HP
+\fB\-\-blame\-format\fR <FORMAT>
+.IP
+Format the attribution (default: '%h %an'). Fields: %h (8-digit hash), %H (full
+hash), %an/%ae (author name/email), %as/%at (author date/Unix time), %cn/%ce
+(committer name/email), %cs/%ct (committer date/Unix time), %s (subject), and %%.
+Dates retain the commit's timezone. Uncommitted lines use a zero hash and
+\&'Not Committed Yet'; unavailable metadata is empty. Terminal control characters
+are escaped, and annotations are shortened to at most 32 terminal columns.
+.HP
 \fB\-d\fR, \fB\-\-diff\fR
 .IP
 Only show lines that have been added/removed/modified with respect to the Git index. Use '\-\-diff\-context=N' to control how much context you want to see.
@@ -242,7 +260,7 @@ replacing them.
 By default, the following components are enabled:
 changes, grid, header\-filename, numbers, snip
 .IP
-Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
+Possible values: *default*, full, auto, plain, changes, blame, header, header-filename, header-filesize, grid,
 rule, numbers, snip.
 .HP
 \fB\-r\fR, \fB\-\-line\-range\fR <N:M>...

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -57,6 +57,21 @@ Options:
           does not otherwise know the filename. Note that the provided file name is also used for
           syntax detection.
 
+      --blame
+          Show Git commit attribution before the line-number sidebar. Uses the history of ordinary
+          UTF-8 files and marks working-tree edits as uncommitted. Files outside a repository and
+          preprocessed or binary or unbuffered inputs have no blame sidebar. This is opt-in and is
+          not included in the default or full styles. Also available as --style=blame. See
+          --blame-format to change the annotation.
+
+      --blame-format <FORMAT>
+          Format the Git blame sidebar (default: '%h %an'). Supported fields: %h (8-digit commit),
+          %H (full commit), %an/%ae (author name/email), %as/%at (author date/Unix time), %cn/%ce
+          (committer name/email), %cs/%ct (committer date/Unix time), %s (subject), and %% (literal
+          percent). Dates use the commit's timezone. Fields unavailable for uncommitted lines are
+          empty. Control characters are escaped, and annotations are shortened to at most 32 columns
+          so source code remains readable.
+
   -d, --diff
           Only show lines that have been added/removed/modified with respect to the Git index. Use
           --diff-context=N to control how much context you want to see.
@@ -201,10 +216,11 @@ Options:
           Possible values:
           
             * default: enables recommended style components (default).
-            * full: enables all available components.
+            * full: enables all components except opt-in Git blame.
             * auto: same as 'default', unless the output is piped.
             * plain: disables all available components.
             * changes: show Git modification markers.
+            * blame: show Git commit attribution (requires the git feature).
             * header: alias for 'header-filename'.
             * header-filename: show filenames before the content.
             * header-filesize: show file sizes before the content.

--- a/doc/short-help.txt
+++ b/doc/short-help.txt
@@ -23,6 +23,8 @@ Options:
           Highlight lines N through M.
       --file-name <name>
           Specify the name to display for a file.
+      --blame
+          Show Git attribution alongside source lines
   -d, --diff
           Only show lines that have been added/removed/modified.
       --tabs <T>
@@ -57,7 +59,7 @@ Options:
           Squeeze consecutive empty lines.
       --style <components>
           Comma-separated list of style elements to display (*default*, auto, full, plain, changes,
-          header, header-filename, header-filesize, grid, rule, numbers, snip).
+          blame, header, header-filename, header-filesize, grid, rule, numbers, snip).
   -r, --line-range <N:M>
           Only print the lines from N to M.
   -L, --list-languages

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -267,7 +267,18 @@ impl App {
     }
 
     pub fn config(&self, inputs: &[Input]) -> Result<Config<'_>> {
-        let style_components = self.style_components()?;
+        #[allow(unused_mut)]
+        let mut style_components = self.style_components()?;
+        #[cfg(feature = "git")]
+        if self.matches.get_flag("blame")
+            && self
+                .matches
+                .get_one::<String>("decorations")
+                .map(String::as_str)
+                != Some("never")
+        {
+            style_components.insert(StyleComponent::Blame);
+        }
 
         let extra_plain = self.matches.get_count("plain") > 1;
         let plain_last_index = self
@@ -440,7 +451,8 @@ impl App {
                     == Some("always")
                 || self.matches.get_flag("force-colorization")
                 || self.number_from_cli
-                || self.number_nonblank_from_cli),
+                || self.number_nonblank_from_cli
+                || (cfg!(feature = "git") && self.matches.get_flag("blame"))),
             tab_width: self
                 .matches
                 .get_one::<String>("tabs")
@@ -507,6 +519,11 @@ impl App {
             style_components,
             syntax_mapping,
             pager: self.matches.get_one::<String>("pager").map(|s| s.as_str()),
+            #[cfg(feature = "git")]
+            blame_format: self
+                .matches
+                .get_one::<String>("blame-format")
+                .map(String::as_str),
             use_italic_text: self
                 .matches
                 .get_one::<String>("italic-text")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -169,6 +169,34 @@ pub fn build_app(interactive_output: bool) -> Command {
     {
         app = app
                 .arg(
+                    Arg::new("blame")
+                        .long("blame")
+                        .overrides_with("blame")
+                        .action(ArgAction::SetTrue)
+                        .help("Show Git attribution alongside source lines")
+                        .long_help("Show Git commit attribution before the line-number sidebar. \
+                            Uses the history of ordinary UTF-8 files and marks working-tree edits \
+                            as uncommitted. Files outside a repository and preprocessed or binary \
+                            or unbuffered inputs have no blame sidebar. This is opt-in and is not included in \
+                            the default or full styles. Also available as --style=blame. \
+                            See --blame-format to change the annotation."),
+                )
+                .arg(
+                    Arg::new("blame-format")
+                        .long("blame-format")
+                        .overrides_with("blame-format")
+                        .value_name("FORMAT")
+                        .help("Format the Git blame sidebar")
+                        .long_help("Format the Git blame sidebar (default: '%h %an'). Supported \
+                            fields: %h (8-digit commit), %H (full commit), %an/%ae (author name/email), \
+                            %as/%at (author date/Unix time), %cn/%ce (committer name/email), \
+                            %cs/%ct (committer date/Unix time), %s (subject), and %% (literal percent). \
+                            Dates use the commit's timezone. Fields unavailable for uncommitted lines \
+                            are empty. Control characters are escaped, and annotations are shortened \
+                            to at most 32 columns so source code remains readable.")
+                        .hide_short_help(true),
+                )
+                .arg(
                     Arg::new("diff")
                         .long("diff")
                         .short('d')
@@ -534,7 +562,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                 })
                 .help(
                     "Comma-separated list of style elements to display \
-                     (*default*, auto, full, plain, changes, header, header-filename, header-filesize, grid, rule, numbers, snip).",
+                     (*default*, auto, full, plain, changes, blame, header, header-filename, header-filesize, grid, rule, numbers, snip).",
                 )
                 .long_help(
                     "Configure which elements (line numbers, file headers, grid \
@@ -554,10 +582,11 @@ pub fn build_app(interactive_output: bool) -> Command {
                         changes, grid, header-filename, numbers, snip\n\n\
                      Possible values:\n\n  \
                      * default: enables recommended style components (default).\n  \
-                     * full: enables all available components.\n  \
+                     * full: enables all components except opt-in Git blame.\n  \
                      * auto: same as 'default', unless the output is piped.\n  \
                      * plain: disables all available components.\n  \
                      * changes: show Git modification markers.\n  \
+                     * blame: show Git commit attribution (requires the git feature).\n  \
                      * header: alias for 'header-filename'.\n  \
                      * header-filename: show filenames before the content.\n  \
                      * header-filesize: show file sizes before the content.\n  \

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -1,0 +1,252 @@
+//! Git attribution for the current working tree, including uncommitted lines.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use gix::diff::blob::pipeline::{Mode, WorktreeRoots};
+use gix::diff::blob::{Algorithm, ResourceKind};
+use gix::object::tree::EntryKind;
+
+use crate::error::{Error, Result};
+
+pub(crate) const DEFAULT_FORMAT: &str = "%h %an";
+
+#[derive(Clone, Debug)]
+enum Part {
+    Literal(String),
+    Field(&'static str),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BlameFormat(Vec<Part>);
+
+impl BlameFormat {
+    pub(crate) fn parse(value: &str) -> Result<Self> {
+        let mut parts = Vec::new();
+        let mut rest = value;
+        while let Some(index) = rest.find('%') {
+            if index > 0 {
+                parts.push(Part::Literal(rest[..index].to_owned()));
+            }
+            rest = &rest[index + 1..];
+            if let Some(next) = rest.strip_prefix('%') {
+                parts.push(Part::Literal("%".to_owned()));
+                rest = next;
+                continue;
+            }
+            let field = ["an", "ae", "as", "at", "cn", "ce", "cs", "ct", "h", "H", "s"]
+                .into_iter().find(|field| rest.starts_with(field))
+                .ok_or_else(|| Error::Msg("Unknown --blame-format field; supported fields: %h %H %an %ae %as %at %cn %ce %cs %ct %s %%".into()))?;
+            parts.push(Part::Field(field));
+            rest = &rest[field.len()..];
+        }
+        if !rest.is_empty() {
+            parts.push(Part::Literal(rest.to_owned()));
+        }
+        Ok(Self(parts))
+    }
+
+    fn render(&self, info: &CommitInfo) -> String {
+        let mut output = String::new();
+        for part in &self.0 {
+            output.push_str(match part {
+                Part::Literal(text) => text,
+                Part::Field("h") => &info.hash[..info.hash.len().min(8)],
+                Part::Field("H") => &info.hash,
+                Part::Field("an") => &info.author,
+                Part::Field("ae") => &info.author_email,
+                Part::Field("as") => &info.author_date,
+                Part::Field("at") => &info.author_time,
+                Part::Field("cn") => &info.committer,
+                Part::Field("ce") => &info.committer_email,
+                Part::Field("cs") => &info.committer_date,
+                Part::Field("ct") => &info.committer_time,
+                Part::Field("s") => &info.summary,
+                Part::Field(_) => unreachable!("only validated fields are stored"),
+            });
+        }
+        crate::sanitize_for_terminal(&output)
+    }
+}
+
+#[derive(Default)]
+struct CommitInfo {
+    hash: String,
+    author: String,
+    author_email: String,
+    author_date: String,
+    author_time: String,
+    committer: String,
+    committer_email: String,
+    committer_date: String,
+    committer_time: String,
+    summary: String,
+}
+
+impl CommitInfo {
+    fn uncommitted(hash: String) -> Self {
+        Self {
+            hash,
+            author: "Not Committed Yet".into(),
+            committer: "Not Committed Yet".into(),
+            summary: "Uncommitted changes".into(),
+            ..Self::default()
+        }
+    }
+
+    fn load(repository: &gix::Repository, id: gix::ObjectId) -> Result<Self> {
+        let commit = repository.find_commit(id).map_err(git_error)?;
+        let author = commit.author().map_err(git_error)?;
+        let committer = commit.committer().map_err(git_error)?;
+        let author_time = author.time().map_err(git_error)?;
+        let committer_time = committer.time().map_err(git_error)?;
+        let message = commit.message_raw().map_err(git_error)?;
+        Ok(Self {
+            hash: id.to_string(),
+            author: String::from_utf8_lossy(author.name.as_ref()).into_owned(),
+            author_email: String::from_utf8_lossy(author.email.as_ref()).into_owned(),
+            author_date: author_time.format_or_unix(gix::date::time::format::SHORT),
+            author_time: author_time.seconds.to_string(),
+            committer: String::from_utf8_lossy(committer.name.as_ref()).into_owned(),
+            committer_email: String::from_utf8_lossy(committer.email.as_ref()).into_owned(),
+            committer_date: committer_time.format_or_unix(gix::date::time::format::SHORT),
+            committer_time: committer_time.seconds.to_string(),
+            summary: String::from_utf8_lossy(message.as_ref())
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .to_owned(),
+        })
+    }
+}
+
+pub(crate) struct BlameLines {
+    pub labels: Vec<String>,
+    // Index zero is the uncommitted label. Store each commit's label only once.
+    pub lines: Vec<usize>,
+}
+
+pub(crate) fn get_git_blame(filename: &Path, format: &BlameFormat) -> Result<Option<BlameLines>> {
+    let absolute = filename.canonicalize()?;
+    if !absolute.metadata()?.is_file() {
+        return Ok(None);
+    }
+    let Some(parent) = absolute.parent() else {
+        return Ok(None);
+    };
+    let Ok(repository) = gix::discover(parent) else {
+        return Ok(None);
+    };
+    let Some(workdir) = repository.workdir() else {
+        return Ok(None);
+    };
+    let workdir = workdir.canonicalize()?;
+    let relative = absolute.strip_prefix(&workdir).map_err(git_error)?;
+    let git_path = gix::path::to_unix_separators_on_windows(gix::path::into_bstr(relative));
+    let working = std::fs::read(&absolute)?;
+    // Blame indexes Git's byte lines, so a decoded UTF-16 input cannot use this map.
+    if std::str::from_utf8(&working).is_err() || working.contains(&0) {
+        return Ok(None);
+    }
+    let line_count = working.split_inclusive(|&b| b == b'\n').count();
+    let mut labels = vec![format.render(&CommitInfo::uncommitted(
+        repository.object_hash().null().to_string(),
+    ))];
+    let mut output = vec![0; line_count];
+    if repository.head().map_err(git_error)?.is_unborn() {
+        return Ok(Some(BlameLines {
+            labels,
+            lines: output,
+        }));
+    }
+    let head = repository.head_commit().map_err(git_error)?;
+    let tree = head.tree().map_err(git_error)?;
+    let Some(entry) = tree.lookup_entry_by_path(relative).map_err(git_error)? else {
+        return Ok(Some(BlameLines {
+            labels,
+            lines: output,
+        }));
+    };
+    let outcome = repository
+        .blame_file(
+            git_path.as_ref(),
+            head.id,
+            gix::repository::blame_file::Options {
+                rewrites: Some(Default::default()),
+                ..Default::default()
+            },
+        )
+        .map_err(git_error)?;
+    let mut old_lines = vec![0; outcome.blob.split_inclusive(|&b| b == b'\n').count()];
+    let mut commits = HashMap::new();
+    for entry in &outcome.entries {
+        let label = match commits.get(&entry.commit_id) {
+            Some(&index) => index,
+            None => {
+                let index = labels.len();
+                labels.push(format.render(&CommitInfo::load(&repository, entry.commit_id)?));
+                commits.insert(entry.commit_id, index);
+                index
+            }
+        };
+        let range = entry.start_in_blamed_file as usize
+            ..(entry.start_in_blamed_file as usize + entry.len.get() as usize);
+        old_lines
+            .get_mut(range)
+            .ok_or("Invalid Git blame line range")?
+            .fill(label);
+    }
+    // Use Git's clean-filter pipeline, including core.autocrlf and attributes,
+    // so worktree edits shift attribution without mislabelling unchanged lines.
+    let mut cache = repository
+        .diff_resource_cache(
+            Mode::ToGit,
+            WorktreeRoots {
+                old_root: None,
+                new_root: Some(workdir),
+            },
+        )
+        .map_err(git_error)?;
+    cache
+        .set_resource(
+            entry.id().detach(),
+            EntryKind::Blob,
+            git_path.as_ref(),
+            ResourceKind::OldOrSource,
+            &repository,
+        )
+        .map_err(git_error)?;
+    cache
+        .set_resource(
+            repository.object_hash().null(),
+            EntryKind::Blob,
+            git_path.as_ref(),
+            ResourceKind::NewOrDestination,
+            &repository,
+        )
+        .map_err(git_error)?;
+    let prepared = cache.prepare_diff().map_err(git_error)?;
+    let input = prepared.interned_input();
+    if input.after.len() != output.len() || input.before.len() != old_lines.len() {
+        // A custom clean filter may change the line count. Its positions do not
+        // describe the file bat prints, so omit the annotation in that case.
+        return Ok(None);
+    }
+    let diff = gix::diff::blob::diff_with_slider_heuristics(Algorithm::Histogram, &input);
+    let (mut before, mut after) = (0usize, 0usize);
+    for hunk in diff.hunks() {
+        let unchanged = hunk.before.start as usize - before;
+        output[after..after + unchanged].copy_from_slice(&old_lines[before..before + unchanged]);
+        before = hunk.before.end as usize;
+        after = hunk.after.end as usize;
+    }
+    output[after..].copy_from_slice(&old_lines[before..]);
+    Ok(Some(BlameLines {
+        labels,
+        lines: output,
+    }))
+}
+
+fn git_error(error: impl std::fmt::Display) -> Error {
+    Error::Msg(format!("Could not read Git blame: {error}"))
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,10 @@ pub struct Config<'a> {
     /// Command to start the pager
     pub pager: Option<&'a str>,
 
+    /// Format for the optional Git blame sidebar.
+    #[cfg(feature = "git")]
+    pub blame_format: Option<&'a str>,
+
     /// Whether or not to use ANSI italics
     pub use_italic_text: bool,
 

--- a/src/decorations.rs
+++ b/src/decorations.rs
@@ -164,3 +164,88 @@ impl Decoration for GridBorderDecoration {
         self.cached.width
     }
 }
+
+#[cfg(feature = "git")]
+pub(crate) struct BlameDecoration {
+    labels: Vec<String>,
+    lines: Vec<usize>,
+    color: Style,
+    width: usize,
+}
+
+#[cfg(feature = "git")]
+impl BlameDecoration {
+    pub(crate) fn new(blame: crate::blame::BlameLines, colors: &Colors, max_width: usize) -> Self {
+        use unicode_segmentation::UnicodeSegmentation;
+        use unicode_width::UnicodeWidthStr;
+        let width = blame
+            .labels
+            .iter()
+            .map(|label| label.width())
+            .max()
+            .unwrap_or(0)
+            .min(max_width);
+        let labels = blame
+            .labels
+            .into_iter()
+            .map(|label| {
+                let mut value = String::new();
+                let mut used = 0;
+                let limit = if label.width() > width {
+                    width.saturating_sub(1)
+                } else {
+                    width
+                };
+                for grapheme in label.graphemes(true) {
+                    if used + grapheme.width() > limit {
+                        break;
+                    }
+                    used += grapheme.width();
+                    value.push_str(grapheme);
+                }
+                if label.width() > width && width > 0 {
+                    value.push('…');
+                    used += 1;
+                }
+                value.push_str(&" ".repeat(width - used));
+                value
+            })
+            .collect();
+        Self {
+            labels,
+            lines: blame.lines,
+            color: colors.line_number,
+            width,
+        }
+    }
+}
+
+#[cfg(feature = "git")]
+impl Decoration for BlameDecoration {
+    fn generate(
+        &self,
+        _line_number: usize,
+        continuation: bool,
+        printer: &InteractivePrinter,
+    ) -> DecorationText {
+        let label = if continuation {
+            None
+        } else {
+            printer
+                .source_line
+                .checked_sub(1)
+                .and_then(|line| self.lines.get(line))
+                .and_then(|&index| self.labels.get(index))
+        };
+        DecorationText {
+            width: self.width,
+            text: self
+                .color
+                .paint(label.cloned().unwrap_or_else(|| " ".repeat(self.width)))
+                .to_string(),
+        }
+    }
+    fn width(&self) -> usize {
+        self.width
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 
 #![deny(unsafe_code)]
 
+#[cfg(feature = "git")]
+mod blame;
 mod macros;
 
 pub mod assets;

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -23,6 +23,8 @@ struct ActiveStyleComponents {
     header_filename: bool,
     #[cfg(feature = "git")]
     vcs_modification_markers: bool,
+    #[cfg(feature = "git")]
+    git_blame: bool,
     grid: bool,
     rule: bool,
     line_numbers: bool,
@@ -168,6 +170,20 @@ impl<'a> PrettyPrinter<'a> {
     #[cfg(feature = "git")]
     pub fn vcs_modification_markers(&mut self, yes: bool) -> &mut Self {
         self.active_style_components.vcs_modification_markers = yes;
+        self
+    }
+
+    /// Show commit attribution before line numbers (default: false).
+    #[cfg(feature = "git")]
+    pub fn git_blame(&mut self, yes: bool) -> &mut Self {
+        self.active_style_components.git_blame = yes;
+        self
+    }
+
+    /// Set the Git blame annotation format (default: "%h %an").
+    #[cfg(feature = "git")]
+    pub fn blame_format(&mut self, format: &'a str) -> &mut Self {
+        self.config.blame_format = Some(format);
         self
     }
 
@@ -325,6 +341,11 @@ impl<'a> PrettyPrinter<'a> {
         #[cfg(feature = "git")]
         if self.active_style_components.vcs_modification_markers {
             self.config.style_components.insert(StyleComponent::Changes);
+        }
+
+        #[cfg(feature = "git")]
+        if self.active_style_components.git_blame {
+            self.config.style_components.insert(StyleComponent::Blame);
         }
 
         // Collect the inputs to print

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -207,6 +207,8 @@ pub(crate) struct InteractivePrinter<'a> {
     content_type: Option<ContentType>,
     #[cfg(feature = "git")]
     pub line_changes: &'a Option<LineChanges>,
+    #[cfg(feature = "git")]
+    pub source_line: usize,
     highlighter_from_set: Option<HighlighterFromSet<'a>>,
     background_color_highlight: Option<Color>,
     consecutive_empty_lines: usize,
@@ -234,6 +236,29 @@ impl<'a> InteractivePrinter<'a> {
 
         // Create decorations.
         let mut decorations: Vec<Box<dyn Decoration>> = Vec::new();
+
+        #[cfg(feature = "git")]
+        if config.style_components.blame() {
+            let format = crate::blame::BlameFormat::parse(
+                config.blame_format.unwrap_or(crate::blame::DEFAULT_FORMAT),
+            )?;
+            #[cfg(feature = "lessopen")]
+            let preprocessed = config.use_lessopen;
+            #[cfg(not(feature = "lessopen"))]
+            let preprocessed = false;
+            if !preprocessed && !config.unbuffered {
+                if let crate::input::OpenedInputKind::OrdinaryFile(path) = &input.kind {
+                    if let Some(lines) = crate::blame::get_git_blame(path, &format)? {
+                        let max_width = config.term_width.saturating_sub(14).min(32);
+                        if max_width >= 8 {
+                            decorations.push(Box::new(crate::decorations::BlameDecoration::new(
+                                lines, &colors, max_width,
+                            )));
+                        }
+                    }
+                }
+            }
+        }
 
         if config.style_components.numbers() {
             decorations.push(Box::new(LineNumberDecoration::new(&colors)));
@@ -340,6 +365,8 @@ impl<'a> InteractivePrinter<'a> {
             ansi_style: AnsiStyle::new(),
             #[cfg(feature = "git")]
             line_changes,
+            #[cfg(feature = "git")]
+            source_line: 0,
             highlighter_from_set,
             background_color_highlight,
             consecutive_empty_lines: 0,
@@ -653,6 +680,10 @@ impl Printer for InteractivePrinter<'_> {
         line_buffer: &[u8],
         max_buffered_line_number: MaxBufferedLineNumber,
     ) -> Result<()> {
+        #[cfg(feature = "git")]
+        {
+            self.source_line += 1;
+        }
         let line = if self.config.show_nonprintable {
             replace_nonprintable(
                 line_buffer,

--- a/src/style.rs
+++ b/src/style.rs
@@ -9,6 +9,8 @@ pub enum StyleComponent {
     Auto,
     #[cfg(feature = "git")]
     Changes,
+    #[cfg(feature = "git")]
+    Blame,
     Grid,
     Rule,
     Header,
@@ -33,6 +35,8 @@ impl StyleComponent {
             }
             #[cfg(feature = "git")]
             StyleComponent::Changes => &[StyleComponent::Changes],
+            #[cfg(feature = "git")]
+            StyleComponent::Blame => &[StyleComponent::Blame],
             StyleComponent::Grid => &[StyleComponent::Grid],
             StyleComponent::Rule => &[StyleComponent::Rule],
             StyleComponent::Header => &[StyleComponent::HeaderFilename],
@@ -70,6 +74,8 @@ impl FromStr for StyleComponent {
             "auto" => Ok(StyleComponent::Auto),
             #[cfg(feature = "git")]
             "changes" => Ok(StyleComponent::Changes),
+            #[cfg(feature = "git")]
+            "blame" => Ok(StyleComponent::Blame),
             "grid" => Ok(StyleComponent::Grid),
             "rule" => Ok(StyleComponent::Rule),
             "header" => Ok(StyleComponent::Header),
@@ -96,6 +102,11 @@ impl StyleComponents {
     #[cfg(feature = "git")]
     pub fn changes(&self) -> bool {
         self.0.contains(&StyleComponent::Changes)
+    }
+
+    #[cfg(feature = "git")]
+    pub fn blame(&self) -> bool {
+        self.0.contains(&StyleComponent::Blame)
     }
 
     pub fn grid(&self) -> bool {

--- a/tests/git_blame.rs
+++ b/tests/git_blame.rs
@@ -1,0 +1,392 @@
+#![cfg(feature = "git")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::{tempdir, TempDir};
+
+mod utils;
+use utils::command::bat;
+
+struct Repo {
+    directory: TempDir,
+    file: PathBuf,
+}
+
+fn git(path: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .current_dir(path)
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env(
+            "GIT_CONFIG_GLOBAL",
+            if cfg!(windows) { "NUL" } else { "/dev/null" },
+        )
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+impl Repo {
+    fn empty() -> Self {
+        let directory = tempdir().unwrap();
+        git(directory.path(), &["init", "-b", "main"]);
+        git(directory.path(), &["config", "user.name", "Committer"]);
+        git(
+            directory.path(),
+            &["config", "user.email", "committer@example.test"],
+        );
+        git(directory.path(), &["config", "core.autocrlf", "false"]);
+        let file = directory.path().join("source.rs");
+        Self { directory, file }
+    }
+
+    fn new() -> Self {
+        let repo = Self::empty();
+        fs::write(&repo.file, "alpha\nbravo\ncharlie\n").unwrap();
+        repo.commit("Ada", "initial");
+        fs::write(&repo.file, "alpha\nBETA\ncharlie\n").unwrap();
+        repo.commit("Bea", "edit");
+        repo
+    }
+
+    fn commit(&self, author: &str, subject: &str) {
+        git(self.directory.path(), &["add", "-A"]);
+        let output = Command::new("git")
+            .current_dir(self.directory.path())
+            .args(["commit", "-m", subject])
+            .env("GIT_AUTHOR_NAME", author)
+            .env("GIT_AUTHOR_EMAIL", "author@example.test")
+            .env("GIT_COMMITTER_NAME", "Committer")
+            .env("GIT_COMMITTER_EMAIL", "committer@example.test")
+            .env("GIT_AUTHOR_DATE", "2020-02-03T04:05:06+02:00")
+            .env("GIT_COMMITTER_DATE", "2021-03-04T05:06:07-03:00")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env(
+                "GIT_CONFIG_GLOBAL",
+                if cfg!(windows) { "NUL" } else { "/dev/null" },
+            )
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn output(&self, options: &[&str]) -> String {
+        let mut command = bat();
+        if !options
+            .iter()
+            .any(|option| option.starts_with("--blame-format"))
+        {
+            command.arg("--blame-format=%h");
+        }
+        let bytes = command
+            .args([
+                "--paging=never",
+                "--color=never",
+                "--style=plain",
+                "--blame",
+                "--terminal-width=120",
+            ])
+            .args(options)
+            .arg(&self.file)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        String::from_utf8(bytes).unwrap()
+    }
+
+    fn expected_hashes(&self) -> Vec<String> {
+        let relative = self.file.strip_prefix(self.directory.path()).unwrap();
+        git(
+            self.directory.path(),
+            &[
+                "blame",
+                "--line-porcelain",
+                "--",
+                relative.to_str().unwrap(),
+            ],
+        )
+        .lines()
+        .filter_map(|line| {
+            let parts: Vec<_> = line.split_whitespace().collect();
+            (parts.len() >= 3
+                && parts[0].len() == 40
+                && parts[0].bytes().all(|b| b.is_ascii_hexdigit()))
+            .then(|| parts[0][..8].to_owned())
+        })
+        .collect()
+    }
+
+    fn check_hashes(&self) {
+        let output = self.output(&[]);
+        let actual: Vec<_> = output
+            .lines()
+            .map(|line| line.split_whitespace().next().unwrap().to_owned())
+            .collect();
+        assert_eq!(actual, self.expected_hashes(), "{output}");
+    }
+}
+
+#[test]
+fn committed_lines_match_git_and_custom_fields_use_author_metadata() {
+    let repo = Repo::new();
+    repo.check_hashes();
+    let output = repo.output(&["--blame-format=%an|%as|%s"]);
+    let lines: Vec<_> = output.lines().collect();
+    assert!(lines[0].contains("Ada|2020-02-03|initial"), "{output}");
+    assert!(lines[1].contains("Bea|2020-02-03|edit"), "{output}");
+    assert!(lines[2].contains("Ada|2020-02-03|initial"), "{output}");
+    let output = repo.output(&["--blame-format=%cn|%cs|%%"]);
+    assert!(output.contains("Committer|2021-03-04|%"), "{output}");
+}
+
+#[test]
+fn insertions_deletions_and_staged_changes_keep_unchanged_attribution() {
+    let repo = Repo::new();
+    for content in [
+        "new first\nalpha\nBETA\ncharlie\n",
+        "alpha\ncharlie\n",
+        "alpha\nchanged\ncharlie\nnew last\n",
+        "",
+    ] {
+        fs::write(&repo.file, content).unwrap();
+        if !content.is_empty() {
+            repo.check_hashes();
+        } else {
+            assert_eq!(repo.output(&[]), "");
+        }
+    }
+    fs::write(&repo.file, "alpha\nstaged\ncharlie\n").unwrap();
+    git(repo.directory.path(), &["add", "source.rs"]);
+    repo.check_hashes();
+}
+
+#[test]
+fn renamed_files_keep_their_original_authors() {
+    let mut repo = Repo::new();
+    git(
+        repo.directory.path(),
+        &["mv", "source.rs", "a renamed file.rs"],
+    );
+    repo.file = repo.directory.path().join("a renamed file.rs");
+    repo.commit("Ren", "rename");
+    repo.check_hashes();
+}
+
+#[test]
+fn merge_history_matches_git_attribution() {
+    let repo = Repo::new();
+    git(repo.directory.path(), &["checkout", "-b", "topic"]);
+    fs::write(&repo.file, "topic\nBETA\ncharlie\n").unwrap();
+    repo.commit("Topic", "topic");
+    git(repo.directory.path(), &["checkout", "main"]);
+    fs::write(&repo.file, "alpha\nBETA\nmain\n").unwrap();
+    repo.commit("Main", "main");
+    git(
+        repo.directory.path(),
+        &["merge", "--no-ff", "-m", "merge", "topic"],
+    );
+    repo.check_hashes();
+}
+
+#[test]
+fn linked_worktrees_use_their_own_head_and_edits() {
+    let original = Repo::new();
+    let worktree = tempdir().unwrap();
+    git(
+        original.directory.path(),
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            worktree.path().to_str().unwrap(),
+        ],
+    );
+    let repo = Repo {
+        file: worktree.path().join("source.rs"),
+        directory: worktree,
+    };
+    fs::write(&repo.file, "alpha\nlocal edit\ncharlie\n").unwrap();
+    repo.check_hashes();
+}
+
+#[test]
+fn untracked_and_unborn_files_are_marked_uncommitted() {
+    let repo = Repo::empty();
+    fs::write(&repo.file, "unborn\n").unwrap();
+    assert!(repo.output(&[]).contains("00000000"));
+    repo.commit("Ada", "first");
+    let new_file = repo.directory.path().join("untracked.rs");
+    fs::write(&new_file, "untracked\n").unwrap();
+    let output = bat()
+        .args([
+            "--paging=never",
+            "--color=never",
+            "--style=plain",
+            "--blame",
+        ])
+        .arg(new_file)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(String::from_utf8(output)
+        .unwrap()
+        .contains("Not Committed Yet"));
+}
+
+#[test]
+fn non_repository_and_named_stdin_inputs_do_not_gain_false_attribution() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("source.rs");
+    fs::write(&file, "plain\n").unwrap();
+    bat()
+        .args([
+            "--paging=never",
+            "--color=never",
+            "--style=plain",
+            "--blame",
+        ])
+        .arg(file)
+        .assert()
+        .success()
+        .stdout("plain\n");
+    let repo = Repo::new();
+    bat()
+        .args([
+            "--paging=never",
+            "--color=never",
+            "--style=plain",
+            "--blame",
+            "--file-name",
+        ])
+        .arg(&repo.file)
+        .write_stdin("different\n")
+        .assert()
+        .success()
+        .stdout("different\n");
+}
+
+#[test]
+fn crlf_worktree_conversion_does_not_mark_every_line_as_modified() {
+    let repo = Repo::new();
+    git(repo.directory.path(), &["config", "core.autocrlf", "true"]);
+    fs::write(&repo.file, "alpha\r\nBETA\r\ncharlie\r\n").unwrap();
+    repo.check_hashes();
+}
+
+#[test]
+fn line_ranges_squeezing_and_nonblank_numbering_keep_physical_attribution() {
+    let repo = Repo::new();
+    fs::write(&repo.file, "alpha\n\n\nBETA\ncharlie\n").unwrap();
+    repo.commit("Extra", "spacing");
+    let hashes = repo.expected_hashes();
+    let output = repo.output(&["--number-nonblank", "--squeeze-blank", "--line-range=2:"]);
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains(&hashes[3]) && line.ends_with("BETA")),
+        "{output}"
+    );
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains(&hashes[4]) && line.ends_with("charlie")),
+        "{output}"
+    );
+}
+
+#[test]
+fn metadata_is_sanitized_and_wide_authors_fit_the_sidebar() {
+    let repo = Repo::empty();
+    fs::write(&repo.file, "one\n").unwrap();
+    repo.commit("Alex界界界界界界界界界界界界界界界界\x1b[31m", "metadata");
+    let output = repo.output(&["--blame-format=%an", "--terminal-width=48"]);
+    assert!(!output.contains('\x1b'), "{output:?}");
+    assert!(output.contains('…'), "{output}");
+    for line in output.lines() {
+        assert!(unicode_width::UnicodeWidthStr::width(line) <= 48);
+    }
+    let escaped = repo.output(&["--blame-format=%s\x1b[2J"]);
+    assert!(!escaped.contains('\x1b'), "{escaped:?}");
+}
+
+#[test]
+fn wrapping_does_not_repeat_attribution_on_continuations() {
+    let repo = Repo::new();
+    fs::write(
+        &repo.file,
+        "a long source line that wraps into several screen rows with annotations\n",
+    )
+    .unwrap();
+    repo.commit("Wrap", "wrap");
+    let output = repo.output(&["--terminal-width=28", "--wrap=character"]);
+    let hash = git(repo.directory.path(), &["rev-parse", "HEAD"]);
+    assert!(output.lines().count() > 1);
+    assert_eq!(output.matches(&hash[..8]).count(), 1, "{output}");
+}
+
+#[test]
+fn invalid_formats_fail_and_full_style_remains_opt_in() {
+    let repo = Repo::new();
+    bat()
+        .args(["--paging=never", "--blame", "--blame-format=%q"])
+        .arg(&repo.file)
+        .assert()
+        .failure();
+    let output = bat()
+        .args([
+            "--paging=never",
+            "--color=never",
+            "--decorations=always",
+            "--style=full",
+        ])
+        .arg(&repo.file)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    for hash in repo.expected_hashes() {
+        assert!(!text.contains(&hash), "{text}");
+    }
+    let output = repo.output(&["--decorations=never"]);
+    assert_eq!(output, "alpha\nBETA\ncharlie\n");
+}
+
+#[test]
+fn library_printer_exposes_blame_without_changing_the_input_text() {
+    let repo = Repo::new();
+    let mut text = String::new();
+    bat::PrettyPrinter::new()
+        .input_file(&repo.file)
+        .colored_output(false)
+        .term_width(120)
+        .git_blame(true)
+        .blame_format("%an")
+        .print_with_writer(Some(&mut text))
+        .unwrap();
+    assert!(text.contains("Ada") && text.contains("Bea"), "{text}");
+    assert!(text.lines().next().unwrap().ends_with("alpha"));
+}
+
+#[test]
+fn unbuffered_mode_and_repeated_options_preserve_source_lines() {
+    let repo = Repo::new();
+    assert_eq!(repo.output(&["--unbuffered"]), "alpha\nBETA\ncharlie\n");
+    let output = repo.output(&["--blame", "--blame-format=%h", "--blame-format=%an"]);
+    assert!(output.contains("Ada") && output.contains("Bea"), "{output}");
+}


### PR DESCRIPTION
Show commit attribution before line numbers with --blame or the blame style component. Keep it opt-in, including when using the full style, and expose the same controls through PrettyPrinter.

Use gix's blame support to follow renames and merge history, then map HEAD attribution onto the current worktree with Git's clean-filter pipeline. Insertions, modifications and staged changes are marked uncommitted; unchanged lines retain their original commits. Handle linked worktrees, unborn repositories, untracked files and CRLF conversion. Preserve physical attribution when ranges, squeezing or nonblank numbering change the displayed line numbers.

Add --blame-format for commit hashes, author/committer names, emails, dates, Unix times and subjects. Sanitize metadata, truncate by Unicode grapheme boundaries to a bounded sidebar width, and leave wrapped continuation annotations empty. Ordinary UTF-8 files are supported; stdin, preprocessing, unbuffered input, binary files and files outside repositories omit attribution. History is computed before printing, so large histories can delay initial output.

This revisits the static blame feature proposed by @userwiths in #2851, which was welcomed after a rebase and later closed as stale. The implementation uses the repository's current gix dependency, enabling its blame feature and adding gix-blame 0.16.0.

Validation: all 487 all-feature tests passed (7 ignored), including 14 regressions comparing attribution against git blame across edits, renames, merges, worktrees and CRLF conversion. All 8 default-feature help tests passed. All-target/all-feature Clippy with warnings denied, formatting, whitespace checks, Bash/Zsh completion syntax, and a library build without Git or paging passed. README, manual, help snapshots and all four completions are updated. GitHub CI will validate other platforms.

Fixes #1536. Fixes #2810.