### PR TITLE
Reserve prompt rows during automatic less paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Features
 
+- Add `--paging-reserve` to keep rows available for multiline shell prompts during automatic less paging, see #0 (@Matei02355).
+
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)
 - Map justfile, Justfile, .justfile, and *.justfile to Makefile syntax highlighting, see #3623 (@zachvalenta)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## Features
 
-- Add `--paging-reserve` to keep rows available for multiline shell prompts during automatic less paging, see #0 (@Matei02355).
+- Add `--paging-reserve` to keep rows available for multiline shell prompts during automatic less paging, see #3999 (@Matei02355).
 
 - Add `-b` / `--number-nonblank` flag to only number non-blank lines, for `cat -b` compatibility. Closes #3856, see #3857 (@MeGaurav4)
 - Add a `--sanitize=<auto|always|never>` flag for safe display of untrusted input. It implies `--strip-ansi` at the same value and additionally substitutes terminal-active control bytes (cursor moves, charset switches, beep, etc.) and Unicode bidi / zero-width formatting characters with the Unicode replacement character (U+FFFD). Mitigates Trojan-Source-style spoofing (CVE-2021-42574). See #3729 (@curious-rabbit)

--- a/README.md
+++ b/README.md
@@ -696,6 +696,21 @@ For `less` 530 or newer, it should work out of the box.
 The `-S`/`--chop-long-lines` option is added when `bat`'s `-S`/`--chop-long-lines` option is used. This tells `less`
 to truncate any lines larger than the terminal width.
 
+### Reserve rows for a shell prompt
+
+With less 632 or newer, use `bat --paging-reserve=4 file.txt` to reserve four
+terminal rows for a multiline shell prompt during automatic paging. Output that
+would fill those rows stays in the pager; shorter output still exits automatically.
+This reduces the less viewport as well as its one-screen threshold. Use a nonnegative
+number of rows; zero disables the reservation. `--paging=always` and
+`--paging=never` retain their existing behavior.
+
+The option sets `LESS_LINES` only for the child pager and overrides an inherited
+value. Ordinary reservations follow less's terminal resizing behavior. If the
+reservation already fills the current terminal, the viewport is fixed at one row.
+Unsupported pagers and older less versions report an error when automatic paging
+would use the reservation. This option can also be placed in the configuration file.
+
 ### Indentation
 
 `bat` expands tabs to 4 spaces by itself, not relying on the pager. To change this, simply add the

--- a/assets/completions/_bat.ps1.in
+++ b/assets/completions/_bat.ps1.in
@@ -136,6 +136,7 @@ Register-ArgumentCompleter -Native -CommandName '{{PROJECT_EXECUTABLE}}' -Script
         #   [CompletionResult]::new('-l'                      , 'l'                     , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
             [CompletionResult]::new('--language'              , 'language'              , [CompletionResultType]::ParameterName, 'Set the language for syntax highlighting.')
         #   [CompletionResult]::new('-H'                      , 'H'                     , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
+            [CompletionResult]::new('--paging-reserve', 'paging-reserve', [CompletionResultType]::ParameterName, 'Reserve rows during automatic less paging.')
             [CompletionResult]::new('--highlight-line'        , 'highlight-line'        , [CompletionResultType]::ParameterName, 'Highlight lines N through M.')
             [CompletionResult]::new('--file-name'             , 'file-name'             , [CompletionResultType]::ParameterName, 'Specify the name to display for a file.')
             [CompletionResult]::new('--diff-context'          , 'diff-context'          , [CompletionResultType]::ParameterName, 'diff-context')

