### PR TITLE
Write each rendered source line as one output operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
-- Submit rendered lines in one output write to reduce overhead for colored Git logs and pagers, see #0 (@Matei02355). Closes #1147
+- Submit rendered lines in one output write to reduce overhead for colored Git logs and pagers, see #3993 (@Matei02355). Closes #1147
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Syntax highlighting for Python files using uv as script runner in shebang #3689 (@janlarres)
 
 ## Bugfixes
+- Submit rendered lines in one output write to reduce overhead for colored Git logs and pagers, see #0 (@Matei02355). Closes #1147
 - Allow boolean flags to be given more than once, so that a flag set in the config file can also be passed on the command line without erroring, see #3912 (@logarithmone1128)
 - Use parsed CLI arguments to detect number flags, see #3908 (@cuishuang)
 - Detect binary content beyond the first line, preventing encrypted files with early line breaks from being treated as text. Closes #3554, see #3877 (@Matei02355)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -210,6 +210,7 @@ pub(crate) struct InteractivePrinter<'a> {
     highlighter_from_set: Option<HighlighterFromSet<'a>>,
     background_color_highlight: Option<Color>,
     consecutive_empty_lines: usize,
+    rendered_line: String,
     strip_ansi: bool,
     sanitize: bool,
     strip_overstrike: bool,
