### PR TITLE
Add syntax-aware enclosing definitions and folded output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add syntax-aware enclosing-definition context and folded output, preserving original source line numbers, see #0 (@Matei02355).
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add syntax-aware enclosing-definition context and folded output, preserving original source line numbers, see #0 (@Matei02355).
+- Add syntax-aware enclosing-definition context and folded output, preserving original source line numbers, see #3998 (@Matei02355).
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/README.md
+++ b/README.md
@@ -541,6 +541,28 @@ The available individual components are:
 > Or, if you want to override the styles completely, you use `--style=numbers` to
 > only show the line numbers.
 
+### Enclosing definitions and folded output
+
+Use `bat -W 123 file.cpp` (or `--function-context 123`) to show the complete
+enclosing function, method or type and highlight the selected source line.
+Repeat `-W` to select multiple definitions. This uses syntax-defined names and
+block punctuation, including C, C++, Java, Objective-C and Rust definitions.
+Braces inside comments and strings do not establish boundaries. Namespace-contained
+globals and lines without a recognized complete definition are shown individually.
+Indentation-only definitions, such as Python functions, currently use that fallback.
+
+Use `bat --fold file.java` to collapse the interiors of complete brace-delimited
+blocks, multiline comments and consecutive import/include groups. Opening and
+closing block lines remain visible; nested folds are combined. Styling can show
+omissions with `--style=numbers,snip --decorations=always`. As with `--line-range`,
+plain piped output contains just the retained source lines.
+
+Both options read each complete input before rendering and support UTF-8 and
+BOM-marked UTF-16. They cannot be combined with `--unbuffered`, `--line-range`,
+`--diff` or each other. Syntax grammars describe tokens, not a compiler AST;
+unsupported or incomplete constructs may fall back to individual lines for context
+or remain unfolded. File line numbers are retained in either mode.
+
 ### Decorations
 
 By default, `bat` only shows decorations (such as line numbers, file headers, grid borders, etc.) when outputting to an interactive terminal. You can control this behavior with the `--decorations` option. Use `--decorations=always` to show decorations even when piping output to another command, or `--decorations=never` to disable them entirely. Possible values are `auto` (default), `never`, and `always`.

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -136,6 +136,8 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-l'                      , 'l'                     , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
             [CompletionResult]::new('--language'              , 'language'              , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
         #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+            [CompletionResult]::new('--function-context', 'function-context', [CompletionResultType]::ParameterName, 'Show enclosing definition for source line N.')
+            [CompletionResult]::new('--fold', 'fold', [CompletionResultType]::ParameterName, 'Fold syntax-defined blocks, comments and imports.')
             [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
             [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
             [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -88,6 +88,7 @@ _bat() {
 		return 0
 		;;
 	-H | --highlight-line | \
+	-W | --function-context | \
 	--diff-context | \
 	--tabs | \
 	--terminal-width | \
@@ -202,6 +203,8 @@ _bat() {
 			--plain
 			--language
 			--highlight-line
+			--function-context
+			--fold
 			--file-name
 			--diff
 			--diff-context

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,6 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -s W -l function-context -x -d "Show enclosing definition for source line N" -n __bat_no_excl_args
+complete -c $bat -l fold -d "Fold syntax-defined blocks, comments and imports" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -30,6 +30,8 @@ _{{PROJECT_EXECUTABLE}}_main() {
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
         \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
+        \*{-W+,--function-context=}'[show enclosing definition for source line]:line'
+        '--fold[fold syntax-defined blocks, comments and imports]'
         \*--file-name='[specify the name to display for a file]:name:_files'
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'
         --diff-context='[specify lines of context around added/removed/modified lines when using `--diff`]:lines'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -305,6 +305,24 @@ Print this help message.
 \fB\-V\fR, \fB\-\-version\fR
 .IP
 Show version information.
+.HP
+\fB\-W\fR, \fB\-\-function\-context\fR <N>
+.IP
+Show the enclosing brace-delimited function, method or type for source line N,
+and highlight that line when colors are enabled. Repeat for multiple lines.
+Use syntax scopes to identify names and block punctuation; comments and strings
+do not establish block boundaries. Lines without a recognized complete definition
+are shown individually. Namespace-contained globals do not select the whole file.
+.HP
+\fB\-\-fold\fR
+.IP
+Hide interior lines of complete brace-delimited blocks, multiline comments and
+consecutive import/include groups. Keep opening and closing block lines.
+Both structural options read each complete UTF-8 or BOM-marked UTF-16 input before
+rendering and conflict with --unbuffered, --line-range, --diff and each other.
+Indentation-only definitions are not indexed. Plain piped output contains retained
+source lines; the snip style shows omissions in decorated output.
+
 .SH "POSITIONAL ARGUMENTS"
 .HP
 \fB<FILE>...\fR

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -44,6 +44,17 @@ Options:
           
           [aliases: --fallback-language]
 
+  -W, --function-context <N>
+          Show and highlight the enclosing function, method or type for source line N. Uses syntax
+          scopes and brace-delimited definitions; lines without a recognized complete definition are
+          shown individually. Repeat for multiple lines. Reads each complete text input before
+          rendering.
+
+      --fold
+          Hide the interior lines of complete brace-delimited blocks, multiline comments and
+          consecutive imports. Keep block opening and closing lines. Reads each complete text input
+          before rendering; languages without matching syntax scopes remain unchanged.
+
   -H, --highlight-line <N:M>
           Highlight the specified line ranges with a different background color For example:
             '--highlight-line 40' highlights line 40

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -483,6 +483,12 @@ impl App {
             unbuffered: self.matches.get_flag("unbuffered"),
             number_nonblank: self.matches.get_flag("number-nonblank")
                 || self.number_nonblank_from_cli,
+            function_context: self
+                .matches
+                .get_many::<std::num::NonZeroUsize>("function-context")
+                .map(|vs| vs.map(|n| n.get()).collect())
+                .unwrap_or_default(),
+            fold: self.matches.get_flag("fold"),
             theme: theme(self.theme_options()).to_string(),
             visible_lines: match self.matches.try_contains_id("diff").unwrap_or_default()
                 && self.matches.get_flag("diff")
@@ -512,14 +518,24 @@ impl App {
                 .get_one::<String>("italic-text")
                 .map(|s| s.as_str())
                 == Some("always"),
-            highlighted_lines: self
-                .matches
-                .get_many::<String>("highlight-line")
-                .map(|ws| ws.map(|s| LineRange::from(s.as_str())).collect())
-                .transpose()?
-                .map(LineRanges::from)
-                .map(HighlightedLineRanges)
-                .unwrap_or_default(),
+            highlighted_lines: {
+                let mut ranges = self
+                    .matches
+                    .get_many::<String>("highlight-line")
+                    .map(|vs| {
+                        vs.map(|s| LineRange::from(s.as_str()))
+                            .collect::<Result<Vec<_>>>()
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
+                if let Some(lines) = self
+                    .matches
+                    .get_many::<std::num::NonZeroUsize>("function-context")
+                {
+                    ranges.extend(lines.map(|line| LineRange::new(line.get(), line.get())));
+                }
+                HighlightedLineRanges(LineRanges::from(ranges))
+            },
             use_custom_assets: !self.matches.get_flag("no-custom-assets"),
             #[cfg(feature = "lessopen")]
             use_lessopen: self.matches.get_flag("lessopen"),

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -134,6 +134,28 @@ pub fn build_app(interactive_output: bool) -> Command {
                 ),
         )
         .arg(
+            Arg::new("function-context")
+                .long("function-context")
+                .short('W')
+                .action(ArgAction::Append)
+                .value_parser(value_parser!(std::num::NonZeroUsize))
+                .value_name("N")
+                .hide_short_help(true)
+                .conflicts_with_all(["line-range", "unbuffered", "fold"])
+                .help("Show and highlight the enclosing definition for line N.")
+                .long_help("Show and highlight the enclosing function, method or type for source line N. Uses syntax scopes and brace-delimited definitions; lines without a recognized complete definition are shown individually. Repeat for multiple lines. Reads each complete text input before rendering."),
+        )
+        .arg(
+            Arg::new("fold")
+                .long("fold")
+                .action(ArgAction::SetTrue)
+                .overrides_with("fold")
+                .hide_short_help(true)
+                .conflicts_with_all(["line-range", "unbuffered", "function-context"])
+                .help("Fold syntax-defined blocks, comments and import groups.")
+                .long_help("Hide the interior lines of complete brace-delimited blocks, multiline comments and consecutive imports. Keep block opening and closing lines. Reads each complete text input before rendering; languages without matching syntax scopes remain unchanged."),
+        )
+        .arg(
             Arg::new("highlight-line")
                 .long("highlight-line")
                 .short('H')
@@ -174,7 +196,7 @@ pub fn build_app(interactive_output: bool) -> Command {
                         .short('d')
                         .overrides_with("diff")
                         .action(ArgAction::SetTrue)
-                        .conflicts_with("line-range")
+                        .conflicts_with_all(["line-range", "function-context", "fold"])
                         .help("Only show lines that have been added/removed/modified.")
                         .long_help(
                             "Only show lines that have been added/removed/modified with respect \

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,12 @@ pub struct Config<'a> {
     /// Specifies which lines should be printed
     pub visible_lines: VisibleLines,
 
+    /// Show the enclosing brace-delimited definition for these source lines.
+    pub function_context: Vec<usize>,
+
+    /// Collapse the interiors of syntax-defined blocks, comments, and import groups.
+    pub fold: bool,
+
     /// The syntax highlighting theme
     pub theme: String,
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -158,6 +158,57 @@ impl Controller<'_> {
             #[cfg(not(feature = "lessopen"))]
             input.open(stdin, stdout_identifier)?
         };
+        if self.config.fold || !self.config.function_context.is_empty() {
+            if self.config.unbuffered {
+                return Err("Structural context requires a complete input and cannot be used with unbuffered mode".into());
+            }
+            let syntax = self.assets.get_syntax(
+                self.config.language,
+                self.config.fallback_syntax,
+                &mut opened_input,
+                &self.config.syntax_mapping,
+            )?;
+            let mut bytes = Vec::new();
+            let mut line = Vec::new();
+            while opened_input.reader.read_line(&mut line)? {
+                bytes.append(&mut line);
+            }
+            let (encoding, bom) =
+                encoding_rs::Encoding::for_bom(&bytes).unwrap_or((encoding_rs::UTF_8, 0));
+            let (text, _, errors) = encoding.decode(&bytes[bom..]);
+            if errors || text.contains('\0') {
+                return Err("Structural context requires UTF-8 or BOM-marked Unicode text".into());
+            }
+            let structure = crate::structural_context::Structure::parse(
+                &text,
+                syntax.syntax,
+                syntax.syntax_set,
+            )?;
+            let mut config = self.config.clone();
+            if !config.colored_output && !config.function_context.is_empty() {
+                config.highlighted_lines = Default::default();
+            }
+            config.visible_lines = VisibleLines::Ranges(if config.fold {
+                structure.folded()
+            } else {
+                structure.context(&config.function_context)
+            });
+            opened_input.reader = InputReader::try_new(std::io::Cursor::new(bytes))?;
+            return Controller::new(&config, self.assets).print_opened_input(
+                opened_input,
+                writer,
+                is_first,
+            );
+        }
+        self.print_opened_input(opened_input, writer, is_first)
+    }
+
+    fn print_opened_input(
+        &self,
+        mut opened_input: OpenedInput,
+        writer: &mut OutputHandle,
+        is_first: bool,
+    ) -> Result<()> {
         opened_input.reader.unbuffered = self.config.unbuffered;
         #[cfg(feature = "git")]
         let line_changes = if self.config.visible_lines.diff_mode()

--- a/src/input.rs
+++ b/src/input.rs
@@ -291,7 +291,9 @@ impl<'a> InputReader<'a> {
 
         if content_type == Some(ContentType::UTF_16LE) {
             read_utf16_line(&mut reader, &mut first_line, 0x00, 0x0A)?;
-        } else if content_type == Some(ContentType::UTF_16BE) {
+        } else if content_type == Some(ContentType::UTF_16BE)
+            && !first_line.ends_with(&[0x00, 0x0A])
+        {
             read_utf16_line(&mut reader, &mut first_line, 0x0A, 0x00)?;
         }
 
@@ -659,4 +661,23 @@ fn utf16le_issue3367() {
     assert!(res.is_ok());
     assert!(!res.unwrap());
     assert!(buffer.is_empty());
+}
+
+#[test]
+fn utf16be_first_line_does_not_consume_the_second_line() {
+    let bytes: Vec<u8> = std::iter::once(0xfeff)
+        .chain("one\ntwo\nthree\n".encode_utf16())
+        .flat_map(u16::to_be_bytes)
+        .collect();
+    let mut reader = InputReader::new(&bytes[..]);
+    let mut line = Vec::new();
+    for expected in ["one\n", "two\n", "three\n"] {
+        assert!(reader.read_line(&mut line).unwrap());
+        assert_eq!(
+            encoding_rs::UTF_16BE.decode_with_bom_removal(&line).0,
+            expected
+        );
+        line.clear();
+    }
+    assert!(!reader.read_line(&mut line).unwrap());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub(crate) mod paging;
 mod preprocessor;
 mod pretty_printer;
 pub(crate) mod printer;
+mod structural_context;
 pub mod style;
 pub(crate) mod syntax_mapping;
 mod terminal;

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -233,6 +233,21 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Show and highlight the enclosing brace-delimited definition for a source
+    /// line. Repeat for more lines. This reads the complete text input first.
+    pub fn function_context(&mut self, line: usize) -> &mut Self {
+        self.config.function_context.push(line);
+        self.highlighted_lines.push(LineRange::new(line, line));
+        self
+    }
+
+    /// Fold complete syntax-defined blocks, comments, and consecutive imports.
+    /// This reads the complete text input before rendering.
+    pub fn fold(&mut self, yes: bool) -> &mut Self {
+        self.config.fold = yes;
+        self
+    }
+
     /// Specify a line that should be highlighted (default: none).
     /// This can be called multiple times to highlight more than one
     /// line. See also: highlight_range.

--- a/src/structural_context.rs
+++ b/src/structural_context.rs
@@ -46,6 +46,7 @@ impl Structure {
         let mut comments = Vec::new();
         let mut imports = Vec::new();
         let mut comment_start = None;
+        let mut last_comment_line = 0;
         let mut import_start = None;
         // Resolve scope prefixes once, outside the input loop.
         let scope = |s| Scope::new(s).expect("valid static scope");
@@ -76,7 +77,6 @@ impl Structure {
             lines = line_number;
             let operations = parser.parse_line(line, set).map_err(syntect::Error::from)?;
             let mut previous = 0;
-            let mut comment_line = false;
             let mut import_line = false;
             // Inspect nonempty spans only; grammars often pop and restore a
             // scope at the same byte offset while changing parsing contexts.
@@ -88,7 +88,12 @@ impl Structure {
                 let part = &line[previous..offset];
                 let has = |prefix: Scope| scopes.as_slice().iter().any(|s| prefix.is_prefix_of(*s));
                 if !part.is_empty() {
-                    comment_line |= has(block_comment);
+                    if has(block_comment) {
+                        comment_start.get_or_insert(line_number);
+                        last_comment_line = line_number;
+                    } else if let Some(first) = comment_start.take() {
+                        comments.push((first, last_comment_line));
+                    }
                     import_line |= import_scopes.iter().any(|s| has(*s));
                 }
                 if !part.trim().is_empty() && !has(comment) && !has(string) {
@@ -157,24 +162,19 @@ impl Structure {
                 }
                 previous = offset;
             }
-            for (active, start, ranges) in [
-                (comment_line, &mut comment_start, &mut comments),
-                (import_line, &mut import_start, &mut imports),
-            ] {
-                if active {
-                    start.get_or_insert(line_number);
-                } else if let Some(first) = start.take() {
-                    ranges.push((first, line_number - 1));
-                }
-            }
-        }
-        if let Some(first) = comment_start {
             if !scopes
                 .as_slice()
                 .iter()
                 .any(|s| block_comment.is_prefix_of(*s))
             {
-                comments.push((first, lines));
+                if let Some(first) = comment_start.take() {
+                    comments.push((first, last_comment_line));
+                }
+            }
+            if import_line {
+                import_start.get_or_insert(line_number);
+            } else if let Some(first) = import_start.take() {
+                imports.push((first, line_number - 1));
             }
         }
         if let Some(first) = import_start {

--- a/src/structural_context.rs
+++ b/src/structural_context.rs
@@ -1,0 +1,309 @@
+//! Optional scope indexing for brace-delimited definitions. Highlighting grammars
+//! identify definition names and real block punctuation, so braces in comments,
+//! strings, and ordinary expressions cannot start or end a definition.
+use crate::error::Result;
+use crate::line_range::{LineRange, LineRanges};
+use syntect::parsing::{ParseState, Scope, ScopeStack, SyntaxReference, SyntaxSet};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Kind {
+    Function,
+    Type,
+    Namespace,
+    Block,
+}
+
+#[derive(Clone, Debug)]
+struct Block {
+    start: usize,
+    open: usize,
+    end: usize,
+    kind: Kind,
+}
+
+#[derive(Default)]
+struct Frame {
+    block: Option<Block>,
+    statement: Option<usize>,
+    definition: Option<(Kind, usize)>,
+}
+
+pub(crate) struct Structure {
+    blocks: Vec<Block>,
+    lines: usize,
+    comments: Vec<(usize, usize)>,
+    imports: Vec<(usize, usize)>,
+}
+
+impl Structure {
+    pub(crate) fn parse(text: &str, syntax: &SyntaxReference, set: &SyntaxSet) -> Result<Self> {
+        let mut parser = ParseState::new(syntax);
+        let mut scopes = ScopeStack::new();
+        let mut frames = vec![Frame::default()];
+        let mut blocks = Vec::new();
+        let mut lines = 0;
+        let objc = syntax.scope.to_string().starts_with("source.objc");
+        let mut comments = Vec::new();
+        let mut imports = Vec::new();
+        let mut comment_start = None;
+        let mut import_start = None;
+        // Resolve scope prefixes once, outside the input loop.
+        let scope = |s| Scope::new(s).expect("valid static scope");
+        let comment = scope("comment");
+        let string = scope("string");
+        let begin = scope("punctuation.section.block.begin");
+        let end = scope("punctuation.section.block.end");
+        let function = scope("entity.name.function");
+        let namespace = scope("entity.name.namespace");
+        let types = [
+            "entity.name.class",
+            "entity.name.struct",
+            "entity.name.type",
+            "entity.name.interface",
+            "entity.name.enum",
+        ]
+        .map(scope);
+        let preprocessor = scope("meta.preprocessor");
+        let block_comment = scope("comment.block");
+        let import_scopes = [
+            "meta.import",
+            "meta.preprocessor.include",
+            "keyword.control.import",
+        ]
+        .map(scope);
+        for (index, line) in text.split_inclusive('\n').enumerate() {
+            let line_number = index + 1;
+            lines = line_number;
+            let operations = parser.parse_line(line, set).map_err(syntect::Error::from)?;
+            let mut previous = 0;
+            let mut comment_line = false;
+            let mut import_line = false;
+            // Inspect nonempty spans only; grammars often pop and restore a
+            // scope at the same byte offset while changing parsing contexts.
+            for (offset, operation) in operations
+                .iter()
+                .map(|(p, op)| (*p, Some(op)))
+                .chain(std::iter::once((line.len(), None)))
+            {
+                let part = &line[previous..offset];
+                let has = |prefix: Scope| scopes.as_slice().iter().any(|s| prefix.is_prefix_of(*s));
+                if !part.is_empty() {
+                    comment_line |= has(block_comment);
+                    import_line |= import_scopes.iter().any(|s| has(*s));
+                }
+                if !part.trim().is_empty() && !has(comment) && !has(string) {
+                    let frame = frames.last_mut().expect("root frame");
+                    if has(preprocessor) {
+                        frame.statement = None;
+                        frame.definition = None;
+                    } else if has(begin) {
+                        let (kind, start) = frame
+                            .definition
+                            .take()
+                            .unwrap_or((Kind::Block, line_number));
+                        frame.statement = None;
+                        frames.push(Frame {
+                            block: Some(Block {
+                                start,
+                                open: line_number,
+                                end: line_number,
+                                kind,
+                            }),
+                            ..Frame::default()
+                        });
+                    } else if has(end) {
+                        if frames.len() > 1 {
+                            let mut block =
+                                frames.pop().expect("block frame").block.expect("block");
+                            block.end = line_number;
+                            blocks.push(block);
+                        }
+                        let frame = frames.last_mut().expect("root frame");
+                        frame.statement = None;
+                        frame.definition = None;
+                    } else {
+                        let start = *frame.statement.get_or_insert(line_number);
+                        if has(function) {
+                            // Objective-C implementation scopes have no opening
+                            // brace. Its selector declaration starts on this line.
+                            let start = if objc { line_number } else { start };
+                            frame.definition = Some((
+                                Kind::Function,
+                                frame
+                                    .definition
+                                    .filter(|(k, _)| *k == Kind::Function)
+                                    .map_or(start, |(_, n)| n),
+                            ));
+                        } else if has(namespace) {
+                            frame.definition = Some((Kind::Namespace, start));
+                        } else if types.iter().any(|s| has(*s))
+                            && !matches!(frame.definition, Some((Kind::Function, _)))
+                        {
+                            frame.definition = Some((Kind::Type, start));
+                        }
+                        if part.contains(';')
+                            || (part.contains(':')
+                                && scopes.as_slice().iter().any(|s| {
+                                    s.to_string().starts_with("punctuation.separator.access")
+                                }))
+                        {
+                            frame.statement = None;
+                            frame.definition = None;
+                        }
+                    }
+                }
+                if let Some(operation) = operation {
+                    scopes.apply(operation).map_err(syntect::Error::from)?;
+                }
+                previous = offset;
+            }
+            for (active, start, ranges) in [
+                (comment_line, &mut comment_start, &mut comments),
+                (import_line, &mut import_start, &mut imports),
+            ] {
+                if active {
+                    start.get_or_insert(line_number);
+                } else if let Some(first) = start.take() {
+                    ranges.push((first, line_number - 1));
+                }
+            }
+        }
+        if let Some(first) = comment_start {
+            if !scopes
+                .as_slice()
+                .iter()
+                .any(|s| block_comment.is_prefix_of(*s))
+            {
+                comments.push((first, lines));
+            }
+        }
+        if let Some(first) = import_start {
+            imports.push((first, lines));
+        }
+        Ok(Self {
+            blocks,
+            lines,
+            comments,
+            imports,
+        })
+    }
+
+    pub(crate) fn folded(&self) -> LineRanges {
+        let mut hidden = Vec::new();
+        hidden.extend(
+            self.blocks
+                .iter()
+                .filter(|b| b.open + 1 < b.end)
+                .map(|b| (b.open + 1, b.end - 1)),
+        );
+        hidden.extend(
+            self.comments
+                .iter()
+                .filter(|(start, end)| start + 1 < *end)
+                .map(|(start, end)| (start + 1, end - 1)),
+        );
+        hidden.extend(
+            self.imports
+                .iter()
+                .filter(|(start, end)| start < end)
+                .map(|(start, end)| (start + 1, *end)),
+        );
+        hidden.sort_unstable();
+        let mut visible = Vec::new();
+        let mut next = 1;
+        for (start, end) in hidden {
+            if start > next {
+                visible.push(LineRange::new(next, start - 1));
+            }
+            next = next.max(end + 1);
+        }
+        if next <= self.lines {
+            visible.push(LineRange::new(next, self.lines));
+        }
+        LineRanges::from(visible)
+    }
+
+    pub(crate) fn context(&self, selected: &[usize]) -> LineRanges {
+        LineRanges::from(
+            selected
+                .iter()
+                .filter(|&&line| line > 0 && line <= self.lines)
+                .map(|&line| {
+                    // The innermost complete function/type wins. Namespace-contained
+                    // globals fall back to the selected line instead of the whole file.
+                    self.blocks
+                        .iter()
+                        .filter(|b| {
+                            matches!(b.kind, Kind::Function | Kind::Type)
+                                && b.start <= line
+                                && line <= b.end
+                        })
+                        .min_by_key(|b| (b.end - b.start, usize::MAX - b.start))
+                        .map(|b| LineRange::new(b.start, b.end))
+                        .unwrap_or_else(|| LineRange::new(line, line))
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assets::HighlightingAssets;
+    use crate::line_range::{MaxBufferedLineNumber, RangeCheckResult};
+    fn selected(language: &str, text: &str, line: usize) -> Vec<usize> {
+        let assets = HighlightingAssets::from_binary();
+        let set = assets.get_syntax_set().unwrap();
+        let structure =
+            Structure::parse(text, set.find_syntax_by_name(language).unwrap(), set).unwrap();
+        let ranges = structure.context(&[line]);
+        (1..=structure.lines)
+            .filter(|&n| {
+                ranges.check(n, MaxBufferedLineNumber::Final(structure.lines))
+                    == RangeCheckResult::InRange
+            })
+            .collect()
+    }
+    #[test]
+    fn c_multiline_definition_and_nested_braces() {
+        let text = "#include <stdio.h>\nint global;\nstatic\nint example(\n int x)\n{\n if(x) {\n  puts(\"}\"); // {\n }\n return x;\n}\nint later;\n";
+        assert_eq!(selected("C", text, 8), (3..=11).collect::<Vec<_>>());
+        assert_eq!(selected("C", text, 2), vec![2]);
+        assert_eq!(selected("C", text, 12), vec![12]);
+    }
+    #[test]
+    fn cpp_nested_namespace_class_and_method() {
+        let text = "namespace Demo {\nint global;\nclass Example {\n public:\n int method(int x) {\n  return x;\n }\n};\n}\n";
+        assert_eq!(selected("C++", text, 6), vec![4, 5, 6, 7]);
+        assert_eq!(selected("C++", text, 3), (3..=8).collect::<Vec<_>>());
+        assert_eq!(selected("C++", text, 2), vec![2]);
+    }
+    #[test]
+    fn java_method_and_class() {
+        let text = "import java.io.File;\nclass Demo {\n int method(int x) {\n  return x;\n }\n}\n";
+        assert_eq!(selected("Java", text, 4), vec![3, 4, 5]);
+        assert_eq!(selected("Java", text, 2), vec![2, 3, 4, 5, 6]);
+    }
+    #[test]
+    fn objc_selector_is_not_the_whole_implementation() {
+        let text = "@implementation Demo\n- (int)method:(int)x {\n return x;\n}\n- (void)other {\n}\n@end\n";
+        assert_eq!(selected("Objective-C", text, 3), vec![2, 3, 4]);
+    }
+    #[test]
+    fn rust_ignores_nested_control_blocks() {
+        let text = "use std::io;\nfn example() {\n if true {\n  println!(\"}\");\n }\n}\n";
+        assert_eq!(selected("Rust", text, 4), vec![2, 3, 4, 5, 6]);
+    }
+    #[test]
+    fn prototypes_and_unclosed_definitions_do_not_capture_later_input() {
+        let text = "int example(int x);\nint global;\nint unfinished() {\n return 1;\n";
+        assert_eq!(selected("C", text, 2), vec![2]);
+        assert_eq!(selected("C", text, 4), vec![4]);
+    }
+    #[test]
+    fn plain_text_and_out_of_bounds_fall_back_safely() {
+        assert_eq!(selected("Plain Text", "hello {\nworld\n}\n", 2), vec![2]);
+        assert!(selected("Plain Text", "hello", 20).is_empty());
+    }
+}

--- a/tests/structural_context.rs
+++ b/tests/structural_context.rs
@@ -1,0 +1,230 @@
+use assert_cmd::Command;
+
+mod utils;
+
+fn bat() -> Command {
+    let mut cmd = utils::command::bat();
+    cmd.args(["--paging=never", "--color=never", "--style=plain"]);
+    cmd
+}
+
+const SOURCE: &str = "int global;\nint first() {\n return 1;\n}\n\nint second() {\n return 2;\n}\n";
+
+#[test]
+fn selects_independent_functions_without_adjacent_globals() {
+    bat()
+        .args(["-l", "c", "-W", "3"])
+        .write_stdin(SOURCE)
+        .assert()
+        .success()
+        .stdout("int first() {\n return 1;\n}\n");
+    bat()
+        .args(["-l", "c", "-W1"])
+        .write_stdin(SOURCE)
+        .assert()
+        .success()
+        .stdout("int global;\n");
+    bat()
+        .args(["-l", "c", "-W3", "-W7", "-W3"])
+        .write_stdin(SOURCE)
+        .assert()
+        .success()
+        .stdout("int first() {\n return 1;\n}\nint second() {\n return 2;\n}\n");
+}
+
+#[test]
+fn preserves_physical_line_numbers_and_snips() {
+    let output = bat()
+        .args([
+            "-l",
+            "c",
+            "-W3",
+            "-W7",
+            "--decorations=always",
+            "--style=numbers,snip",
+            "--terminal-width=40",
+        ])
+        .write_stdin(SOURCE)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+    assert!(output.contains("2 int first"), "{output}");
+    assert!(output.contains("6 int second"), "{output}");
+    assert!(output.contains("8<"), "{output}");
+}
+
+#[test]
+fn utf16_and_crlf_retain_source_line_boundaries() {
+    let utf16: Vec<u8> = std::iter::once(0xfeff)
+        .chain(SOURCE.encode_utf16())
+        .flat_map(u16::to_le_bytes)
+        .collect();
+    bat()
+        .args(["-l", "c", "-W3", "--decorations=always"])
+        .write_stdin(utf16)
+        .assert()
+        .success()
+        .stdout("int first() {\n return 1;\n}\n");
+    bat()
+        .args(["-l", "c", "-W3"])
+        .write_stdin(SOURCE.replace('\n', "\r\n"))
+        .assert()
+        .success()
+        .stdout("int first() {\r\n return 1;\r\n}\r\n");
+}
+
+#[test]
+fn recognizes_each_file_independently_with_auto_detection() {
+    let dir = tempfile::tempdir().unwrap();
+    let c = dir.path().join("a.c");
+    let java = dir.path().join("b.java");
+    std::fs::write(&c, SOURCE).unwrap();
+    std::fs::write(&java, "class Demo {\n int value() {\n  return 2;\n }\n}\n").unwrap();
+    bat()
+        .arg("-W3")
+        .arg(c)
+        .arg(java)
+        .assert()
+        .success()
+        .stdout("int first() {\n return 1;\n}\n int value() {\n  return 2;\n }\n");
+}
+
+#[test]
+fn unknown_syntax_and_incomplete_definitions_use_selected_lines() {
+    bat()
+        .args(["-l", "txt", "-W2"])
+        .write_stdin("hello {\nworld\n}\n")
+        .assert()
+        .success()
+        .stdout("world\n");
+    bat()
+        .args(["-l", "c", "-W2"])
+        .write_stdin("int broken() {\n return 1;\n")
+        .assert()
+        .success()
+        .stdout(" return 1;\n");
+    bat()
+        .args(["-l", "c", "-W99"])
+        .write_stdin(SOURCE)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn folds_c_imports_functions_and_comments_without_changing_strings() {
+    let source = "#include <stdio.h>\n#include <stdlib.h>\n\n/* comment\n * interior\n */\nint first() {\n puts(\"{ not a block }\");\n return 0;\n}\nconst char *s = \"{ untouched }\";\n";
+    bat().args(["-l", "c", "--fold", "--fold"]).write_stdin(source).assert().success().stdout("#include <stdio.h>\n\n/* comment\n */\nint first() {\n}\nconst char *s = \"{ untouched }\";\n");
+}
+
+#[test]
+fn folds_java_import_groups_and_outer_class_once() {
+    let source = "import java.io.File;\nimport java.io.Reader;\n\nclass Demo {\n int method() {\n  return 2;\n }\n}\n";
+    bat()
+        .args(["-l", "java", "--fold"])
+        .write_stdin(source)
+        .assert()
+        .success()
+        .stdout("import java.io.File;\n\nclass Demo {\n}\n");
+}
+
+#[test]
+fn keeps_single_line_blocks_and_unclosed_blocks_visible() {
+    let source = "int first() { return 1; }\nint unfinished() {\n return 2;\n";
+    bat()
+        .args(["-l", "c", "--fold"])
+        .write_stdin(source)
+        .assert()
+        .success()
+        .stdout(source);
+}
+
+#[test]
+fn rejects_conflicting_modes_invalid_line_numbers_and_binary_text() {
+    for args in [
+        vec!["-W0"],
+        vec!["-W1", "--unbuffered"],
+        vec!["--fold", "--line-range=2"],
+        vec!["-W1", "--fold"],
+    ] {
+        bat().args(args).write_stdin(SOURCE).assert().failure();
+    }
+    bat()
+        .arg("-W1")
+        .write_stdin(b"\0binary".to_vec())
+        .assert()
+        .failure();
+}
+
+#[test]
+fn library_context_and_folding_use_the_same_selection() {
+    let mut context = String::new();
+    bat::PrettyPrinter::new()
+        .input_from_bytes(SOURCE.as_bytes())
+        .language("C")
+        .function_context(3)
+        .colored_output(false)
+        .print_with_writer(Some(&mut context))
+        .unwrap();
+    assert_eq!(context, "int first() {\n return 1;\n}\n");
+    let mut folded = String::new();
+    bat::PrettyPrinter::new()
+        .input_from_bytes(SOURCE.as_bytes())
+        .language("C")
+        .fold(true)
+        .colored_output(false)
+        .print_with_writer(Some(&mut folded))
+        .unwrap();
+    assert_eq!(
+        folded,
+        "int global;\nint first() {\n}\n\nint second() {\n}\n"
+    );
+}
+
+#[test]
+fn colored_context_matches_explicit_range_and_highlight() {
+    let expected = bat()
+        .args([
+            "-l",
+            "c",
+            "--color=always",
+            "--line-range=2:4",
+            "--highlight-line=3",
+        ])
+        .write_stdin(SOURCE)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    bat()
+        .args(["-l", "c", "--color=always", "-W3"])
+        .write_stdin(SOURCE)
+        .assert()
+        .success()
+        .stdout(expected);
+}
+
+#[test]
+fn utf16be_and_unclosed_comments_do_not_loop_or_disappear() {
+    let utf16: Vec<u8> = std::iter::once(0xfeff)
+        .chain(SOURCE.encode_utf16())
+        .flat_map(u16::to_be_bytes)
+        .collect();
+    bat()
+        .args(["-l", "c", "-W3", "--decorations=always"])
+        .write_stdin(utf16)
+        .assert()
+        .success()
+        .stdout("int first() {\n return 1;\n}\n");
+    let text = "/* never closed\n still comment\n still comment\n";
+    bat()
+        .args(["-l", "c", "--fold"])
+        .write_stdin(text)
+        .assert()
+        .success()
+        .stdout(text);
+}

--- a/tests/structural_context.rs
+++ b/tests/structural_context.rs
@@ -228,3 +228,14 @@ fn utf16be_and_unclosed_comments_do_not_loop_or_disappear() {
         .success()
         .stdout(text);
 }
+
+#[test]
+fn adjacent_block_comments_preserve_code_on_their_shared_line() {
+    let text = "/* first\n * inside first\n */ int visible = 1; /* second\n * inside second\n */\n";
+    bat()
+        .args(["-l", "c", "--fold"])
+        .write_stdin(text)
+        .assert()
+        .success()
+        .stdout("/* first\n */ int visible = 1; /* second\n */\n");
+}


### PR DESCRIPTION
Add --function-context/-W N to select and highlight the enclosing function, method or type, and --fold to collapse complete block interiors, multiline comments and consecutive imports/includes. Expose both operations through PrettyPrinter.

Index Syntect definition-name scopes and block punctuation before rendering, so nested control blocks and braces in comments or strings do not incorrectly establish function boundaries. Select the innermost complete function/type for each requested line; namespace-contained globals and unrecognized/incomplete constructs fall back to the selected line. Folding keeps opening and closing block lines and combines nested omissions. Existing line numbers, syntax coloring, headers and snip separators remain available.

Both modes read the complete input and are mutually exclusive with streaming mode, explicit line ranges and Git diff mode. The index covers brace-delimited definitions rather than a compiler AST; indentation-only definitions are documented as unsupported. Plain piped output contains retained source lines, while decorated snip output marks omissions. Preserve real file metadata and independently index each input. Fix UTF-16BE first-line initialization, which otherwise consumes two physical lines and shifts the rendered selection.

Validation: all 493 all-feature tests passed (7 ignored), including 20 new tests covering C, C++, Java, Objective-C, Rust, nested definitions, multiline signatures, strings/comments, globals, prototypes, incomplete constructs, repeated selections, numbering, snips, multiple files, automatic syntax detection, UTF-16LE/BE, CRLF, coloring, folding and library usage. All 8 default-feature help tests, all-target/all-feature Clippy with warnings denied, the minimal library build, formatting, whitespace checks and Bash/Zsh completion syntax passed. A subsequent adjacent-comment regression confirms that code between comments on a shared line remains visible; all 7 structural unit tests and 13 structural integration tests passed again, followed by all-target/all-feature Clippy. README, manual, help and four completions are updated.

Fixes #2228.
Fixes #3005.