--- a/assets/completions/bat.bash.in
+++ b/assets/completions/bat.bash.in
@@ -89,6 +89,7 @@ _bat() {
 		;;
 	-H | --highlight-line | \
 	--diff-context | \
+	--paging-reserve | \
 	--tabs | \
 	--terminal-width | \
 	-m | --map-syntax | \
@@ -215,6 +216,7 @@ _bat() {
 			--decorations
 			--force-colorization
 			--paging
+			--paging-reserve
 			--no-paging
 			--pager
 			--map-syntax

--- a/assets/completions/bat.fish.in
+++ b/assets/completions/bat.fish.in
@@ -268,3 +268,5 @@ complete -c $bat -s h -d "Print a concise overview of $bat-cache help" -n __bat_
 complete -c $bat -l help -f -d "Print all $bat-cache help" -n __bat_cache_no_excl
 
 # vim:ft=fish
+
+complete -c $bat -l paging-reserve -x -d "Reserve rows during automatic less paging" -n __bat_no_excl_args

--- a/assets/completions/bat.zsh.in
+++ b/assets/completions/bat.zsh.in
@@ -30,6 +30,7 @@ _{{PROJECT_EXECUTABLE}}_main() {
         \*{-p,--plain}'[show plain style (alias for `--style=plain`), repeat twice to disable automatic paging (alias for `--paging=never`)]'
         '(-l --language)'{-l+,--language=}'[set the language for syntax highlighting]:language:->languages'
         \*{-H+,--highlight-line=}'[highlight specified block of lines]:start\:end'
+        '--paging-reserve=[reserve rows during automatic less paging]:rows'
         \*--file-name='[specify the name to display for a file]:name:_files'
         '(-d --diff)'--diff'[only show lines that have been added/removed/modified]'
         --diff-context='[specify lines of context around added/removed/modified lines when using `--diff`]:lines'

--- a/assets/manual/bat.1.in
+++ b/assets/manual/bat.1.in
@@ -305,6 +305,17 @@ Print this help message.
 \fB\-V\fR, \fB\-\-version\fR
 .IP
 Show version information.
+.HP
+\fB\-\-paging\-reserve\fR <N>
+.IP
+Reserve N terminal rows for a multiline shell prompt during automatic paging.
+Requires less 632 or newer and reduces its viewport as well as the one-screen
+threshold. Zero disables the reservation. Forced and disabled paging are unchanged.
+Sets LESS_LINES only for the child pager, overriding an inherited value. Normal
+reservations follow terminal resizing; a reservation at least as large as the
+initial terminal height fixes the viewport at one row. Other pagers report an
+error when automatic paging would use the reservation.
+
 .SH "POSITIONAL ARGUMENTS"
 .HP
 \fB<FILE>...\fR

--- a/doc/long-help.txt
+++ b/doc/long-help.txt
@@ -112,6 +112,12 @@ Options:
           Alias for '--decorations=always --color=always'. This is useful if the output of bat is
           piped to another program, but you want to keep the colorization/decorations.
 
+      --paging-reserve <N>
+          Reserve N terminal rows for a multiline shell prompt when paging automatically. Requires
+          less 632 or newer and reduces its viewport as well as the one-screen threshold. Zero
+          disables the reservation. Forced or disabled paging is unchanged; the viewport is kept at
+          least one row high.
+
       --paging <when>
           Specify when to use the pager. To disable the pager, use '--paging=never' or its
           alias,'-P'. To disable the pager permanently, set BAT_PAGING to 'never'. To control which

--- a/src/bin/bat/app.rs
+++ b/src/bin/bat/app.rs
@@ -429,6 +429,11 @@ impl App {
                     Some("auto") => !env_no_color() && self.interactive_output,
                     _ => unreachable!("other values for --color are not allowed"),
                 },
+            paging_reserve: self
+                .matches
+                .get_one::<u16>("paging-reserve")
+                .copied()
+                .unwrap_or(0),
             paging_mode,
             term_width: maybe_term_width.unwrap_or(Term::stdout().size().1 as usize),
             loop_through: !(self.interactive_output

--- a/src/bin/bat/clap_app.rs
+++ b/src/bin/bat/clap_app.rs
@@ -354,6 +354,17 @@ pub fn build_app(interactive_output: bool) -> Command {
                         to keep the colorization/decorations.")
         )
         .arg(
+            Arg::new("paging-reserve")
+                .long("paging-reserve")
+                .value_name("N")
+                .value_parser(value_parser!(u16))
+                .action(ArgAction::Set)
+                .overrides_with("paging-reserve")
+                .hide_short_help(true)
+                .help("Reserve N terminal rows when paging automatically with less.")
+                .long_help("Reserve N terminal rows for a multiline shell prompt when paging automatically. Requires less 632 or newer and reduces its viewport as well as the one-screen threshold. Zero disables the reservation. Forced or disabled paging is unchanged; the viewport is kept at least one row high."),
+        )
+        .arg(
             Arg::new("paging")
                 .long("paging")
                 .overrides_with("paging")

--- a/src/bin/bat/main.rs
+++ b/src/bin/bat/main.rs
@@ -254,8 +254,12 @@ pub fn list_themes(
         ))?;
     }
 
-    let mut output_type =
-        OutputType::from_mode(config.paging_mode, config.wrapping_mode, config.pager)?;
+    let mut output_type = OutputType::from_mode_with_reserve(
+        config.paging_mode,
+        config.wrapping_mode,
+        config.pager,
+        config.paging_reserve,
+    )?;
     let mut writer = output_type.handle()?;
     writer.write_fmt(format_args!("{buf}"))?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,9 @@ pub struct Config<'a> {
     #[cfg(feature = "paging")]
     pub paging_mode: PagingMode,
 
+    /// Rows to reserve from the automatic less pager viewport (zero disables).
+    pub paging_reserve: u16,
+
     /// Specifies which lines should be printed
     pub visible_lines: VisibleLines,
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -76,10 +76,11 @@ impl Controller<'_> {
 
             let wrapping_mode = self.config.wrapping_mode;
 
-            output_type_opt = Some(OutputType::from_mode(
+            output_type_opt = Some(OutputType::from_mode_with_reserve(
                 paging_mode,
                 wrapping_mode,
                 self.config.pager,
+                self.config.paging_reserve,
             )?);
         }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -78,11 +78,22 @@ impl OutputType {
         wrapping_mode: WrappingMode,
         pager: Option<&str>,
     ) -> Result<Self> {
+        Self::from_mode_with_reserve(paging_mode, wrapping_mode, pager, 0)
+    }
+
+    /// Select output while reserving rows from automatic less paging.
+    #[cfg(feature = "paging")]
+    pub fn from_mode_with_reserve(
+        paging_mode: PagingMode,
+        wrapping_mode: WrappingMode,
+        pager: Option<&str>,
+        reserve: u16,
+    ) -> Result<Self> {
         use self::PagingMode::*;
         Ok(match paging_mode {
-            Always => OutputType::try_pager(SingleScreenAction::Nothing, wrapping_mode, pager)?,
+            Always => OutputType::try_pager(SingleScreenAction::Nothing, wrapping_mode, pager, 0)?,
             QuitIfOneScreen => {
-                OutputType::try_pager(SingleScreenAction::Quit, wrapping_mode, pager)?
+                OutputType::try_pager(SingleScreenAction::Quit, wrapping_mode, pager, reserve)?
             }
             _ => OutputType::stdout(),
         })
@@ -94,6 +105,7 @@ impl OutputType {
         single_screen_action: SingleScreenAction,
         wrapping_mode: WrappingMode,
         pager_from_config: Option<&str>,
+        reserve: u16,
     ) -> Result<Self> {
         use crate::pager::{self, PagerKind, PagerSource};
         use std::process::{Command, Stdio};
@@ -108,6 +120,10 @@ impl OutputType {
 
         if pager.kind == PagerKind::Bat {
             return Err(Error::InvalidPagerValueBat);
+        }
+
+        if reserve > 0 && pager.kind != PagerKind::Less {
+            return Err("--paging-reserve requires less 632 or newer".into());
         }
 
         if pager.kind == PagerKind::Builtin {
@@ -129,6 +145,28 @@ impl OutputType {
         let args = pager.args;
 
         if pager.kind == PagerKind::Less {
+            let less_version =
+                if reserve > 0 || args.is_empty() || pager.source == PagerSource::EnvVarPager {
+                    retrieve_less_version(&pager.bin)
+                } else {
+                    None
+                };
+            if reserve > 0 {
+                if !matches!(less_version, Some(LessVersion::Less(version)) if version >= 632) {
+                    return Err("--paging-reserve requires less 632 or newer".into());
+                }
+                let height = console::Term::stdout().size().0;
+                // A negative LESS_LINES follows normal terminal resizing. If
+                // the reservation already fills this terminal, retain one row
+                // rather than let less fall back to its default screen height.
+                let rows = if reserve < height {
+                    format!("-{reserve}")
+                } else {
+                    "1".to_owned()
+                };
+                p.env("LESS_LINES", rows);
+            }
+
             // less needs to be called with the '-R' option in order to properly interpret the
             // ANSI color sequences printed by bat. If someone has set PAGER="less -F", we
             // therefore need to overwrite the arguments and add '-R'.
@@ -146,8 +184,6 @@ impl OutputType {
                 if wrapping_mode == WrappingMode::NoWrapping(true) {
                     p.arg("-S"); // Short version of --chop-long-lines for compatibility
                 }
-
-                let less_version = retrieve_less_version(&pager.bin);
 
                 // Ensures that 'less' quits together with 'bat'
                 // The BusyBox version of less does not support -K
@@ -177,6 +213,11 @@ impl OutputType {
                 }
             } else {
                 p.args(args);
+            }
+            if reserve > 0 {
+                // An explicit automatic reservation also applies to custom
+                // less arguments, which may not already contain -F.
+                p.arg("-F");
             }
             p.env("LESSCHARSET", "UTF-8");
 

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -220,6 +220,14 @@ impl<'a> PrettyPrinter<'a> {
         self
     }
 
+    /// Reserve terminal rows from the automatic less pager viewport. Requires
+    /// less 632 or newer; has no effect on forced or disabled paging.
+    #[cfg(feature = "paging")]
+    pub fn paging_reserve(&mut self, rows: u16) -> &mut Self {
+        self.config.paging_reserve = rows;
+        self
+    }
+
     /// Specify the command to start the pager (default: use "less")
     #[cfg(feature = "paging")]
     pub fn pager(&mut self, cmd: &'a str) -> &mut Self {

--- a/tests/paging/reserve.py
+++ b/tests/paging/reserve.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""PTY regressions: python3 tests/paging/reserve.py /path/to/bat /path/to/less.
+Requires POSIX and less 632 or newer. No dependencies outside the standard library.
+"""
+import argparse
+import fcntl
+import os
+from pathlib import Path
+import pty
+import select
+import signal
+import struct
+import tempfile
+import termios
+import time
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('bat')
+parser.add_argument('less')
+args = parser.parse_args()
+binary, pager = str(Path(args.bat).resolve()), str(Path(args.less).resolve())
+
+
+def check(root, name, text, options, expected_pager, expected_error=None):
+    source = root / 'input.txt'
+    source.write_text(text)
+    pid, fd = pty.fork()
+    if pid == 0:
+        fcntl.ioctl(1, termios.TIOCSWINSZ, struct.pack('HHHH', 24, 60, 0, 0))
+        env = dict(os.environ, TERM='xterm-256color')
+        for key in ['BAT_OPTS', 'BAT_PAGER', 'PAGER', 'LESS', 'LESS_LINES', 'LESSOPEN', 'LESSCLOSE', 'BAT_STYLE', 'BAT_THEME']:
+            env.pop(key, None)
+        command = [binary, '--no-config', '--paging=auto', '--color=never', '--decorations=always', '--style=plain', '--terminal-width=60', f'--pager={pager}', *options, str(source)]
+        os.execve(binary, command, env)
+    data = b''
+    ended = False
+    status = None
+    deadline = time.monotonic() + 2
+    try:
+        while time.monotonic() < deadline:
+            ready, _, _ = select.select([fd], [], [], 0.03)
+            if ready:
+                try:
+                    chunk = os.read(fd, 65536)
+                    data += chunk
+                except OSError:
+                    pass
+            child, state = os.waitpid(pid, os.WNOHANG)
+            if child:
+                ended, status = True, state
+                break
+        assert (not ended) == expected_pager, (name, expected_pager, data.decode(errors='replace'))
+        if expected_error:
+            assert expected_error.encode() in data, (name, data)
+            assert os.waitstatus_to_exitcode(status) != 0
+        elif ended:
+            assert os.waitstatus_to_exitcode(status) == 0, (name, data)
+        else:
+            os.write(fd, b'q')
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                ready, _, _ = select.select([fd], [], [], 0.03)
+                if ready:
+                    try:
+                        os.read(fd, 65536)
+                    except OSError:
+                        pass
+                child, state = os.waitpid(pid, os.WNOHANG)
+                if child:
+                    ended, status = True, state
+                    break
+            assert ended and os.waitstatus_to_exitcode(status) == 0, name
+        print(f'{name}: passed', flush=True)
+    finally:
+        if not ended:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        os.close(fd)
+
+
+with tempfile.TemporaryDirectory(prefix='bat-reserve-') as directory:
+    root = Path(directory)
+    medium = ''.join(f'ROW{n:03d}\n' for n in range(1, 22))
+    short = ''.join(f'ROW{n:03d}\n' for n in range(1, 11))
+    check(root, 'normal automatic threshold', medium, [], False)
+    check(root, 'reserved prompt rows engage paging', medium, ['--paging-reserve=4'], True)
+    check(root, 'short output still exits', short, ['--paging-reserve=4'], False)
+    check(root, 'zero disables reservation', medium, ['--paging-reserve=0'], False)
+    check(root, 'last reservation wins', medium, ['--paging-reserve=4', '--paging-reserve=0'], False)
+    check(root, 'disabled paging ignores reservation', medium, ['--paging-reserve=4', '--paging=never'], False)
+    check(root, 'forced paging stays enabled', short, ['--paging-reserve=4', '--paging=always'], True)
+    check(root, 'visible ranges determine threshold', medium, ['--paging-reserve=4', '--line-range=1:10'], False)
+    check(root, 'wrapped output uses rendered rows', ('x' * 120 + '\n') * 10, ['--paging-reserve=4', '--wrap=character'], True)
+    check(root, 'custom less arguments retain automatic exit', short, ['--paging-reserve=4', f'--pager={pager} -R'], False)
+    check(root, 'large reservation stays usable', short, ['--paging-reserve=65535'], True)
+    check(root, 'unsupported pager reports error', short, ['--paging-reserve=4', '--pager=builtin'], False, '--paging-reserve requires less 632 or newer')

--- a/tests/paging_reserve.rs
+++ b/tests/paging_reserve.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "paging")]
+mod utils;
+
+#[test]
+fn reservation_is_repeatable_and_does_not_force_paging_when_disabled() {
+    utils::command::bat()
+        .args([
+            "--paging=never",
+            "--paging-reserve=3",
+            "--paging-reserve=0",
+            "--style=plain",
+        ])
+        .write_stdin("hello\n")
+        .assert()
+        .success()
+        .stdout("hello\n");
+}
+
+#[test]
+fn rejects_negative_and_out_of_range_reservations() {
+    for value in ["-1", "65536", "abc"] {
+        utils::command::bat()
+            .arg(format!("--paging-reserve={value}"))
+            .write_stdin("hello\n")
+            .assert()
+            .failure();
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    use bat::{output::OutputType, PagingMode, WrappingMode};
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    fn pager(version: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("less");
+        let script = format!("#!/bin/sh\nif [ \"$1\" = '--version' ]; then printf '%s\\n' '{version}'; exit 0; fi\nprintf '%s\\n' \"${{LESS_LINES-unset}}\" \"$@\" > '{}'; exit 0\n", dir.path().join("received").display());
+        fs::write(&path, script).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        let command = format!("'{}' -R", path.display());
+        (dir, command)
+    }
+
+    #[test]
+    fn automatic_reservation_sets_child_height_and_enables_custom_less_exit() {
+        let (dir, command) = pager("less 632 (test)");
+        drop(
+            OutputType::from_mode_with_reserve(
+                PagingMode::QuitIfOneScreen,
+                WrappingMode::Character,
+                Some(&command),
+                4,
+            )
+            .unwrap(),
+        );
+        let received = fs::read_to_string(dir.path().join("received")).unwrap();
+        assert!(
+            received.starts_with("-4\n") || received.starts_with("1\n"),
+            "{received}"
+        );
+        assert!(received.lines().any(|arg| arg == "-R"));
+        assert!(received.lines().any(|arg| arg == "-F"));
+    }
+
+    #[test]
+    fn old_and_unrecognized_less_versions_report_an_actionable_error() {
+        for version in ["less 590 (test)", "BusyBox v1.36", "custom pager"] {
+            let (dir, command) = pager(version);
+            let error = OutputType::from_mode_with_reserve(
+                PagingMode::QuitIfOneScreen,
+                WrappingMode::Character,
+                Some(&command),
+                4,
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("less 632 or newer"));
+            assert!(!dir.path().join("received").exists());
+        }
+    }
+
+    #[test]
+    fn forced_paging_ignores_reservation_and_keeps_custom_arguments() {
+        let (dir, command) = pager("less 590 (test)");
+        drop(
+            OutputType::from_mode_with_reserve(
+                PagingMode::Always,
+                WrappingMode::Character,
+                Some(&command),
+                4,
+            )
+            .unwrap(),
+        );
+        let received = fs::read_to_string(dir.path().join("received")).unwrap();
+        assert!(!received.lines().any(|arg| arg == "-F"));
+        assert!(received.lines().any(|arg| arg == "-R"));
+    }
+}


### PR DESCRIPTION
Add --paging-reserve=N and PrettyPrinter::paging_reserve to reserve terminal rows for a multiline shell prompt during automatic paging. This implements the prompt-reservation use case in #1620; negative offsets remain outside this option's scope.

Use less's LESS_LINES support, available in stable releases from 632 onward, to reduce both its viewport and its one-screen threshold. Ordinary reservations follow less's resize handling; a reservation that already fills the terminal leaves one row. Set the variable only for the child pager, overriding inherited LESS_LINES. Preserve forced and disabled paging, support repeated options, and apply automatic exit to custom less arguments. Unsupported pagers and older less versions report an actionable error when a reservation would be used.

Keep OutputType::from_mode compatible and add a separate constructor accepting the reservation. Wire the setting through normal output and theme previews. Document the viewport tradeoff in help, README and the manual; update all four completions.

Validation: all 478 all-feature tests passed (7 ignored), including new checks for argument validation, repeated settings, child pager configuration, old/unrecognized versions and forced-paging behavior. All 8 default-feature help tests, all-target/all-feature Clippy with warnings denied, the minimal library build, formatting, whitespace checks and Bash/Zsh completion syntax passed. Twelve real PTY checks against less 668 verified the automatic threshold, short output, disabled/forced paging, visible ranges, wrapped rows, custom arguments, oversized reservations and unsupported pagers. The standalone PTY regression script is included.

Fixes #1620.