@@ -343,6 +344,7 @@ impl<'a> InteractivePrinter<'a> {
             highlighter_from_set,
             background_color_highlight,
             consecutive_empty_lines: 0,
+            rendered_line: String::new(),
             strip_ansi,
             sanitize,
             strip_overstrike,
@@ -646,6 +648,42 @@ impl Printer for InteractivePrinter<'_> {
     }
 
     fn print_line(
+        &mut self,
+        out_of_range: bool,
+        handle: &mut OutputHandle,
+        line_number: usize,
+        line_buffer: &[u8],
+        max_buffered_line_number: MaxBufferedLineNumber,
+    ) -> Result<()> {
+        // Submit each rendered source line together. In particular, a pager pipe
+        // must not receive a separate write for every ANSI segment or sidebar cell.
+        // Unbuffered input still calls this once per available input fragment.
+        let mut rendered = std::mem::take(&mut self.rendered_line);
+        rendered.clear();
+        let result = self.render_line(
+            out_of_range,
+            &mut OutputHandle::FmtWrite(&mut rendered),
+            line_number,
+            line_buffer,
+            max_buffered_line_number,
+        );
+        let written = if rendered.is_empty() {
+            Ok(())
+        } else {
+            handle.write_fmt(format_args!("{rendered}"))
+        };
+        // Keep the common buffer but release oversized allocations after a long
+        // line, instead of retaining them until the entire file has been printed.
+        if rendered.capacity() <= 64 * 1024 {
+            self.rendered_line = rendered;
+        }
+        written?;
+        result
+    }
+}
+
+impl InteractivePrinter<'_> {
+    fn render_line(
         &mut self,
         out_of_range: bool,
         handle: &mut OutputHandle,

--- a/tests/benchmarks/compare-output-writes.py
+++ b/tests/benchmarks/compare-output-writes.py
@@ -1,0 +1,41 @@
+"""Compare two release builds through a draining pager, checking output equality.
+
+Usage: python3 tests/benchmarks/compare-output-writes.py BASELINE CANDIDATE
+Build both with the same toolchain, release settings and default features.
+This measures formatting and pipe overhead, not terminal rendering speed.
+"""
+import argparse
+import os,subprocess,time,hashlib,statistics,json,pathlib,tempfile
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("baseline", type=pathlib.Path)
+parser.add_argument("candidate", type=pathlib.Path)
+parser.add_argument("--runs", type=int, default=8)
+args = parser.parse_args()
+if args.runs < 1:
+    parser.error("--runs must be positive")
+run_count = args.runs
+root=pathlib.Path(__file__).resolve().parents[2]
+base=str(args.baseline.resolve(strict=True))
+new=str(args.candidate.resolve(strict=True))
+temporary = tempfile.TemporaryDirectory(prefix='bat-output-benchmark-')
+data = pathlib.Path(temporary.name)
+gitlog=data/'history.txt'
+gitlog.write_bytes(b''.join((f'* \x1b[31m{i:08x}\x1b[0m -\x1b[33m (HEAD -> main)\x1b[0m A commit subject with more text for wrapping \x1b[32m(2 days ago)\x1b[0m \x1b[1;34m<Author Name>\x1b[0m\n').encode() for i in range(80000)))
+seq=data/'sequence.txt';seq.write_text(''.join(f'{i}\n' for i in range(1,1000001)))
+rust=data/'source.rs';rust.write_bytes((root/'src/printer.rs').read_bytes()*20)
+report=[]
+for name,path,extra in [('colored-history',gitlog,['--wrap=character','-l','txt']),('million-lines',seq,['--wrap=character','-l','txt']),('rust',rust,['--wrap=character','-l','rs']),('plain',gitlog,['--style=plain','--color=never'])]:
+    args=['--no-config','--no-custom-assets','--color=always','--style=numbers','--terminal-width=80','--paging=always','--pager=cat']+extra+[str(path)]
+    env={k:v for k,v in os.environ.items() if not k.startswith('BAT_') and k not in ['PAGER','LESS','NO_COLOR','COLORTERM','LESSOPEN','LESSCLOSE']};env['TERM']='xterm-256color'
+    outputs=[subprocess.check_output([binary]+args,env=env) for binary in [base,new]]
+    assert outputs[0]==outputs[1],name
+    runs=[[],[]]
+    for i in range(run_count):
+        for index in ([0,1] if i%2==0 else [1,0]):
+            start=time.perf_counter()
+            subprocess.run([[base,new][index]]+args,stdout=subprocess.DEVNULL,check=True,env=env)
+            runs[index].append(time.perf_counter()-start)
+    row={'workload':name,'input_bytes':path.stat().st_size,'output_sha256':hashlib.sha256(outputs[0]).hexdigest(),'seconds':runs,'baseline_median':statistics.median(runs[0]),'new_median':statistics.median(runs[1])}
+    row['speedup']=row['baseline_median']/row['new_median']
+    report.append(row);print(json.dumps(row),flush=True)
+temporary.cleanup()

--- a/tests/output_buffering.rs
+++ b/tests/output_buffering.rs
@@ -1,0 +1,127 @@
+use std::io::{self, Cursor, Write};
+
+use bat::assets::HighlightingAssets;
+use bat::config::Config;
+use bat::controller::Controller;
+use bat::input::Input;
+use bat::output::OutputHandle;
+use bat::style::StyleComponent;
+use bat::WrappingMode;
+
+#[derive(Default)]
+struct RecordingWriter {
+    writes: Vec<Vec<u8>>,
+    maximum_write: Option<usize>,
+}
+
+impl Write for RecordingWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        let size = self.maximum_write.unwrap_or(bytes.len()).min(bytes.len());
+        self.writes.push(bytes[..size].to_vec());
+        Ok(size)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn config(wrapping_mode: WrappingMode) -> Config<'static> {
+    let mut config = Config {
+        language: Some("txt"),
+        term_width: 38,
+        tab_width: 4,
+        colored_output: true,
+        true_color: true,
+        theme: "Monokai Extended".to_owned(),
+        wrapping_mode,
+        ..Default::default()
+    };
+    config.style_components.insert(StyleComponent::LineNumbers);
+    config
+}
+
+const TEXT: &[u8] = b"* \x1b[31m12345678\x1b[0m - \x1b[33mHEAD\x1b[0m colored history\n* \x1b[32mabcdefgh\x1b[0m a longer line of text that wraps several times\nlast";
+
+#[test]
+fn colored_and_wrapped_lines_are_submitted_as_whole_lines() {
+    let assets = HighlightingAssets::from_binary();
+    for wrapping in [
+        WrappingMode::NoWrapping(false),
+        WrappingMode::Character,
+        WrappingMode::Word,
+    ] {
+        let config = config(wrapping);
+        let controller = Controller::new(&config, &assets);
+        let mut writer = RecordingWriter::default();
+        assert!(controller
+            .run(
+                vec![Input::from_reader(Box::new(Cursor::new(TEXT)))],
+                Some(&mut OutputHandle::IoWrite(&mut writer)),
+            )
+            .unwrap());
+        assert_eq!(writer.writes.len(), 3, "{:?}", config.wrapping_mode);
+        let mut expected = String::new();
+        controller
+            .run(
+                vec![Input::from_reader(Box::new(Cursor::new(TEXT)))],
+                Some(&mut OutputHandle::FmtWrite(&mut expected)),
+            )
+            .unwrap();
+        assert_eq!(writer.writes.concat(), expected.as_bytes());
+        assert!(expected.contains("12345678") && expected.contains("last"));
+    }
+}
+
+#[test]
+fn short_writes_do_not_truncate_or_repeat_rendered_bytes() {
+    let assets = HighlightingAssets::from_binary();
+    let config = config(WrappingMode::Character);
+    let controller = Controller::new(&config, &assets);
+    let mut writer = RecordingWriter {
+        maximum_write: Some(3),
+        ..Default::default()
+    };
+    controller
+        .run(
+            vec![Input::from_reader(Box::new(Cursor::new(TEXT)))],
+            Some(&mut OutputHandle::IoWrite(&mut writer)),
+        )
+        .unwrap();
+    let mut expected = String::new();
+    controller
+        .run(
+            vec![Input::from_reader(Box::new(Cursor::new(TEXT)))],
+            Some(&mut OutputHandle::FmtWrite(&mut expected)),
+        )
+        .unwrap();
+    assert_eq!(writer.writes.concat(), expected.as_bytes());
+}
+
+#[test]
+fn failed_output_preserves_the_io_error_kind() {
+    struct Fails;
+    impl Write for Fails {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::ErrorKind::BrokenPipe.into())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    let assets = HighlightingAssets::from_binary();
+    let config = config(WrappingMode::Character);
+    let mut kind = None;
+    let successful = Controller::new(&config, &assets)
+        .run_with_error_handler(
+            vec![Input::from_reader(Box::new(Cursor::new(TEXT)))],
+            Some(&mut OutputHandle::IoWrite(&mut Fails)),
+            |error, _| {
+                if let bat::error::Error::Io(error) = error {
+                    kind = Some(error.kind());
+                }
+            },
+        )
+        .unwrap();
+    assert!(!successful);
+    assert_eq!(kind, Some(io::ErrorKind::BrokenPipe));
+}


