### PR TITLE
Underline existing literal file paths without replacing syntax colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add opt-in underlining of existing literal file paths while preserving syntax colors, see #0 (@Matei02355). Closes #2907
+- Add opt-in underlining of existing literal file paths while preserving syntax colors, see #3996 (@Matei02355). Closes #2907
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add opt-in underlining of existing literal file paths while preserving syntax colors, see #0 (@Matei02355). Closes #2907
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/README.md
+++ b/README.md
@@ -499,6 +499,26 @@ Although these themes are more restricted, they have three advantages over truec
 - Adapt to terminal theme changes. Even for already printed output.
 - Visually harmonize better with other terminal software.
 
+### Existing file paths
+
+Use `bat --show-paths config.toml` to underline recognizable paths that exist on
+the local filesystem. Files and directories are checked relative to the input
+file's directory. Standard input and custom readers use the working directory;
+a display-only filename does not change that base.
+
+The option recognizes paths containing `/`, native Windows paths containing `\`,
+`~/` paths, and quoted filenames containing a dot, such as `"config.toml"`. Quoting
+also allows spaces in a path. It checks literal spellings without decoding string
+escapes or evaluating shell variables, and ignores URLs. Missing or inaccessible
+paths remain unchanged. Underlining preserves syntax colors and other font
+attributes, including colors that identify escapes or invalid syntax; it does not
+validate a configuration language's interpretation of a string.
+
+Checks are cached per input, with a bounded cache for long streams. This extra
+filesystem work only happens when the option and colored output are enabled.
+The option is disabled by default and is also available through
+`PrettyPrinter::show_paths`.
+
 ### Output style
 
 You can use the `--style` option to control the appearance of `bat`'s output.

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -136,6 +136,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-l'                      , 'l'                     , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
             [CompletionResult]::new('--language'              , 'language'              , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
         #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+            [CompletionResult]::new('--show-paths', 'show-paths', [CompletionResultType]::ParameterName, 'Underline existing literal file paths.')
             [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
             [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
             [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -201,6 +201,7 @@ _bat() {
 			--binary
 			--plain
 			--language
+			--show-paths
 			--highlight-line
 			--file-name
 			--diff

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -176,6 +176,8 @@ complete -c $bat -s h -d "Print a concise overview" -n __fish_is_first_arg
 
 complete -c $bat -l help -f -d "Print all help information" -n __fish_is_first_arg
 
+complete -c $bat -l show-paths -d "Underline existing literal file paths" -n __bat_no_excl_args
+
 complete -c $bat -s H -l highlight-line -x -d "Highlight line(s) N[:M]" -n __bat_no_excl_args
 
 complete -c $bat -l ignored-suffix -x -d "Ignore extension" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -30,6 +30,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
         \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
+        --show-paths'[underline existing literal file paths]'
         \*--file-name='[specify the name to display for a file]:name:_files'
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'
         --diff-context='[specify lines of context around added/removed/modified lines when using `--diff`]:lines'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -68,6 +68,19 @@ specified as a name (like 'C++' or 'LaTeX') or possible file extension
 (like 'cpp', 'hpp' or 'md'). Use '\-\-list\-languages' to show all supported
 language names and file extensions.
 .HP
+\fB\-\-show\-paths\fR
+.IP
+Underline recognizable literal file paths that exist locally. Relative paths use
+the input file's directory; stdin and custom readers use the working directory.
+Recognizes slash-separated paths, native Windows paths, ~/ paths, and quoted
+filenames containing a dot. Quoted paths may contain spaces. URLs and shell
+variables are ignored and string escapes are not decoded. This checks literal
+path spellings, not a configuration language's interpretation of a string.
+.IP
+Missing or inaccessible paths remain unchanged. Existing syntax colors and font
+attributes are preserved, including escape and error colors. Checks are cached
+per input with bounded memory. Disabled by default; requires colored output.
+.HP
 \fB\-H\fR, \fB\-\-highlight\-line\fR <N:M>...
 .IP
 Highlight the specified line ranges with a different background color. For example:

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -44,6 +44,14 @@ Options:
           
           [aliases: --fallback-language]
 
+      --show-paths
+          Underline recognizable literal file paths that exist. Relative paths are checked from the
+          input file's directory, or the working directory for stdin. Recognizes slash-separated
+          paths, native Windows paths, ~/ paths, and quoted filenames containing a dot. URLs and
+          shell variables are ignored; escapes are not decoded. Existing syntax colors are
+          preserved, including escape and error colors. Checks are cached per input. Disabled by
+          default and requires colored output.
+
   -H, --highlight-line <N:M>
           Highlight the specified line ranges with a different background color For example:
             '--highlight-line 40' highlights line 40

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -383,6 +383,7 @@ impl App {
                 .get_one::<String>("fallback-syntax")
                 .map(|s| s.as_str()),
             show_nonprintable: self.matches.get_flag("show-all"),
+            show_paths: self.matches.get_flag("show-paths"),
             nonprintable_notation: match self
                 .matches
                 .get_one::<String>("nonprintable-notation")

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -134,6 +134,20 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("show-paths")
+                .long("show-paths")
+                .overrides_with("show-paths")
+                .action(ArgAction::SetTrue)
+                .help("Underline existing file paths in the output")
+                .long_help("Underline recognizable literal file paths that exist. Relative paths \
+                    are checked from the input file's directory, or the working directory for stdin. \
+                    Recognizes slash-separated paths, native Windows paths, ~/ paths, and quoted \
+                    filenames containing a dot. URLs and shell variables are ignored; escapes are \
+                    not decoded. Existing syntax colors are preserved, including escape and error \
+                    colors. Checks are cached per input. Disabled by default and requires colored output.")
+                .hide_short_help(true),
+        )
+        .arg(
             Arg::new("highlight-line")
                 .long("highlight-line")
                 .short('H')

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,9 @@ pub struct Config<'a> {
     /// Whether or not to show/replace non-printable characters like space, tab and newline.
     pub show_nonprintable: bool,
 
+    /// Underline literal paths which exist relative to each input file.
+    pub show_paths: bool,
+
     /// The configured notation for non-printable characters
     pub nonprintable_notation: NonprintableNotation,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod output;
 mod pager;
 #[cfg(feature = "paging")]
 pub(crate) mod paging;
+mod path_annotations;
 mod preprocessor;
 mod pretty_printer;
 pub(crate) mod printer;

--- a/src/path_annotations.rs
+++ b/src/path_annotations.rs
@@ -1,0 +1,246 @@
+//! Underline recognizable literal paths that exist on the local filesystem.
+use std::collections::HashMap;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+use syntect::highlighting::{FontStyle, Style};
+
+pub(crate) struct PathAnnotations {
+    base: PathBuf,
+    home: Option<PathBuf>,
+    exists: HashMap<PathBuf, bool>,
+}
+
+impl PathAnnotations {
+    pub(crate) fn new(base: PathBuf) -> Self {
+        Self {
+            base,
+            home: std::env::var_os(if cfg!(windows) { "USERPROFILE" } else { "HOME" })
+                .map(PathBuf::from),
+            exists: HashMap::new(),
+        }
+    }
+
+    fn resolve(&self, text: &str, quoted: bool) -> Option<PathBuf> {
+        // URLs and shell expansion expressions are not filesystem locations.
+        // Inspect literal spellings only; never evaluate escapes or variables.
+        if text.is_empty() || text.contains("://") || text.contains(['$', '`', '\0', '\r', '\n']) {
+            return None;
+        }
+        let drive =
+            text.as_bytes().get(1) == Some(&b':') && text.as_bytes()[0].is_ascii_alphabetic();
+        if drive && !cfg!(windows) {
+            return None;
+        }
+        if !(text.contains('/')
+            || (cfg!(windows) && text.contains('\\'))
+            || (quoted && text.contains('.')))
+        {
+            return None;
+        }
+        let path = if let Some(relative) = text.strip_prefix("~/").or_else(|| {
+            if cfg!(windows) {
+                text.strip_prefix("~\\")
+            } else {
+                None
+            }
+        }) {
+            self.home.as_ref()?.join(relative)
+        } else {
+            PathBuf::from(text)
+        };
+        Some(if path.is_absolute() {
+            path
+        } else {
+            self.base.join(path)
+        })
+    }
+
+    fn ranges(&mut self, line: &str) -> Vec<Range<usize>> {
+        let mut ranges = Vec::new();
+        let mut chars = line.char_indices().peekable();
+        while let Some((start, character)) = chars.next() {
+            if character == '\'' || character == '"' {
+                let begin = start + character.len_utf8();
+                let mut end = None;
+                for (index, next) in chars.by_ref() {
+                    if next == character {
+                        end = Some(index);
+                        break;
+                    }
+                    if next == '\r' || next == '\n' {
+                        break;
+                    }
+                }
+                if let Some(end) = end {
+                    self.add_if_present(line, begin..end, true, &mut ranges);
+                }
+            } else if !delimiter(character) {
+                let mut end = start + character.len_utf8();
+                while let Some(&(index, next)) = chars.peek() {
+                    if delimiter(next) {
+                        break;
+                    }
+                    chars.next();
+                    end = index + next.len_utf8();
+                }
+                self.add_if_present(line, start..end, false, &mut ranges);
+            }
+        }
+        ranges
+    }
+
+    fn add_if_present(
+        &mut self,
+        line: &str,
+        range: Range<usize>,
+        quoted: bool,
+        ranges: &mut Vec<Range<usize>>,
+    ) {
+        let Some(path) = self.resolve(&line[range.clone()], quoted) else {
+            return;
+        };
+        let present = if let Some(&present) = self.exists.get(&path) {
+            present
+        } else {
+            let present = std::fs::metadata(&path).is_ok();
+            // Limit retained paths when processing long streams with many unique candidates.
+            if self.exists.len() >= 4096 {
+                self.exists.clear();
+            }
+            self.exists.insert(path, present);
+            present
+        };
+        if present {
+            ranges.push(range);
+        }
+    }
+
+    pub(crate) fn highlight<'a>(
+        &mut self,
+        line: &'a str,
+        regions: Vec<(Style, &'a str)>,
+    ) -> Vec<(Style, &'a str)> {
+        let ranges = self.ranges(line);
+        if ranges.is_empty() {
+            return regions;
+        }
+        let mut output = Vec::new();
+        let mut offset = 0;
+        let mut first_range = 0;
+        for (style, text) in regions {
+            let end = offset + text.len();
+            let mut cursor = offset;
+            while first_range < ranges.len() && ranges[first_range].end <= cursor {
+                first_range += 1;
+            }
+            for range in ranges[first_range..]
+                .iter()
+                .take_while(|range| range.start < end)
+            {
+                let lo = range.start.max(cursor);
+                let hi = range.end.min(end);
+                if lo >= hi {
+                    continue;
+                }
+                if cursor < lo {
+                    output.push((style, &line[cursor..lo]));
+                }
+                let mut marked = style;
+                marked.font_style.insert(FontStyle::UNDERLINE);
+                output.push((marked, &line[lo..hi]));
+                cursor = hi;
+            }
+            if cursor < end {
+                output.push((style, &line[cursor..end]));
+            }
+            offset = end;
+        }
+        output
+    }
+}
+
+fn delimiter(character: char) -> bool {
+    character.is_whitespace()
+        || matches!(
+            character,
+            '\'' | '"' | '(' | ')' | '{' | '}' | '[' | ']' | '<' | '>' | '=' | ',' | ';'
+        )
+}
+
+pub(crate) fn base_for_file(path: &Path) -> PathBuf {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syntect::highlighting::Color;
+    use tempfile::tempdir;
+
+    #[test]
+    fn annotations_preserve_existing_colors_and_font_attributes() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("present.txt"), "exists").unwrap();
+        let line = "\"./present.txt\"";
+        let ordinary = Style::default();
+        let special = Style {
+            foreground: Color {
+                r: 255,
+                g: 0,
+                b: 0,
+                a: 255,
+            },
+            font_style: FontStyle::BOLD | FontStyle::ITALIC,
+            ..ordinary
+        };
+        let original = vec![
+            (ordinary, &line[..3]),
+            (special, &line[3..7]),
+            (ordinary, &line[7..]),
+        ];
+        let styles: Vec<_> = original
+            .iter()
+            .flat_map(|(style, text)| std::iter::repeat_n(*style, text.len()))
+            .collect();
+        let output = PathAnnotations::new(dir.path().to_owned()).highlight(line, original);
+        assert_eq!(
+            output.iter().map(|(_, text)| *text).collect::<String>(),
+            line
+        );
+        let mut offset = 0;
+        for (style, text) in output {
+            for (index, original_style) in styles.iter().enumerate().skip(offset).take(text.len()) {
+                let mut expected = *original_style;
+                if index > 0 && index < line.len() - 1 {
+                    expected.font_style.insert(FontStyle::UNDERLINE);
+                }
+                assert_eq!(style, expected);
+            }
+            offset += text.len();
+        }
+    }
+
+    #[test]
+    fn tilde_paths_use_home_without_evaluating_other_expressions() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("present.txt"), "exists").unwrap();
+        let mut paths = PathAnnotations {
+            base: PathBuf::from("unused"),
+            home: Some(dir.path().to_owned()),
+            exists: HashMap::new(),
+        };
+        let line = "~/present.txt $HOME/present.txt `pwd`/present.txt";
+        let ranges = paths.ranges(line);
+        assert_eq!(
+            ranges
+                .iter()
+                .map(|range| &line[range.clone()])
+                .collect::<Vec<_>>(),
+            ["~/present.txt"]
+        );
+    }
+}

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -171,6 +171,12 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Underline existing literal file paths (default: false).
+    pub fn show_paths(&mut self, yes: bool) -> &mut Self {
+        self.config.show_paths = yes;
+        self
+    }
+
     /// Whether to print binary content or nonprintable characters (default: no)
     pub fn show_nonprintable(&mut self, yes: bool) -> &mut Self {
         self.config.show_nonprintable = yes;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -210,6 +210,7 @@ pub(crate) struct InteractivePrinter<'a> {
     highlighter_from_set: Option<HighlighterFromSet<'a>>,
     background_color_highlight: Option<Color>,
     consecutive_empty_lines: usize,
+    path_annotations: Option<crate::path_annotations::PathAnnotations>,
     strip_ansi: bool,
     sanitize: bool,
     strip_overstrike: bool,
@@ -343,6 +344,17 @@ impl<'a> InteractivePrinter<'a> {
             highlighter_from_set,
             background_color_highlight,
             consecutive_empty_lines: 0,
+            path_annotations: if config.show_paths && config.colored_output {
+                let base = match &input.kind {
+                    crate::input::OpenedInputKind::OrdinaryFile(path) => {
+                        crate::path_annotations::base_for_file(path)
+                    }
+                    _ => std::path::PathBuf::from("."),
+                };
+                Some(crate::path_annotations::PathAnnotations::new(base))
+            } else {
+                None
+            },
             strip_ansi,
             sanitize,
             strip_overstrike,
@@ -714,6 +726,12 @@ impl Printer for InteractivePrinter<'_> {
                 self.consecutive_empty_lines = 0;
             }
         }
