### PR TITLE
Add opt-in highlighting for TODO and FIXME comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add optional TODO and FIXME highlighting inside language-defined comments, see #0 (@Matei02355). Closes #2225
+- Add optional TODO and FIXME highlighting inside language-defined comments, see #3994 (@Matei02355). Closes #2225
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add optional TODO and FIXME highlighting inside language-defined comments, see #0 (@Matei02355). Closes #2225
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -499,6 +499,24 @@ Although these themes are more restricted, they have three advantages over truec
 - Adapt to terminal theme changes. Even for already printed output.
 - Visually harmonize better with other terminal software.
 
+### TODO comments
+
+Use `bat --highlight-todos file.rs` to emphasize TODO and FIXME annotations in
+comments. Matching is case-insensitive and includes the plural forms TODOS and
+FIXMES. The marker and the rest of its comment on that line become bold amber;
+light themes use a darker amber, and palette-based themes use terminal yellow.
+
+This uses each language's comment definitions, including comments in embedded
+languages. It leaves matching words in strings and ordinary code unchanged, and
+it does not extend a TODO highlight to following lines in a block comment.
+Syntax highlighting and colored output must be enabled. Standard plain text has
+no comment definitions, and lines longer than bat's syntax-highlighting limit
+retain the usual unhighlighted behavior.
+
+The option is disabled by default. Add `--highlight-todos` to the configuration
+file to enable it permanently, or use `PrettyPrinter::highlight_todos` in the
+library.
+
 ### Output style
 
 You can use the `--style` option to control the appearance of `bat`'s output.

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -136,6 +136,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-l'                      , 'l'                     , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
             [CompletionResult]::new('--language'              , 'language'              , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
         #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+            [CompletionResult]::new('--highlight-todos', 'highlight-todos', [CompletionResultType]::ParameterName, 'Emphasize TODO and FIXME comments.')
             [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
             [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
             [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -202,6 +202,7 @@ _bat() {
 			--plain
 			--language
 			--highlight-line
+			--highlight-todos
 			--file-name
 			--diff
 			--diff-context

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -176,6 +176,8 @@ complete -c $bat -s h -d "Print a concise overview" -n __fish_is_first_arg
 
 complete -c $bat -l help -f -d "Print all help information" -n __fish_is_first_arg
 
+complete -c $bat -l highlight-todos -d "Emphasize TODO and FIXME comments" -n __bat_no_excl_args
+
 complete -c $bat -s H -l highlight-line -x -d "Highlight line(s) N[:M]" -n __bat_no_excl_args
 
 complete -c $bat -l ignored-suffix -x -d "Ignore extension" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -30,6 +30,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
         \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
+        --highlight-todos'[emphasize TODO and FIXME comments]'
         \*--file-name='[specify the name to display for a file]:name:_files'
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'
         --diff-context='[specify lines of context around added/removed/modified lines when using `--diff`]:lines'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -68,6 +68,16 @@ specified as a name (like 'C++' or 'LaTeX') or possible file extension
 (like 'cpp', 'hpp' or 'md'). Use '\-\-list\-languages' to show all supported
 language names and file extensions.
 .HP
+\fB\-\-highlight\-todos\fR
+.IP
+Emphasize TODO, TODOS, FIXME and FIXMES inside comments, ignoring case. The marker
+and the remainder of its comment on the current line use bold amber text (darker
+amber for light themes and terminal yellow for palette-based themes). Matching
+text in strings or ordinary code is unchanged. Uses the language's comment
+definitions, including embedded languages. Disabled by default; requires syntax
+highlighting and colored output. Long lines excluded from syntax highlighting
+are also excluded from comment annotations.
+.HP
 \fB\-H\fR, \fB\-\-highlight\-line\fR <N:M>...
 .IP
 Highlight the specified line ranges with a different background color. For example:

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -44,6 +44,13 @@ Options:
           
           [aliases: --fallback-language]
 
+      --highlight-todos
+          Emphasize TODO, TODOS, FIXME and FIXMES in comments, ignoring case. Highlight from the
+          marker to the end of that comment on the current line, using bold amber text (terminal
+          yellow with palette-based themes). Uses syntax comment scopes, so matching text in strings
+          and source code is unchanged. Disabled by default; requires syntax highlighting and
+          colored output.
+
   -H, --highlight-line <N:M>
           Highlight the specified line ranges with a different background color For example:
             '--highlight-line 40' highlights line 40

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -383,6 +383,7 @@ impl App {
                 .get_one::<String>("fallback-syntax")
                 .map(|s| s.as_str()),
             show_nonprintable: self.matches.get_flag("show-all"),
+            highlight_todos: self.matches.get_flag("highlight-todos"),
             nonprintable_notation: match self
                 .matches
                 .get_one::<String>("nonprintable-notation")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -134,6 +134,19 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("highlight-todos")
+                .long("highlight-todos")
+                .overrides_with("highlight-todos")
+                .action(ArgAction::SetTrue)
+                .help("Emphasize TODO and FIXME comments")
+                .long_help("Emphasize TODO, TODOS, FIXME and FIXMES in comments, ignoring case. \
+                    Highlight from the marker to the end of that comment on the current line, \
+                    using bold amber text (terminal yellow with palette-based themes). Uses \
+                    syntax comment scopes, so matching text in strings and source code is unchanged. \
+                    Disabled by default; requires syntax highlighting and colored output.")
+                .hide_short_help(true),
+        )
+        .arg(
             Arg::new("highlight-line")
                 .long("highlight-line")
                 .short('H')

--- a/src/comment_annotations.rs
+++ b/src/comment_annotations.rs
@@ -1,0 +1,328 @@
+//! Optional annotations derived from syntax comment scopes.
+use std::ops::Range;
+
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{
+    Color, FontStyle, HighlightIterator, HighlightState, Highlighter, Style, Theme,
+};
+use syntect::parsing::{ParseState, Scope, ScopeStack, SyntaxReference, SyntaxSet};
+use unicode_segmentation::UnicodeSegmentation;
+
+pub(crate) enum LineHighlighter<'a> {
+    Standard(HighlightLines<'a>),
+    Annotated(CommentHighlighter<'a>),
+}
+
+impl<'a> LineHighlighter<'a> {
+    pub(crate) fn new(syntax: &SyntaxReference, theme: &'a Theme, annotate: bool) -> Self {
+        if annotate {
+            Self::Annotated(CommentHighlighter::new(syntax, theme))
+        } else {
+            Self::Standard(HighlightLines::new(syntax, theme))
+        }
+    }
+
+    pub(crate) fn highlight_line<'b>(
+        &mut self,
+        line: &'b str,
+        set: &SyntaxSet,
+    ) -> Result<Vec<(Style, &'b str)>, syntect::Error> {
+        match self {
+            Self::Standard(highlighter) => highlighter.highlight_line(line, set),
+            Self::Annotated(highlighter) => highlighter.highlight_line(line, set),
+        }
+    }
+}
+
+pub(crate) struct CommentHighlighter<'a> {
+    highlighter: Highlighter<'a>,
+    parse_state: ParseState,
+    highlight_state: HighlightState,
+    comment_stack: ScopeStack,
+    comment_scope: Scope,
+    color: Color,
+}
+
+impl<'a> CommentHighlighter<'a> {
+    fn new(syntax: &SyntaxReference, theme: &'a Theme) -> Self {
+        let highlighter = Highlighter::new(theme);
+        let highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
+        let background = theme.settings.background.unwrap_or(Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 1,
+        });
+        let color = if background.a <= 1 {
+            // Palette-based themes should retain the terminal's yellow instead
+            // of introducing a fixed RGB color into an otherwise adaptive theme.
+            Color {
+                r: 3,
+                g: 0,
+                b: 0,
+                a: 0,
+            }
+        } else if u32::from(background.r) * 299
+            + u32::from(background.g) * 587
+            + u32::from(background.b) * 114
+            > 128_000
+        {
+            Color {
+                r: 153,
+                g: 76,
+                b: 0,
+                a: 255,
+            }
+        } else {
+            Color {
+                r: 255,
+                g: 175,
+                b: 0,
+                a: 255,
+            }
+        };
+        Self {
+            highlighter,
+            parse_state: ParseState::new(syntax),
+            highlight_state,
+            comment_stack: ScopeStack::new(),
+            comment_scope: Scope::new("comment").unwrap(),
+            color,
+        }
+    }
+
+    fn highlight_line<'b>(
+        &mut self,
+        line: &'b str,
+        set: &SyntaxSet,
+    ) -> Result<Vec<(Style, &'b str)>, syntect::Error> {
+        let operations = self.parse_state.parse_line(line, set)?;
+        let mut comments: Vec<Range<usize>> = Vec::new();
+        let mut start = 0;
+        for (end, operation) in &operations {
+            self.add_comment_range(start..*end, &mut comments);
+            self.comment_stack.apply(operation)?;
+            start = *end;
+        }
+        self.add_comment_range(start..line.len(), &mut comments);
+        let regions: Vec<_> = HighlightIterator::new(
+            &mut self.highlight_state,
+            &operations,
+            line,
+            &self.highlighter,
+        )
+        .collect();
+        let annotations: Vec<_> = comments
+            .into_iter()
+            .filter_map(|range| {
+                let text = line[range.clone()]
+                    .split(['\r', '\n'])
+                    .next()
+                    .unwrap_or_default();
+                text.split_word_bound_indices()
+                    .find(|(_, word)| {
+                        ["TODO", "TODOS", "FIXME", "FIXMES"]
+                            .iter()
+                            .any(|marker| word.eq_ignore_ascii_case(marker))
+                    })
+                    .map(|(start, _)| range.start + start..range.start + text.len())
+            })
+            .collect();
+        if annotations.is_empty() {
+            return Ok(regions);
+        }
+        let mut output = Vec::new();
+        let mut offset = 0;
+        for (style, region) in regions {
+            let end = offset + region.len();
+            let mut cursor = offset;
+            for annotation in &annotations {
+                let lo = annotation.start.max(cursor);
+                let hi = annotation.end.min(end);
+                if lo >= hi {
+                    continue;
+                }
+                if cursor < lo {
+                    output.push((style, &line[cursor..lo]));
+                }
+                let mut annotated = style;
+                annotated.foreground = self.color;
+                annotated.font_style.insert(FontStyle::BOLD);
+                output.push((annotated, &line[lo..hi]));
+                cursor = hi;
+            }
+            if cursor < end {
+                output.push((style, &line[cursor..end]));
+            }
+            offset = end;
+        }
+        Ok(output)
+    }
+
+    fn add_comment_range(&self, range: Range<usize>, ranges: &mut Vec<Range<usize>>) {
+        if range.is_empty()
+            || !self
+                .comment_stack
+                .as_slice()
+                .iter()
+                .any(|scope| self.comment_scope.is_prefix_of(*scope))
+        {
+            return;
+        }
+        if let Some(previous) = ranges
+            .last_mut()
+            .filter(|previous| previous.end == range.start)
+        {
+            previous.end = range.end;
+        } else {
+            ranges.push(range);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assets::HighlightingAssets;
+
+    fn changes(language: &str, source: &str, theme_name: &str) -> String {
+        let assets = HighlightingAssets::from_binary();
+        let syntaxes = assets.get_syntax_set().unwrap();
+        let syntax = syntaxes
+            .find_syntax_by_name(language)
+            .unwrap_or_else(|| panic!("missing syntax {language}"));
+        let theme = assets.get_theme(theme_name);
+        let mut standard = LineHighlighter::new(syntax, theme, false);
+        let mut annotated = LineHighlighter::new(syntax, theme, true);
+        let mut changed = String::new();
+        for line in source.split_inclusive('\n') {
+            let plain = standard.highlight_line(line, syntaxes).unwrap();
+            let highlighted = annotated.highlight_line(line, syntaxes).unwrap();
+            assert_eq!(
+                highlighted
+                    .iter()
+                    .map(|(_, text)| *text)
+                    .collect::<String>(),
+                line
+            );
+            let styles: Vec<_> = plain
+                .iter()
+                .flat_map(|(style, text)| std::iter::repeat_n(*style, text.len()))
+                .collect();
+            let mut offset = 0;
+            for (style, text) in highlighted {
+                for (index, character) in text.char_indices() {
+                    if style != styles[offset + index] {
+                        assert!(style.font_style.contains(FontStyle::BOLD));
+                        changed.push(character);
+                    }
+                }
+                offset += text.len();
+            }
+        }
+        changed
+    }
+
+    #[test]
+    fn comments_are_annotated_in_multiple_languages() {
+        for (language, source, expected) in [
+            (
+                "Rust",
+                "let text = \"TODO fake\"; // TODO real\n",
+                "TODO real",
+            ),
+            ("Python", "text = 'TODO fake' # todo real\n", "todo real"),
+            (
+                "Bourne Again Shell (bash)",
+                "echo 'TODO fake' # FIXMES real\n",
+                "FIXMES real",
+            ),
+            (
+                "JavaScript (Babel)",
+                "let text = 'TODO fake'; // fixme real\n",
+                "fixme real",
+            ),
+            ("CSS", "a { /* TODO real */ color: red; }\n", "TODO real */"),
+            ("SQL", "SELECT 'TODO fake'; -- TODO real\n", "TODO real"),
+            (
+                "HTML",
+                "<p>TODO fake</p><!-- TODO real -->\n",
+                "TODO real -->",
+            ),
+        ] {
+            assert_eq!(
+                changes(language, source, "Monokai Extended"),
+                expected,
+                "{language}"
+            );
+        }
+    }
+
+    #[test]
+    fn multiline_comment_state_continues_but_the_annotation_does_not() {
+        let source = "/* ordinary\n * TODO first\n * ordinary next line\n * fixmes second\n */ let TODO = \"FIXME\";\n";
+        assert_eq!(
+            changes("Rust", source, "Monokai Extended"),
+            "TODO firstfixmes second"
+        );
+    }
+
+    #[test]
+    fn markers_use_word_boundaries_and_do_not_affect_other_comments() {
+        let source = "// TODOISH MYTODO FIXMESUFFIX éTODO\n/* TODO one */ let x = \"TODO\"; /* ordinary */ // todos two\n";
+        assert_eq!(
+            changes("Rust", source, "Monokai Extended"),
+            "TODO one */todos two"
+        );
+    }
+
+    #[test]
+    fn embedded_language_comments_and_unicode_are_supported() {
+        let source = "```rust\nlet text = \"TODO fake\"; // TODO 界🙂\n```\nTODO prose\n";
+        assert_eq!(changes("Markdown", source, "Monokai Extended"), "TODO 界🙂");
+    }
+
+    #[test]
+    fn line_endings_and_unterminated_last_lines_are_preserved() {
+        for source in ["// TODO one\r\n// FIXME two", "// TODO one\n// FIXME two"] {
+            assert_eq!(
+                changes("Rust", source, "Monokai Extended"),
+                "TODO oneFIXME two"
+            );
+        }
+    }
+
+    #[test]
+    fn carriage_return_ends_an_annotation() {
+        assert_eq!(
+            changes("Rust", "// TODO one\rnext", "Monokai Extended"),
+            "TODO one"
+        );
+    }
+
+    #[test]
+    fn strings_and_plain_text_do_not_gain_comment_annotations() {
+        for (language, source) in [
+            ("Rust", "let TODO = r#\"/* TODO */\"#;\n"),
+            ("Python", "text = '''TODO\nFIXME'''\n"),
+            ("Plain Text", "// TODO fake\n# FIXME fake\n"),
+        ] {
+            assert_eq!(
+                changes(language, source, "Monokai Extended"),
+                "",
+                "{language}"
+            );
+        }
+    }
+
+    #[test]
+    fn light_and_palette_themes_keep_the_same_annotation_bounds() {
+        for theme in ["GitHub", "ansi", "base16", "1337"] {
+            assert_eq!(
+                changes("Rust", "// TODO text\n", theme),
+                "TODO text",
+                "{theme}"
+            );
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,9 @@ pub struct Config<'a> {
     /// Whether or not to show/replace non-printable characters like space, tab and newline.
     pub show_nonprintable: bool,
 
+    /// Emphasize TODO and FIXME annotations within syntax comment scopes.
+    pub highlight_todos: bool,
+
     /// The configured notation for non-printable characters
     pub nonprintable_notation: NonprintableNotation,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod assets;
 pub mod assets_metadata {
     pub use super::assets::assets_metadata::*;
 }
+mod comment_annotations;
 pub mod config;
 pub mod controller;
 mod decorations;

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -171,6 +171,12 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Emphasize TODO and FIXME markers inside syntax comments (default: false).
+    pub fn highlight_todos(&mut self, yes: bool) -> &mut Self {
+        self.config.highlight_todos = yes;
+        self
+    }
+
     /// Whether to print binary content or nonprintable characters (default: no)
     pub fn show_nonprintable(&mut self, yes: bool) -> &mut Self {
         self.config.show_nonprintable = yes;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -5,7 +5,7 @@ use nu_ansi_term::Style;
 
 use bytesize::ByteSize;
 
-use syntect::easy::HighlightLines;
+use crate::comment_annotations::LineHighlighter;
 use syntect::highlighting::Color;
 use syntect::highlighting::FontStyle;
 use syntect::highlighting::Theme;
@@ -185,14 +185,18 @@ impl Printer for SimplePrinter<'_> {
 }
 
 struct HighlighterFromSet<'a> {
-    highlighter: HighlightLines<'a>,
+    highlighter: LineHighlighter<'a>,
     syntax_set: &'a SyntaxSet,
 }
 
 impl<'a> HighlighterFromSet<'a> {
-    fn new(syntax_in_set: SyntaxReferenceInSet<'a>, theme: &'a Theme) -> Self {
+    fn new(
+        syntax_in_set: SyntaxReferenceInSet<'a>,
+        theme: &'a Theme,
+        highlight_todos: bool,
+    ) -> Self {
         Self {
-            highlighter: HighlightLines::new(syntax_in_set.syntax, theme),
+            highlighter: LineHighlighter::new(syntax_in_set.syntax, theme, highlight_todos),
             syntax_set: syntax_in_set.syntax_set,
         }
     }
@@ -294,7 +298,11 @@ impl<'a> InteractivePrinter<'a> {
                     syntax_in_set.syntax.name == PLAIN_TEXT_SYNTAX,
                     syntax_in_set.syntax.name == MANPAGE_SYNTAX
                         || syntax_in_set.syntax.name == COMMAND_HELP_SYNTAX,
-                    Some(HighlighterFromSet::new(syntax_in_set, theme)),
+                    Some(HighlighterFromSet::new(
+                        syntax_in_set,
+                        theme,
+                        config.highlight_todos,
+                    )),
                 ),
 
                 Err(Error::UndetectedSyntax(_)) => (
@@ -303,7 +311,7 @@ impl<'a> InteractivePrinter<'a> {
                     Some(
                         assets
                             .find_syntax_by_name(PLAIN_TEXT_SYNTAX)?
-                            .map(|s| HighlighterFromSet::new(s, theme))
+                            .map(|s| HighlighterFromSet::new(s, theme, config.highlight_todos))
                             .expect("A plain text syntax is available"),
                     ),
                 ),

--- a/tests/comment_annotations.rs
+++ b/tests/comment_annotations.rs
@@ -1,0 +1,96 @@
+mod utils;
+use utils::command::bat;
+
+#[test]
+fn annotation_flag_preserves_plain_output_and_is_repeatable() {
+    let input = "let text = \"TODO fake\"; // TODO real\n";
+    bat()
+        .args([
+            "--paging=never",
+            "--color=never",
+            "--style=plain",
+            "-l",
+            "rs",
+            "--highlight-todos",
+            "--highlight-todos",
+        ])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(input);
+}
+
+#[test]
+fn library_annotations_change_comment_styles_without_changing_source() {
+    let input = b"let text = \"TODO fake\"; // TODO real\n";
+    let mut plain = String::new();
+    let mut highlighted = String::new();
+    for (enabled, output) in [(false, &mut plain), (true, &mut highlighted)] {
+        bat::PrettyPrinter::new()
+            .input_from_bytes(input)
+            .language("rs")
+            .theme("Monokai Extended")
+            .colored_output(true)
+            .true_color(true)
+            .highlight_todos(enabled)
+            .print_with_writer(Some(output))
+            .unwrap();
+    }
+    assert_ne!(plain, highlighted);
+    let strip = regex::Regex::new("\x1b\\[[0-9;]*m").unwrap();
+    assert_eq!(
+        strip.replace_all(&plain, ""),
+        strip.replace_all(&highlighted, "")
+    );
+    assert!(highlighted.contains("TODO fake"));
+}
+
+#[test]
+fn annotations_do_not_leak_across_line_ranges_or_wrapping() {
+    let output = bat()
+        .args([
+            "--paging=never",
+            "--color=always",
+            "--style=plain",
+            "--theme=Monokai Extended",
+            "-l",
+            "rs",
+            "--highlight-todos",
+            "--line-range=2:",
+            "--terminal-width=24",
+            "--wrap=word",
+        ])
+        .write_stdin(
+            "/*\nTODO long annotation that wraps over several rows\nordinary next line\n*/\n",
+        )
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains("TODO"));
+    assert!(text.contains("ordinary next line"));
+    let strip = regex::Regex::new("\x1b\\[[0-9;]*m").unwrap();
+    assert!(strip.replace_all(&text, "").lines().count() > 3);
+}
+
+#[test]
+fn long_lines_keep_the_existing_highlighting_limit() {
+    let input = format!("// TODO {}\n", "x".repeat(20_000));
+    let mut outputs = Vec::new();
+    for enabled in [false, true] {
+        let mut output = String::new();
+        bat::PrettyPrinter::new()
+            .input_from_bytes(input.as_bytes())
+            .language("rs")
+            .theme("Monokai Extended")
+            .colored_output(true)
+            .true_color(true)
+            .highlight_todos(enabled)
+            .print_with_writer(Some(&mut output))
+            .unwrap();
+        outputs.push(output);
+    }
+    assert_eq!(outputs[0], outputs[1]);
+}


### PR DESCRIPTION
TODO and FIXME annotations currently inherit ordinary comment colors and are easy to miss.

Add --highlight-todos and PrettyPrinter::highlight_todos. Use syntax comment scopes to emphasize TODO, TODOS, FIXME and FIXMES, ignoring case, from the marker to the end of its comment on that line. Leave strings, ordinary code and subsequent block-comment lines unchanged. Support comments inside embedded languages without patching every grammar.

Keep the normal highlighter when the option is disabled. When enabled, parse each line once and retain a comment scope stack alongside the normal highlight state. Apply bold amber while preserving existing background and other font attributes; use darker amber on light themes and terminal yellow for palette-based themes. Preserve source bytes, line endings, range behavior and the existing long-line highlighting limit. The option requires colored output and is disabled by default.

Validation: the full all-feature suite passed 485 tests (7 ignored), including eight scope-level and four CLI/library regressions. Those 12 tests also passed after replacing the marker regex with the existing Unicode word-segmentation dependency so minimal library builds need no additional dependency. Coverage includes Rust, Python, Bash, JavaScript, CSS, SQL, HTML, Markdown embedding, Unicode, word boundaries, CR/LF/CRLF, wrapping, line ranges, strings, plain text, light/palette themes and long lines. All 8 default-feature help tests passed. All-target/all-feature Clippy with warnings denied, the minimal library build, formatting, whitespace checks and Bash/Zsh completion syntax passed.

README, manual, help and all four completions are updated.

Fixes #2225.