### PR DESCRIPTION
Colored Git logs produce many output writes for ANSI segments and sidebar cells, adding overhead when bat feeds a pager.

Render each source line into a reusable string and submit it as one output operation. Preserve byte-for-byte formatting, short-write handling, I/O errors and per-line streaming. Release buffers larger than 64 KiB after their line. Unbuffered mode still submits each available input fragment; it does not wait for the next source line.

Add regression coverage for write counts across character, word and unwrapped output, short writers and broken pipes. Include a standalone benchmark that compares identically built release binaries through a draining pager and verifies output hashes before alternating timed runs.

Validation: all 476 all-feature tests passed (7 ignored), including the three new regressions. Clippy with warnings denied, formatting, whitespace checks and the library-only build passed. Baseline and candidate both emitted a complete line and subsequent partial input before stdin EOF.

On this Linux host, eight alternating runs of an 80,000-line colored log through a cat pager improved from a 1.862 s median to 0.920 s (2.02x). One million numbered lines improved from 3.604 s to 2.503 s (1.44x). Rust highlighting was approximately unchanged (1.077 s versus 1.031 s). The unchanged plain-output path varied from 36.5 ms to 39.0 ms. All four output hashes matched. These measure formatting and pipe overhead, not terminal-emulator performance; no Windows speed claim is made.

Fixes #1147.