### PR TITLE
Support a portable WASI Preview 1 command-line build

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -21,6 +21,7 @@ jobs:
     needs:
       - crate_metadata
       - lint
+      - wasi
       - min_version
       - license_checks
       - test_with_new_syntaxes_and_themes
@@ -61,6 +62,24 @@ jobs:
     - uses: actions/checkout@v6
     - run: cargo fmt -- --check
     - run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+  wasi:
+    name: WASI Preview 1 (${{ matrix.rust }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, '1.88.0']
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+        targets: wasm32-wasip1
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+    - run: cargo build --locked --no-default-features --features wasi-application --target wasm32-wasip1
+    - run: node tests/wasi/smoke.mjs target/wasm32-wasip1/debug/bat.wasm
 
   min_version:
     name: Minimum supported rust version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add a WASI Preview 1 command-line build with Rust-only regexes and runtime validation, see #0 (@Matei02355).
+- Add a WASI Preview 1 command-line build with Rust-only regexes and runtime validation, see #3997 (@Matei02355).
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add a WASI Preview 1 command-line build with Rust-only regexes and runtime validation, see #0 (@Matei02355).
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
+ "rustix",
  "semver",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ minimal-application = [
     "regex-onig",
     "wild",
 ]
+# Portable command-line build for WASI Preview 1 (without native paging or Git).
+wasi-application = ["clap", "etcetera", "wild", "paging", "regex-fancy"]
 git = ["gix"] # Support indicating git modifications
 paging = [ "shell-words", "grep-cli", "minus"] # Support applying a pager on the output
 lessopen = ["execute"] # Support $LESSOPEN preprocessor
@@ -51,21 +53,14 @@ thiserror = "2.0"
 wild = { version = "2.2", optional = true }
 content_inspector = "0.2.4"
 shell-words = { version = "1.1.1", optional = true }
-minus = { version = "5.7", optional = true, features = [
-  "dynamic_output",
-  "search",
-] }
 unicode-width = "0.2.2"
 globset = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.9.28"
 semver = "1.0"
-path_abs = { version = "0.5", default-features = false }
-clircle = { version = "0.6.1", default-features = false }
 bugreport = { version = "0.6.0", optional = true }
 etcetera = { version = "0.11.0", optional = true }
-grep-cli = { version = "0.1.12", optional = true }
 regex = { version = "1.12.3", optional = true }
 walkdir = { version = "2.5", optional = true }
 bytesize = { version = "2.3.1" }
@@ -90,6 +85,18 @@ features = ["parsing"]
 version = "4.6.1"
 optional = true
 features = ["wrap_help", "cargo"]
+
+[target.'cfg(not(target_os = "wasi"))'.dependencies]
+path_abs = { version = "0.5", default-features = false }
+clircle = { version = "0.6.1", default-features = false }
+grep-cli = { version = "0.1.12", optional = true }
+minus = { version = "5.7", optional = true, features = [
+  "dynamic_output",
+  "search",
+] }
+
+[target.'cfg(target_os = "wasi")'.dependencies]
+rustix = { version = "1.1", features = ["fs", "stdio"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1.9.0"

--- a/README.md
+++ b/README.md
@@ -454,6 +454,32 @@ bat --completion <shell>
 # see --help for supported shells
 ```
 
+### WASI Preview 1
+
+Build a portable command-line module with the Rust-only regex backend:
+
+```bash
+rustup target add wasm32-wasip1
+cargo build --release --locked --target wasm32-wasip1 --no-default-features --features wasi-application
+```
+
+The result is `target/wasm32-wasip1/release/bat.wasm`. Run it with a WASI Preview 1
+host that supplies standard input/output and exposes the files you want to read.
+For example, the Node.js launcher below exposes only the current directory as `/`:
+
+```bash
+node examples/wasi.mjs target/wasm32-wasip1/release/bat.wasm --color=always /README.md
+```
+
+The module supports files, stdin, syntax highlighting, themes, line ranges and
+wrapping. Native pagers, Git integration, external preprocessors and asset rebuilding
+are excluded from this feature set; explicit `--paging=always` reports an error.
+Use `--terminal-width` when the host cannot supply a terminal size. `HOME`, XDG and
+`BAT_CONFIG_DIR`/`BAT_CACHE_PATH` refer to paths inside the host's exposed filesystem;
+without `HOME`, configuration locations default to `/.config/bat` and `/.cache/bat`.
+The `regex-fancy` backend has the same syntax compatibility limitations as native
+builds using that backend. This is a WASI command-line module, not a browser DOM API.
+
 ## Customization
 
 ### Highlighting theme

--- a/examples/wasi.mjs
+++ b/examples/wasi.mjs
@@ -1,0 +1,19 @@
+// Node.js 22+: node examples/wasi.mjs path/to/bat.wasm [bat arguments...]
+import fs from 'node:fs';
+import { WASI } from 'node:wasi';
+
+const [wasmPath, ...args] = process.argv.slice(2);
+if (!wasmPath) {
+    console.error('Usage: node examples/wasi.mjs path/to/bat.wasm [bat arguments...]');
+    process.exit(2);
+}
+const wasi = new WASI({
+    version: 'preview1',
+    args: ['bat', '--paging=never', ...args],
+    env: { HOME: '/', TERM: process.env.TERM || 'xterm-256color' },
+    preopens: { '/': process.cwd() },
+    returnOnExit: true,
+});
+const module = await WebAssembly.compile(fs.readFileSync(wasmPath));
+const instance = await WebAssembly.instantiate(module, wasi.getImportObject());
+process.exitCode = wasi.start(instance);

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -7,6 +7,7 @@ use once_cell::unsync::OnceCell;
 use syntect::highlighting::Theme;
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 
+#[cfg(not(target_os = "wasi"))]
 use path_abs::PathAbs;
 
 use crate::error::*;
@@ -229,12 +230,16 @@ impl HighlightingAssets {
         }
 
         let path = input.path();
+        #[cfg(not(target_os = "wasi"))]
         let absolute_path = path.and_then(|p| {
             PathAbs::new(p)
                 .ok()
                 .map(|abs| abs.as_path().to_path_buf())
                 .or_else(|| Some(p.to_owned()))
         });
+
+        #[cfg(target_os = "wasi")]
+        let absolute_path = path.map(|p| std::path::absolute(p).unwrap_or_else(|_| p.to_owned()));
 
         let path_syntax = if let Some(ref path) = absolute_path {
             self.get_syntax_for_path(path, mapping).or_else(|e| {

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+#[cfg(not(target_os = "wasi"))]
 use std::thread::available_parallelism;
 
 use crate::{
@@ -320,7 +321,11 @@ impl App {
         // start building glob matchers for builtin mappings immediately
         // this is an appropriate approach because it's statistically likely that
         // all the custom mappings need to be checked
-        if available_parallelism()?.get() > 1 {
+        #[cfg(not(target_os = "wasi"))]
+        let parallel = available_parallelism()?.get() > 1;
+        #[cfg(target_os = "wasi")]
+        let parallel = false;
+        if parallel {
             syntax_mapping.start_offload_build_all();
         }
 

--- a/src/bin/bat/directories.rs
+++ b/src/bin/bat/directories.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
+#[cfg(not(target_os = "wasi"))]
 use etcetera::BaseStrategy;
 use once_cell::sync::Lazy;
 
@@ -12,6 +13,7 @@ pub struct BatProjectDirs {
 }
 
 impl BatProjectDirs {
+    #[cfg(not(target_os = "wasi"))]
     fn new() -> Option<BatProjectDirs> {
         let basedirs = etcetera::choose_base_strategy().ok()?;
 
@@ -35,6 +37,34 @@ impl BatProjectDirs {
         Some(BatProjectDirs {
             cache_dir,
             config_dir,
+        })
+    }
+
+    // WASI has no user database. Directory locations are guest paths supplied
+    // by the host; the runtime's preopens determine which can actually be read.
+    #[cfg(target_os = "wasi")]
+    fn new() -> Option<BatProjectDirs> {
+        let absolute_env = |name| {
+            env::var_os(name)
+                .map(PathBuf::from)
+                .filter(|p| p.is_absolute())
+        };
+        let home = absolute_env("HOME").unwrap_or_else(|| PathBuf::from("/"));
+        Some(BatProjectDirs {
+            cache_dir: env::var_os("BAT_CACHE_PATH")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    absolute_env("XDG_CACHE_HOME")
+                        .unwrap_or_else(|| home.join(".cache"))
+                        .join("bat")
+                }),
+            config_dir: env::var_os("BAT_CONFIG_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    absolute_env("XDG_CONFIG_HOME")
+                        .unwrap_or_else(|| home.join(".config"))
+                        .join("bat")
+                }),
         })
     }
 

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -361,7 +361,7 @@ fn invoke_bugreport(app: &App, cache_dir: &Path) {
         .info(ColorSchemeCollector)
         .info(CompileTimeInformation::default());
 
-    #[cfg(feature = "paging")]
+    #[cfg(all(feature = "paging", not(target_os = "wasi")))]
     if let Ok(resolved_path) = grep_cli::resolve_binary(pager) {
         report = report.info(CommandOutput::new(
             "Less version",

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,11 @@ pub struct Config<'a> {
     pub number_nonblank: bool,
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 pub fn get_pager_executable(config_pager: Option<&str>) -> Option<String> {
     crate::pager::get_pager(config_pager)
         .ok()
@@ -164,28 +168,44 @@ fn default_config_should_highlight_no_lines() {
     );
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_with_config_pager_less() {
     let result = get_pager_executable(Some("less"));
     assert_eq!(result, Some("less".to_string()));
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_with_config_pager_builtin() {
     let result = get_pager_executable(Some("builtin"));
     assert_eq!(result, None);
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_with_config_pager_more() {
     let result = get_pager_executable(Some("more"));
     assert_eq!(result, Some("more".to_string()));
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_with_bat_pager() {
     std::env::set_var("BAT_PAGER", "most");
@@ -194,7 +214,11 @@ fn get_pager_executable_with_bat_pager() {
     std::env::remove_var("BAT_PAGER");
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_with_pager_more_switches_to_less() {
     std::env::set_var("PAGER", "more");
@@ -203,7 +227,11 @@ fn get_pager_executable_with_pager_more_switches_to_less() {
     std::env::remove_var("PAGER");
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_default() {
     // Ensure no env vars
@@ -213,28 +241,44 @@ fn get_pager_executable_default() {
     assert_eq!(result, Some("less".to_string()));
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_name_ignoring_arguments() {
     let result = get_pager_executable(Some("foo --bar"));
     assert_eq!(result, Some("foo".to_string()));
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_name_ignoring_path() {
     let result = get_pager_executable(Some("/bin/foo test"));
     assert_eq!(result, Some("/bin/foo".to_string()));
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_invalid_command() {
     let result = get_pager_executable(Some("invalid ' command"));
     assert_eq!(result, None);
 }
 
-#[cfg(all(feature = "minimal-application", feature = "paging"))]
+#[cfg(all(
+    feature = "minimal-application",
+    feature = "paging",
+    not(target_os = "wasi")
+))]
 #[test]
 fn get_pager_executable_empty_config() {
     let result = get_pager_executable(Some(""));

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -17,7 +17,7 @@ use std::collections::VecDeque;
 use std::io::{self, BufRead, Write};
 use std::mem;
 
-use clircle::{Clircle, Identifier};
+use crate::io_identifier::{Clircle, Identifier};
 
 pub struct Controller<'a> {
     config: &'a Config<'a>,
@@ -97,7 +97,7 @@ impl Controller<'_> {
         let stdout_identifier = if cfg!(windows) || attached_to_pager {
             None
         } else {
-            clircle::Identifier::stdout()
+            Identifier::stdout()
         };
 
         let mut writer = match (output_handle, &mut output_type_opt) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ pub enum Error {
     InvalidPagerValueBat,
     #[error("{0}")]
     Msg(String),
-    #[cfg(feature = "paging")]
+    #[cfg(all(feature = "paging", not(target_os = "wasi")))]
     #[error(transparent)]
     MinusError(#[from] ::minus::MinusError),
     #[cfg(feature = "lessopen")]

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 
-use clircle::{Clircle, Identifier};
+use crate::io_identifier::{Clircle, Identifier, Stdio};
 use content_inspector::{self, ContentType};
 
 use crate::error::*;
@@ -198,7 +198,7 @@ impl<'a> Input<'a> {
         match self.kind {
             InputKind::StdIn => {
                 if let Some(stdout) = stdout_identifier {
-                    let input_identifier = Identifier::try_from(clircle::Stdio::Stdin)
+                    let input_identifier = Identifier::try_from(Stdio::Stdin)
                         .map_err(|e| format!("Stdin: Error identifying file: {e}"))?;
                     if stdout.surely_conflicts_with(&input_identifier) {
                         return Err("IO circle detected. The input from stdin is also an output. Aborting to avoid infinite loop.".into());
@@ -235,7 +235,7 @@ impl<'a> Input<'a> {
                             )
                             .into());
                         }
-                        file = input_identifier.into_inner().expect("The file was lost in the clircle::Identifier, this should not have happened...");
+                        file = input_identifier.into_inner().expect("The file was lost in the input identifier, this should not have happened...");
                     }
 
                     InputReader::try_new(BufReader::new(file))?

--- a/src/io_identifier.rs
+++ b/src/io_identifier.rs
@@ -1,0 +1,90 @@
+#[cfg(not(target_os = "wasi"))]
+pub(crate) use clircle::{Clircle, Identifier, Stdio};
+
+#[cfg(target_os = "wasi")]
+pub(crate) use wasi::{Clircle, Identifier, Stdio};
+
+#[cfg(target_os = "wasi")]
+mod wasi {
+    use rustix::fs::{fstat, seek, FileType, SeekFrom, Stat};
+    use std::fs::File;
+    use std::io;
+
+    pub(crate) enum Stdio {
+        Stdin,
+        Stdout,
+    }
+
+    pub(crate) trait Clircle {
+        fn stdout() -> Option<Self>
+        where
+            Self: Sized;
+        fn surely_conflicts_with(&self, other: &Self) -> bool;
+        fn into_inner(self) -> Option<File>;
+    }
+
+    pub(crate) struct Identifier {
+        device: u64,
+        inode: u64,
+        regular: bool,
+        file: Option<File>,
+        unread: bool,
+    }
+
+    impl Identifier {
+        fn from_stat(stat: Stat, position: Option<u64>, file: Option<File>) -> Self {
+            Self {
+                device: stat.st_dev,
+                inode: stat.st_ino,
+                regular: FileType::from_raw_mode(stat.st_mode) == FileType::RegularFile,
+                unread: position
+                    .zip(u64::try_from(stat.st_size).ok())
+                    .map(|(position, size)| position < size)
+                    .unwrap_or(true),
+                file,
+            }
+        }
+    }
+
+    impl TryFrom<Stdio> for Identifier {
+        type Error = io::Error;
+        fn try_from(stream: Stdio) -> io::Result<Self> {
+            let fd = match stream {
+                Stdio::Stdin => rustix::stdio::stdin(),
+                Stdio::Stdout => rustix::stdio::stdout(),
+            };
+            Ok(Self::from_stat(
+                fstat(fd)?,
+                seek(fd, SeekFrom::Current(0)).ok(),
+                None,
+            ))
+        }
+    }
+
+    impl TryFrom<File> for Identifier {
+        type Error = io::Error;
+        fn try_from(file: File) -> io::Result<Self> {
+            Ok(Self::from_stat(
+                fstat(&file)?,
+                seek(&file, SeekFrom::Current(0)).ok(),
+                Some(file),
+            ))
+        }
+    }
+
+    impl Clircle for Identifier {
+        fn stdout() -> Option<Self> {
+            Self::try_from(Stdio::Stdout).ok()
+        }
+        fn surely_conflicts_with(&self, other: &Self) -> bool {
+            self.regular
+                && other.regular
+                && self.device == other.device
+                && self.inode == other.inode
+                && other.unread
+        }
+        fn into_inner(self) -> Option<File> {
+            self.file
+        }
+    }
+}

--- a/src/less.rs
+++ b/src/less.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "paging")]
+#![cfg(all(feature = "paging", not(target_os = "wasi")))]
 
 use std::ffi::OsStr;
 use std::process::Command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,14 @@ mod decorations;
 mod diff;
 pub mod error;
 pub mod input;
+mod io_identifier;
 mod less;
 #[cfg(feature = "lessopen")]
 mod lessopen;
 pub mod line_range;
 pub(crate) mod nonprintable_notation;
 pub mod output;
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 mod pager;
 #[cfg(feature = "paging")]
 pub(crate) mod paging;

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,25 +1,25 @@
 use std::fmt;
 use std::io;
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 use std::process::Child;
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 use std::thread::{spawn, JoinHandle};
 
 use crate::error::*;
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 use crate::less::{retrieve_less_version, LessVersion};
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 use crate::paging::PagingMode;
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 use crate::wrapping::WrappingMode;
 
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 pub struct BuiltinPager {
     pager: minus::Pager,
     handle: Option<JoinHandle<Result<()>>>,
 }
 
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 impl BuiltinPager {
     fn new() -> Self {
         let pager = minus::Pager::new();
@@ -45,7 +45,7 @@ impl BuiltinPager {
     }
 }
 
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 impl std::fmt::Debug for BuiltinPager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BuiltinPager")
@@ -55,7 +55,7 @@ impl std::fmt::Debug for BuiltinPager {
     }
 }
 
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 #[derive(Debug, PartialEq)]
 enum SingleScreenAction {
     Quit,
@@ -64,15 +64,27 @@ enum SingleScreenAction {
 
 #[derive(Debug)]
 pub enum OutputType {
-    #[cfg(feature = "paging")]
+    #[cfg(all(feature = "paging", not(target_os = "wasi")))]
     Pager(Child),
-    #[cfg(feature = "paging")]
+    #[cfg(all(feature = "paging", not(target_os = "wasi")))]
     BuiltinPager(BuiltinPager),
     Stdout(io::Stdout),
 }
 
 impl OutputType {
-    #[cfg(feature = "paging")]
+    #[cfg(all(feature = "paging", target_os = "wasi"))]
+    pub fn from_mode(
+        paging_mode: crate::paging::PagingMode,
+        _wrapping_mode: crate::wrapping::WrappingMode,
+        _pager: Option<&str>,
+    ) -> Result<Self> {
+        if paging_mode == crate::paging::PagingMode::Always {
+            return Err("Paging is unavailable in WASI; use --paging=never".into());
+        }
+        Ok(Self::stdout())
+    }
+
+    #[cfg(all(feature = "paging", not(target_os = "wasi")))]
     pub fn from_mode(
         paging_mode: PagingMode,
         wrapping_mode: WrappingMode,
@@ -89,7 +101,7 @@ impl OutputType {
     }
 
     /// Try to launch the pager. Fall back to stdout in case of errors.
-    #[cfg(feature = "paging")]
+    #[cfg(all(feature = "paging", not(target_os = "wasi")))]
     fn try_pager(
         single_screen_action: SingleScreenAction,
         wrapping_mode: WrappingMode,
@@ -203,33 +215,33 @@ impl OutputType {
         OutputType::Stdout(io::stdout())
     }
 
-    #[cfg(feature = "paging")]
+    #[cfg(all(feature = "paging", not(target_os = "wasi")))]
     pub(crate) fn is_pager(&self) -> bool {
         matches!(self, OutputType::Pager(_) | OutputType::BuiltinPager(_))
     }
 
-    #[cfg(not(feature = "paging"))]
+    #[cfg(any(not(feature = "paging"), target_os = "wasi"))]
     pub(crate) fn is_pager(&self) -> bool {
         false
     }
 
     pub fn handle<'a>(&'a mut self) -> Result<OutputHandle<'a>> {
         Ok(match *self {
-            #[cfg(feature = "paging")]
+            #[cfg(all(feature = "paging", not(target_os = "wasi")))]
             OutputType::Pager(ref mut command) => OutputHandle::IoWrite(
                 command
                     .stdin
                     .as_mut()
                     .ok_or("Could not open stdin for pager")?,
             ),
-            #[cfg(feature = "paging")]
+            #[cfg(all(feature = "paging", not(target_os = "wasi")))]
             OutputType::BuiltinPager(ref mut pager) => OutputHandle::FmtWrite(&mut pager.pager),
             OutputType::Stdout(ref mut handle) => OutputHandle::IoWrite(handle),
         })
     }
 }
 
-#[cfg(feature = "paging")]
+#[cfg(all(feature = "paging", not(target_os = "wasi")))]
 impl Drop for OutputType {
     fn drop(&mut self) {
         match *self {

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -4,8 +4,10 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    thread,
 };
+
+#[cfg(not(target_os = "wasi"))]
+use std::thread;
 
 use globset::{Candidate, GlobBuilder, GlobMatcher};
 use once_cell::sync::Lazy;
@@ -86,6 +88,7 @@ impl<'a> SyntaxMapping<'a> {
     /// times by starting this work early in parallel.
     ///
     /// The thread halts if/when `halt_glob_build` is set to true.
+    #[cfg(not(target_os = "wasi"))]
     pub fn start_offload_build_all(&self) {
         let halt = Arc::clone(&self.halt_glob_build);
         thread::spawn(move || {
@@ -102,6 +105,10 @@ impl<'a> SyntaxMapping<'a> {
         // resources (e.g. IO), it would be a good idea to store the handle
         // and join it on drop.
     }
+
+    /// WASI Preview 1 has no threads; builtin matchers remain lazily initialized.
+    #[cfg(target_os = "wasi")]
+    pub fn start_offload_build_all(&self) {}
 
     pub fn insert(&mut self, from: &str, to: MappingTarget<'a>) -> Result<()> {
         let matcher = make_glob_matcher(from, Case::Insensitive)?;

--- a/src/syntax_mapping.rs
+++ b/src/syntax_mapping.rs
@@ -10,6 +10,7 @@ use std::{
 use std::thread;
 
 use globset::{Candidate, GlobBuilder, GlobMatcher};
+#[cfg(not(target_os = "wasi"))]
 use once_cell::sync::Lazy;
 
 use crate::error::Result;

--- a/tests/wasi/smoke.mjs
+++ b/tests/wasi/smoke.mjs
@@ -4,28 +4,38 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { WASI } from 'node:wasi';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
-const module = await WebAssembly.compile(fs.readFileSync(process.argv[2]));
+// Model real CLI invocations with one WASI instance per host process. Besides
+// bounding memory, this avoids the Node 22 crash observed after repeatedly
+// creating and exiting WASI instances in the same process.
+if (process.argv[3] === '--case') {
+    const { args, env, root } = JSON.parse(process.argv[4]);
+    const wasi = new WASI({ version: 'preview1', args, env, preopens: { '/': root }, returnOnExit: true });
+    const module = await WebAssembly.compile(fs.readFileSync(process.argv[2]));
+    const instance = await WebAssembly.instantiate(module, wasi.getImportObject());
+    process.exit(wasi.start(instance));
+}
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bat-wasi-'));
 let checks = 0;
 let invocation = 0;
 function run(args, { stdin = '', env = {}, config = false, circular = false } = {}) {
+    console.log(`WASI invocation ${invocation}: ${args.join(" ")}`);
     const prefix = path.join(root, `run-${invocation++}`);
     fs.writeFileSync(`${prefix}.in`, stdin);
     const input = fs.openSync(`${prefix}.in`, 'r');
     const output = fs.openSync(circular ? `${prefix}.in` : `${prefix}.out`, circular ? 'a' : 'w');
     const error = fs.openSync(`${prefix}.err`, 'w');
     try {
-        const wasi = new WASI({
-            version: 'preview1',
+        const result = spawnSync(process.execPath, [fileURLToPath(import.meta.url), process.argv[2], '--case', JSON.stringify({
             args: ['bat', ...(config ? [] : ['--no-config']), ...args],
             env: { TERM: 'xterm-256color', ...env },
-            preopens: { '/': root },
-            stdin: input, stdout: output, stderr: error,
-            returnOnExit: true,
-        });
-        const instance = new WebAssembly.Instance(module, wasi.getImportObject());
-        const code = wasi.start(instance);
+            root,
+        })], { stdio: [input, output, error], timeout: 30000 });
+        assert.equal(result.signal, null, `WASI host terminated with ${result.signal}`);
+        if (result.error) throw result.error;
+        const code = result.status;
         return {
             code,
             stdout: fs.readFileSync(circular ? `${prefix}.in` : `${prefix}.out`, 'utf8'),

--- a/tests/wasi/smoke.mjs
+++ b/tests/wasi/smoke.mjs
@@ -1,0 +1,99 @@
+// Run with Node.js 22+: node tests/wasi/smoke.mjs path/to/bat.wasm
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { WASI } from 'node:wasi';
+
+const module = await WebAssembly.compile(fs.readFileSync(process.argv[2]));
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bat-wasi-'));
+let checks = 0;
+let invocation = 0;
+function run(args, { stdin = '', env = {}, config = false, circular = false } = {}) {
+    const prefix = path.join(root, `run-${invocation++}`);
+    fs.writeFileSync(`${prefix}.in`, stdin);
+    const input = fs.openSync(`${prefix}.in`, 'r');
+    const output = fs.openSync(circular ? `${prefix}.in` : `${prefix}.out`, circular ? 'a' : 'w');
+    const error = fs.openSync(`${prefix}.err`, 'w');
+    try {
+        const wasi = new WASI({
+            version: 'preview1',
+            args: ['bat', ...(config ? [] : ['--no-config']), ...args],
+            env: { TERM: 'xterm-256color', ...env },
+            preopens: { '/': root },
+            stdin: input, stdout: output, stderr: error,
+            returnOnExit: true,
+        });
+        const instance = new WebAssembly.Instance(module, wasi.getImportObject());
+        const code = wasi.start(instance);
+        return {
+            code,
+            stdout: fs.readFileSync(circular ? `${prefix}.in` : `${prefix}.out`, 'utf8'),
+            stderr: fs.readFileSync(`${prefix}.err`, 'utf8'),
+        };
+    } finally {
+        fs.closeSync(input); fs.closeSync(output); fs.closeSync(error);
+    }
+}
+function ok(result, expected) {
+    assert.equal(result.code, 0, result.stderr);
+    if (expected !== undefined) assert.equal(result.stdout, expected);
+    checks++;
+    return result.stdout;
+}
+const plain = ['--paging=never', '--color=never', '--style=plain'];
+const strip = text => text.replace(/\x1b\[[0-9;]*m/g, '');
+try {
+    assert.match(ok(run(['--version'])), /^bat /);
+    assert.match(ok(run(['--help'])), /Usage:/);
+    assert.match(ok(run(['--list-languages', '--color=never'])), /Rust/);
+    assert.match(ok(run(['--list-themes', '--color=never'])), /Monokai Extended/);
+    ok(run(plain, { stdin: 'stdin without HOME\n' }), 'stdin without HOME\n');
+    ok(run(plain, { stdin: '' }), '');
+    ok(run(plain, { stdin: 'αβ\r\n第二行\r\nlast' }), 'αβ\r\n第二行\r\nlast');
+    fs.writeFileSync(path.join(root, 'space ü.rs'), 'fn main() {}\n');
+    fs.writeFileSync(path.join(root, 'second.txt'), 'second\n');
+    ok(run([...plain, '/space ü.rs', '/second.txt']), 'fn main() {}\nsecond\n');
+    ok(run([...plain, '--line-range=2:3'], { stdin: 'one\ntwo\nthree\nfour\n' }), 'two\nthree\n');
+    for (const [language, code] of [
+        ['C', 'int main(void) { return 0; }\n'],
+        ['Rust', 'fn main() { println!("hello"); }\n'],
+        ['Python', 'def hello():\n    print("hello")\n'],
+        ['JSON', '{"hello": true}\n'],
+        ['YAML', 'hello: true\n'],
+        ['TOML', 'hello = true\n'],
+        ['CSS', 'body { color: red; }\n'],
+        ['HTML', '<p>Hello</p>\n'],
+        ['Markdown', '# Hello\n\n**world**\n'],
+        ['JavaScript', 'function hello() { return 42; }\n'],
+    ]) {
+        const output = ok(run(['--paging=never', '--color=always', '--style=plain', '--language', language], { stdin: code }));
+        assert.match(output, /\x1b\[/, language);
+        assert.equal(strip(output), code, language);
+    }
+    const numbered = ok(run(['--paging=never', '--color=never', '--decorations=always', '--style=numbers'], { stdin: 'a\nb\n' }));
+    assert.match(numbered, /1.*a\n.*2.*b\n/s);
+    const wrapped = ok(run(['--paging=never', '--color=never', '--decorations=always', '--style=plain', '--terminal-width=4', '--wrap=character'], { stdin: 'abcdefgh\n' }));
+    assert.equal(wrapped, 'abcd\nefgh\n');
+    const missing = run([...plain, '/missing.txt']);
+    assert.notEqual(missing.code, 0); assert.match(missing.stderr, /missing.txt/); checks++;
+    const paging = run(['--paging=always'], { stdin: 'hello\n' });
+    assert.notEqual(paging.code, 0); assert.match(paging.stderr, /Paging is unavailable in WASI/); checks++;
+    const circle = run(plain, { stdin: 'original\n', circular: true });
+    assert.notEqual(circle.code, 0); assert.match(circle.stderr, /input.*output|output.*input/i);
+    assert.equal(circle.stdout, 'original\n'); checks++;
+    ok(run(plain, { stdin: '', circular: true }), '');
+    for (const [directory, env] of [
+        ['.config/bat', { HOME: '/' }],
+        ['xdg/bat', { XDG_CONFIG_HOME: '/xdg' }],
+        ['custom', { BAT_CONFIG_DIR: '/custom' }],
+    ]) {
+        fs.mkdirSync(path.join(root, directory), { recursive: true });
+        fs.writeFileSync(path.join(root, directory, 'config'), '--line-range=2\n--style=plain\n--color=never\n--paging=never\n');
+        ok(run([], { config: true, env, stdin: 'one\ntwo\nthree\n' }), 'two\n');
+        fs.rmSync(path.join(root, directory), { recursive: true });
+    }
+    console.log(`${checks} WASI runtime checks passed`);
+} finally {
+    fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
Add a wasi-application feature bundle for compiling bat's command-line interface to wasm32-wasip1 on stable Rust. It uses the existing Rust-only regex backend and embedded assets, without native pagers, Git, external preprocessors or asset rebuilding.

Separate native-only dependencies and I/O identification from the WASI implementation. Preserve circular input/output detection with safe rustix APIs, including the empty-input case. Resolve guest filesystem paths without path_abs's nightly-only WASI requirement. Use host-provided directory environment variables, retain lazy syntax mapping on the single-threaded runtime, and report an explicit error for forced paging.

Include a Node.js launcher, build instructions and a WASI runtime test suite. Add stable and MSRV build/runtime jobs to the existing CI gate. This targets the WASI Preview 1 command-line interface; it does not introduce a browser DOM API or promise compatibility with every iOS host. The existing regex-fancy backend's syntax compatibility limitations remain applicable.

Validation: compiled the actual wasm32-wasip1 executable with official Rust 1.91.1 and ran 28 checks under both Node.js 22.23.2 and 24's WASI runtimes, with each command in a separate host process, covering files, Unicode paths, stdin, CRLF, empty input, ten highlighting languages, line ranges, numbering, wrapping, configuration, missing files, forced-pager errors and circular-output protection. All 473 native all-feature tests passed (7 ignored), along with all-target/all-feature Clippy with warnings denied, the minimal library build, formatting and whitespace checks.

Fixes #2661.