### PR TITLE
Explain how styles and decorations interact in pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Other
 
-- Clarify how automatic styles interact with decoration settings when piping output, see #0 (@Matei02355). Closes #1743
+- Clarify how automatic styles interact with decoration settings when piping output, see #3992 (@Matei02355). Closes #1743
 
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Other
 
+- Clarify how automatic styles interact with decoration settings when piping output, see #0 (@Matei02355). Closes #1743
+
 - Update Cargo dependencies to resolve current RustSec advisories, see #3861 (@TyceHerrman)
 - Add instructions for removing fish help abbreviations to README, see #3655 (@claw-explorer). Closes #3536
 - Add .NET slnx extension, see #3682 (@ltrzesniewski)

--- a/README.md
+++ b/README.md
@@ -547,6 +547,27 @@ By default, `bat` only shows decorations (such as line numbers, file headers, gr
 
 There is also the `--force-colorization` option, which is an alias for `--decorations=always --color=always`. This is useful if you want to keep colorization and decorations when piping `bat`'s output to another program.
 
+`--style` chooses the components; `--decorations` controls whether the chosen
+components are displayed. These settings act separately. In particular,
+`--style=auto` selects no components when stdout is redirected, even with
+`--decorations=always` or `-f`. The default style is `default`, not `auto`.
+
+For predictable piped output, choose a style explicitly and enable decorations:
+
+```sh
+bat --style=numbers --decorations=always file.rs | other-command
+bat --style=full --force-colorization file.rs | other-command
+```
+
+If your configuration contains `--style=auto`, replace it with `--style=default`
+to keep the normal terminal layout and let `--decorations=auto` suppress it when
+piping. Then `--decorations=always` can enable that layout without changing its
+components. Other configured style components and numbering flags still apply.
+
+`auto` can also be combined with individual components. For example,
+`--style=auto,numbers` selects the default layout on a terminal but only line
+numbers when piped; the piped numbers still need `--decorations=always` (or `-f`).
+
 ### Adding new syntaxes / language definitions
 
 Should you find that a particular syntax is not available within `bat`, you can follow these

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -242,6 +242,14 @@ replacing them.
 By default, the following components are enabled:
 changes, grid, header\-filename, numbers, snip
 .IP
+The style selects components, while '\-\-decorations' controls whether those
+components are displayed. The auto style selects no components when stdout is
+redirected, even with '\-\-decorations=always' or '\-f'. The default style is
+default, not auto. Use '\-\-style=numbers \-\-decorations=always' to pipe line
+numbers, or '\-\-style=full \-f' to pipe the full colored layout.
+A style such as auto,numbers selects the default layout on a terminal but only
+numbers when piped; decorations must still be enabled for those numbers.
+.IP
 Possible values: *default*, full, auto, plain, changes, header, header-filename, header-filesize, grid,
 rule, numbers, snip.
 .HP


### PR DESCRIPTION
The documentation currently says --decorations=always enables decorations in pipelines without explaining that --style=auto has already selected an empty layout. This makes the two independent automatic settings difficult to understand.

Clarify that --style selects components and --decorations controls their display, and that the default style is default. Show explicit pipeline commands, explain how replacing a configured auto style with default lets decorations control the existing layout, and document the mixed auto,numbers case. Update README and the manual together.

This addresses the requested documentation clarification in #1743. It does not introduce new style syntax or alter existing flag behavior.

Validation: checked 20 redirected-output and real-PTY combinations against the current baseline binary, covering auto, default, numbers, auto,numbers and full with automatic and forced decorations. Whitespace checks passed.

Fixes #1743.