+
+        let regions = if let Some(annotations) = &mut self.path_annotations {
+            annotations.highlight(&line, regions)
+        } else {
+            regions
+        };
 
         let mut cursor: usize = 0;
         let mut cursor_max: usize = self.config.term_width;

--- a/tests/path_annotations.rs
+++ b/tests/path_annotations.rs
@@ -1,0 +1,167 @@
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod utils;
+use utils::command::bat;
+
+fn output(file: &Path, extra: &[&str]) -> String {
+    let bytes = bat()
+        .args([
+            "--paging=never",
+            "--color=always",
+            "--theme=ansi",
+            "--style=plain",
+            "--wrap=never",
+            "--show-paths",
+            "-l",
+            "txt",
+        ])
+        .args(extra)
+        .arg(file)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(bytes).unwrap()
+}
+
+#[test]
+fn paths_are_relative_to_each_real_input_directory() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("nested")).unwrap();
+    fs::write(dir.path().join("present.txt"), "exists").unwrap();
+    let first = dir.path().join("first.txt");
+    let second = dir.path().join("nested/second.txt");
+    let input = "\"present.txt\" ./missing.txt\n";
+    fs::write(&first, input).unwrap();
+    fs::write(&second, input).unwrap();
+    assert!(output(&first, &[]).contains("\x1b[4mpresent.txt\x1b[0m"));
+    assert_eq!(output(&second, &[]), input);
+    assert!(output(&first, &["--file-name=elsewhere/input.rs"]).contains("\x1b[4mpresent.txt"));
+}
+
+#[test]
+fn quoted_unicode_paths_with_spaces_and_directories_are_recognized() {
+    let dir = tempdir().unwrap();
+    fs::create_dir(dir.path().join("some folder 界")).unwrap();
+    fs::write(dir.path().join("some folder 界/name.txt"), "exists").unwrap();
+    let file = dir.path().join("source.txt");
+    fs::write(&file, "\"./some folder 界/name.txt\" './some folder 界'\n").unwrap();
+    let out = output(&file, &[]);
+    assert!(
+        out.contains("\x1b[4m./some folder 界/name.txt\x1b[0m"),
+        "{out:?}"
+    );
+    assert!(out.contains("\x1b[4m./some folder 界\x1b[0m"), "{out:?}");
+}
+
+#[test]
+fn urls_expansions_missing_paths_and_unclosed_quotes_remain_unmarked() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("exists.txt"), "exists").unwrap();
+    let file = dir.path().join("source.txt");
+    let input = "https://example.test/exists.txt \"file:///exists.txt\" $HOME/exists.txt ./missing.txt\n\"./exists.txt\n";
+    fs::write(&file, input).unwrap();
+    assert_eq!(output(&file, &[]), input);
+}
+
+#[test]
+fn stdin_uses_working_directory_even_with_a_display_filename() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("exists.txt"), "exists").unwrap();
+    let out = bat()
+        .current_dir(dir.path())
+        .args([
+            "--paging=never",
+            "--color=always",
+            "--theme=ansi",
+            "--style=plain",
+            "--show-paths",
+            "--wrap=never",
+            "-l",
+            "txt",
+            "--file-name=elsewhere/source.txt",
+        ])
+        .write_stdin("./exists.txt\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(
+        String::from_utf8(out).unwrap(),
+        "\x1b[4m./exists.txt\x1b[0m\n"
+    );
+}
+
+#[test]
+fn color_never_and_disabled_option_preserve_literal_output() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("exists.txt"), "exists").unwrap();
+    let file = dir.path().join("source.txt");
+    fs::write(&file, "./exists.txt\n").unwrap();
+    assert_eq!(
+        output(&file, &["--color=never", "--show-paths"]),
+        "./exists.txt\n"
+    );
+    bat()
+        .args([
+            "--paging=never",
+            "--color=always",
+            "--theme=ansi",
+            "--style=plain",
+            "-l",
+            "txt",
+        ])
+        .arg(&file)
+        .assert()
+        .success()
+        .stdout("./exists.txt\n");
+}
+
+#[test]
+fn library_option_marks_paths_in_file_inputs() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("exists.txt"), "exists").unwrap();
+    let file = dir.path().join("source.txt");
+    fs::write(&file, "./exists.txt\n").unwrap();
+    let mut out = String::new();
+    bat::PrettyPrinter::new()
+        .input_file(file)
+        .language("txt")
+        .theme("ansi")
+        .colored_output(true)
+        .show_paths(true)
+        .print_with_writer(Some(&mut out))
+        .unwrap();
+    assert!(out.contains("\x1b[4m./exists.txt\x1b[0m"), "{out:?}");
+}
+
+#[cfg(windows)]
+#[test]
+fn native_windows_drive_and_relative_paths_are_supported() {
+    let dir = tempdir().unwrap();
+    let existing = dir.path().join("exists.txt");
+    fs::write(&existing, "exists").unwrap();
+    let file = dir.path().join("source.txt");
+    let absolute = existing.to_str().unwrap();
+    fs::write(&file, format!("\"{absolute}\" .\\exists.txt\n")).unwrap();
+    let out = output(&file, &[]);
+    assert!(
+        out.contains(&format!("\x1b[4m{absolute}\x1b[0m")),
+        "{out:?}"
+    );
+    assert!(out.contains("\x1b[4m.\\exists.txt\x1b[0m"), "{out:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn broken_symlinks_are_not_present_paths() {
+    let dir = tempdir().unwrap();
+    std::os::unix::fs::symlink("missing", dir.path().join("broken")).unwrap();
+    let file = dir.path().join("source.txt");
+    fs::write(&file, "./broken\n").unwrap();
+    assert_eq!(output(&file, &[]), "./broken\n");
+}


### PR DESCRIPTION
Add --show-paths and PrettyPrinter::show_paths to underline recognizable literal paths that exist locally. This follows the issue author's proposed first iteration of checking existing paths only.

Resolve relative paths from each real input file's directory, or the working directory for stdin and custom readers. A display-only filename does not change that base. Recognize slash-separated paths, native Windows paths, leading ~/ and quoted filenames containing a dot; quoted paths may contain spaces. Ignore URLs and shell expressions, and leave missing or inaccessible paths unchanged.

Underline instead of replacing foreground colors, so existing escape/error colors and other font attributes remain visible. This checks literal path spellings, without decoding language escapes or claiming to validate configuration semantics. Cache checks separately for each input, retaining at most 4096 entries. Skip the filesystem work unless the option and colored output are enabled, and only inspect lines that will be displayed.

Validation: all 482 all-feature tests passed (7 ignored), including nine Linux regressions for per-file bases, display names, stdin, Unicode/space-containing paths, directories, missing paths, broken symlinks, URLs, unclosed quotes, home expansion, color suppression, library usage and preservation of existing styles. An additional Windows-only regression covers drive and backslash paths. All 8 default-feature help tests passed. All-target/all-feature Clippy with warnings denied, the minimal library build, formatting, whitespace checks and Bash/Zsh completion syntax passed. README, manual, help and all four completions are updated.

Fixes #2907.